### PR TITLE
Add automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+      time: "08:00"
+      timezone: America/New_York
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary

- check Python dependencies weekly on Monday mornings
- check GitHub Actions dependencies monthly
- cap concurrent Dependabot pull requests to limit review noise

## Validation

- `ruff check .` passes
- `62 passed`

This PR intentionally does not add an environment lock file. Exact environment locking requires a separate decision about the package-management workflow.