### PR TITLE
Add citation and release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+## 0.1.0 — 2026-08-28
+
+First reproducible research-foundation release.
+
+### Included
+
+- Separate WUP and GHSL rolling-origin forecasting workflows.
+- Fixed-2025 and dynamic-boundary GHSL sensitivity analysis on matched rows.
+- Actual WUP 2018 vintage evaluation against WUP 2025 estimates.
+- Country-clustered, country-and-time, equal-country and influence diagnostics.
+- Explicit match-coverage and crosswalk-selection audits.
+- Registered source checksums and pinned result hashes and dimensions.
+- Cross-platform locked Python environment and protected GitHub Actions checks.
+
+### Principal limitations
+
+- WUP and GHSL use different urban definitions and are not pooled.
+- Fixed 2025 GHSL polygons remove changing-boundary arithmetic but use future
+  geographic information when applied to historical populations.
+- Most WUP rolling-origin results use revised history rather than information
+  vintages available at each forecast origin.
+- The WUP 2018 vintage comparison is restricted to a selected matched sample of
+  large agglomerations and does not validate small-city forecasts.
+- Raw source files and generated empirical CSVs are not redistributed; exact
+  permitted inputs must be acquired and registered locally.
+- No project-wide software license has been selected, so this release does not
+  grant reuse rights beyond those already provided by law or source licenses.
+
+### Reproduction
+
+Use the commands in `README.md`. The committed `uv.lock` fixes the software
+environment, while `data/manifest.csv` and the files under `results/` identify the
+expected empirical inputs and outputs.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,22 @@
+cff-version: 1.2.0
+message: "If you use this software or its documented research results, please cite it as below."
+type: software
+title: "Global Urban Growth Lab"
+version: 0.1.0
+date-released: 2026-08-28
+authors:
+  - family-names: Stone
+    given-names: Daniel
+repository-code: "https://github.com/danielastone/Global-Urban-Growth-Lab"
+url: "https://github.com/danielastone/Global-Urban-Growth-Lab"
+abstract: >-
+  Reproducible Python workflows for testing population-growth forecasts across
+  World Urbanization Prospects city records and Global Human Settlement Layer
+  urban-centre definitions, with explicit vintage, boundary, selection and
+  dependence diagnostics.
+keywords:
+  - urban population
+  - population forecasting
+  - World Urbanization Prospects
+  - Global Human Settlement Layer
+  - reproducible research

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 A reproducible research program testing what can—and cannot—forecast population growth across the global urban hierarchy.
 
+For version history and citation metadata, see [CHANGELOG.md](CHANGELOG.md) and
+[CITATION.cff](CITATION.cff).
+
 ## Research question
 
 How much incremental out-of-sample forecasting value comes from a city's recent growth, initial size, hierarchy position, national demography, urbanization stage, spatial context, and common shocks?


### PR DESCRIPTION
## Summary

- add valid CFF 1.2.0 citation metadata for version 0.1.0
- add a changelog that records included capabilities and principal limitations
- link citation and version history from the README

## Validation

- `cffconvert --validate` passes against CFF schema 1.2.0
- locked Ruff check passes
- `62 passed`

This PR does not create a Git tag or GitHub release. Those must point to the post-merge main commit so the citation version and released code agree.