### PR TITLE
Audit forecast sample selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Add source-specific WUP and GHSL city-origin sample-selection ledgers.
+- Record threshold, projection, analytical-coverage, future-reference polygon and
+  2025 quality-conditioning flags before forecast scoring.
+- Keep fixed and changing boundary streams separate in both detailed and summary
+  selection outputs.
+
 ## 0.1.0 — 2026-08-28
 
 First reproducible research-foundation release.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ The GHSL workflow accepts only the fixed-2025 boundary product and first reconci
 
 The boundary-sensitivity workflow then restricts fixed and dynamic GHSL streams to identical identifiers, countries, origins and complete forecast rows. Their outcomes remain definition-specific and are never treated as interchangeable ground truth.
 
+Each primary workflow also writes a source-specific `*_selection_ledger.csv` and
+`*_selection_summary.csv` before forecast scoring. The ledgers retain excluded
+city-origin rows and machine-readable reasons; WUP threshold and projection
+selection, fixed-GHSL future-reference geography, and dynamic-GHSL 2025 quality
+conditioning are not collapsed into one generic missing-data category. Fixed and
+dynamic streams remain separate, and changing polygons remain a sensitivity rather
+than the primary geographic estimand.
+
 Generated CSVs remain outside Git, but the expected file hashes and dimensions are committed under `results/`. Verification therefore detects undocumented changes in default outputs. GitHub Actions validates code and unit tests only because raw source files are not committed; it does not reproduce the empirical tables.
 
 ## Minimum analytical panel

--- a/docs/data-contract.md
+++ b/docs/data-contract.md
@@ -60,3 +60,30 @@ Global, region, subregion, and country historical means are computed only from
 training outcomes. Their leave-city-out versions subtract every prior outcome for
 the focal city before scoring, preventing the aggregation ladder from inheriting a
 mechanical city-history advantage.
+
+## Forecast-sample selection ledger
+
+Every baseline workflow must emit a city-origin ledger before calculating forecast
+metrics. An absent city is an analytical result, not an ignorable missing row. The
+ledger universe is source-specific and the WUP, fixed-GHSL and dynamic-GHSL ledgers
+must never be pooled.
+
+The WUP ledger starts from every city exposed by F21, including records whose first
+nonblank population occurs in the projection period. It separately records exact
+population coverage, stricter F21/F25/F30/F34 analytical coverage, 2025 reference
+eligibility, projection-period presence and whether the outcome is an estimate.
+`future_projection_selected` requires both failure of 2025 reference eligibility
+and a projection-period record; 2025 ineligibility alone is not proof of future
+selection.
+
+The fixed-GHSL ledger identifies its geography as
+`fixed_2025_polygon_using_future_reference`. This is time-stable arithmetic but not
+historically available geography. The dynamic-GHSL ledger is a sensitivity only and
+identifies `conditioned_on_2025_quality`; changing polygons are not part of the
+primary estimand.
+
+Each ledger has one row per source city and declared forecast origin. `included` is
+accompanied by a mutually exclusive `primary_exclusion_reason`, while independent
+flags preserve overlapping selection mechanisms. Summaries use the complete
+source-origin universe as their denominator and report countries as coverage, not
+as a substitute denominator.

--- a/docs/research-design.md
+++ b/docs/research-design.md
@@ -105,6 +105,15 @@ Applied to five-year origins from 1980–2020, the exact-year rule yields 72,857
 
 WUP F21 reports blank annual cells while a city is below 50,000. Therefore, WUP alone cannot identify behavior immediately below the threshold. Analyses must report entry cohorts and balanced samples; any regression-discontinuity-style interpretation around 50,000 is invalid without a separate source that observes both sides consistently.
 
+Balanced observation is not a selection correction. Requiring a city at every
+origin conditions on later threshold status and continued traceability. Before any
+balanced-cohort estimate is interpreted, report the city-origin selection ledger
+for the full publisher-exposed universe and separate contemporaneously eligible,
+threshold-entering, projection-selected and analytically incomplete records. Fixed
+GHSL and dynamic GHSL receive separate ledgers: fixed polygons use future 2025
+geography, while dynamic trajectories condition on 2025 quality control and are not
+eligible for the primary geographically stable estimand.
+
 ## Commercial decision rule
 
 Do not market point forecasts for individual small cities from aggregate fit statistics. A viable product requires calibrated prediction intervals, material improvement over public baselines, stable performance across geographies, and evidence that the target customer acts differently because of the forecast. Municipal financing applications may value risk bands and scenario diagnostics more than a single growth estimate.

--- a/docs/research-status.md
+++ b/docs/research-status.md
@@ -4,6 +4,20 @@
 
 The source and transformation pipeline is reproducible from registered local files, but all results remain **retrospective current-revision tests**. The WUP and GHSL exercises use different city definitions and must not be pooled. WUP supplies demographic city records without a verified stable-polygon restriction. GHSL supplies a balanced panel calculated inside fixed 2025 polygons, but that definition uses future geographic information and is not vintage-correct. Neither is sufficient for a commercial forecasting claim.
 
+## Sample-selection audit status
+
+The executable workflows now produce source-specific city-origin inclusion ledgers
+and origin-level summaries. They expose threshold blanks, missing analytical
+covariates, projection outcomes, future-projection selection, fixed-2025 future
+geography and dynamic-stream 2025 quality conditioning. No corrected forecast
+estimate has been asserted: the ledgers diagnose how each published result is
+selected, and the next empirical step is to re-estimate prespecified ex-ante
+eligibility cohorts after regenerating the outputs from the registered raw files.
+
+The existing balanced WUP result remains an established-city estimand, not a repair
+for below-threshold missingness. Dynamic GHSL remains a changing-boundary
+sensitivity and cannot replace the fixed-polygon primary analysis.
+
 ## Fixed-2025-boundary sensitivity
 
 The GHSL fixed-boundary workflow uses all 11,422 quality-controlled urban-centre polygons at every five-year epoch. Historical population and built-up values are calculated inside the same 2025 polygon. The executable workflow also reconciles the fixed and multi-temporal products at their common 2025 point before forecasting; mismatched identifiers, countries, population beyond rounding tolerance, built-up area or polygon area fail validation. This validates the common 2025 cross-stream point and fixed-boundary semantics—not the historical accuracy of a 2025 polygon applied backward.

--- a/scripts/run_ghsl_boundary_sensitivity.py
+++ b/scripts/run_ghsl_boundary_sensitivity.py
@@ -19,6 +19,7 @@ from urban_growth.forecast import (
     matched_boundary_forecast_panels,
     temporal_reversal_diagnostics,
 )
+from urban_growth.selection import ghsl_forecast_selection_ledger, selection_summary
 
 
 def main() -> None:
@@ -43,6 +44,12 @@ def main() -> None:
         fixed, origins, reconciliation=reconciliation
     )
     dynamic_intervals = build_ghsl_dynamic_forecast_intervals(dynamic, origins)
+    fixed_selection = ghsl_forecast_selection_ledger(
+        fixed, origins, boundary_mode="fixed"
+    )
+    dynamic_selection = ghsl_forecast_selection_ledger(
+        dynamic, origins, boundary_mode="dynamic"
+    )
     fixed_matched, dynamic_matched = matched_boundary_forecast_panels(
         fixed_intervals, dynamic_intervals
     )
@@ -63,6 +70,10 @@ def main() -> None:
         "ghsl_boundary_matched_coverage.csv": fixed_matched.groupby("period_start").agg(
             matched_rows=("city_id", "size"), countries=("country_code", "nunique")
         ).reset_index(),
+        "ghsl_boundary_fixed_selection_ledger.csv": fixed_selection,
+        "ghsl_boundary_fixed_selection_summary.csv": selection_summary(fixed_selection),
+        "ghsl_boundary_dynamic_selection_ledger.csv": dynamic_selection,
+        "ghsl_boundary_dynamic_selection_summary.csv": selection_summary(dynamic_selection),
     }
     args.output_dir.mkdir(parents=True, exist_ok=True)
     for name, frame in results.items():

--- a/scripts/run_ghsl_fixed_baselines.py
+++ b/scripts/run_ghsl_fixed_baselines.py
@@ -19,6 +19,7 @@ from urban_growth.forecast import (
     rolling_baseline_errors,
     temporal_reversal_diagnostics,
 )
+from urban_growth.selection import ghsl_forecast_selection_ledger, selection_summary
 
 
 def main() -> None:
@@ -68,12 +69,27 @@ def main() -> None:
         type=Path,
         default=Path("outputs/ghsl_fixed_hierarchy_model_metrics.csv"),
     )
+    parser.add_argument(
+        "--selection-ledger-output",
+        type=Path,
+        default=Path("outputs/ghsl_fixed_selection_ledger.csv"),
+    )
+    parser.add_argument(
+        "--selection-summary-output",
+        type=Path,
+        default=Path("outputs/ghsl_fixed_selection_summary.csv"),
+    )
     args = parser.parse_args()
     fixed = fixed_2025_theme_panel(read_ghsl_theme_csv(str(args.input)))
     dynamic = multitemporal_boundary_panel(read_ghsl_mtuc_csv(str(args.dynamic_input)))
     reconciliation = reconcile_2025_streams(fixed, dynamic)
+    construction_origins = list(range(1980, 2025, 5))
+    selection_ledger = ghsl_forecast_selection_ledger(
+        fixed, construction_origins, boundary_mode="fixed"
+    )
+    selection_audit_summary = selection_summary(selection_ledger)
     intervals = build_ghsl_fixed_forecast_intervals(
-        fixed, list(range(1980, 2025, 5)), reconciliation=reconciliation
+        fixed, construction_origins, reconciliation=reconciliation
     )
     origins = list(range(1985, 2025, 5))
     metrics = evaluate_rolling_baselines(intervals, origins)
@@ -98,6 +114,8 @@ def main() -> None:
         (args.gapped_metrics_output, gapped_metrics),
         (args.gapped_temporal_output, gapped_temporal),
         (args.hierarchy_output, hierarchy),
+        (args.selection_ledger_output, selection_ledger),
+        (args.selection_summary_output, selection_audit_summary),
     ]:
         path.parent.mkdir(parents=True, exist_ok=True)
         frame.to_csv(path, index=False)

--- a/scripts/run_wup_baselines.py
+++ b/scripts/run_wup_baselines.py
@@ -28,6 +28,7 @@ from urban_growth.forecast import (
     temporal_reversal_diagnostics,
     two_way_cluster_bootstrap_paired_difference,
 )
+from urban_growth.selection import selection_summary, wup_forecast_selection_ledger
 from urban_growth.wup_panel import build_wup_city_year_panel
 
 
@@ -137,6 +138,16 @@ def main() -> None:
         type=Path,
         default=Path("outputs/wup_aggregation_country_time_bootstrap.csv"),
     )
+    parser.add_argument(
+        "--selection-ledger-output",
+        type=Path,
+        default=Path("outputs/wup_selection_ledger.csv"),
+    )
+    parser.add_argument(
+        "--selection-summary-output",
+        type=Path,
+        default=Path("outputs/wup_selection_summary.csv"),
+    )
     args = parser.parse_args()
     raw = args.raw_dir
     national = read_f01_country_city_population(
@@ -151,7 +162,12 @@ def main() -> None:
         raw / "WUP2025-F34-DEGURBA-Cities_Pop_density.xlsx"
     )
     city_year = build_wup_city_year_panel(population, area, built, density)
-    intervals = build_forecast_intervals(city_year, list(range(1980, 2025, 5)))
+    construction_origins = list(range(1980, 2025, 5))
+    selection_ledger = wup_forecast_selection_ledger(
+        population, city_year, construction_origins
+    )
+    selection_audit_summary = selection_summary(selection_ledger)
+    intervals = build_forecast_intervals(city_year, construction_origins)
     intervals = attach_national_city_category_baseline(intervals, national)
     metrics = evaluate_rolling_baselines(intervals, list(range(1985, 2025, 5)))
     errors = rolling_baseline_errors(intervals, list(range(1985, 2025, 5)))
@@ -264,6 +280,10 @@ def main() -> None:
     aggregation_bootstrap.to_csv(args.aggregation_bootstrap_output, index=False)
     args.aggregation_country_time_output.parent.mkdir(parents=True, exist_ok=True)
     aggregation_country_time.to_csv(args.aggregation_country_time_output, index=False)
+    args.selection_ledger_output.parent.mkdir(parents=True, exist_ok=True)
+    selection_ledger.to_csv(args.selection_ledger_output, index=False)
+    args.selection_summary_output.parent.mkdir(parents=True, exist_ok=True)
+    selection_audit_summary.to_csv(args.selection_summary_output, index=False)
     print(args.output)
     print(args.paired_output)
     print(args.bootstrap_output)
@@ -285,6 +305,8 @@ def main() -> None:
     print(args.balanced_country_time_bootstrap_output)
     print(args.aggregation_bootstrap_output)
     print(args.aggregation_country_time_output)
+    print(args.selection_ledger_output)
+    print(args.selection_summary_output)
 
 
 if __name__ == "__main__":

--- a/src/urban_growth/selection.py
+++ b/src/urban_growth/selection.py
@@ -1,0 +1,264 @@
+"""Machine-readable audits of forecast-sample construction."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
+
+
+def _validate_origins(origins: list[int]) -> list[int]:
+    if not origins or any(not isinstance(year, int) for year in origins):
+        raise SourceSchemaError("Selection-audit origins must be non-empty integer years")
+    if len(origins) != len(set(origins)):
+        raise SourceSchemaError("Selection-audit origins must be unique")
+    return sorted(origins)
+
+
+def _coverage_flags(
+    ledger: pd.DataFrame,
+    panel: pd.DataFrame,
+    *,
+    lookback_years: int,
+    horizon_years: int,
+    outcome_gap_years: int,
+) -> pd.DataFrame:
+    require_columns(panel, {"city_id", "year"}, source_name="selection-audit panel")
+    reject_duplicate_keys(panel, ["city_id", "year"], source_name="selection-audit panel")
+    available = pd.MultiIndex.from_frame(panel[["city_id", "year"]])
+    years = {
+        "lag_available": ledger["origin"] - lookback_years,
+        "origin_available": ledger["origin"],
+        "outcome_start_available": ledger["origin"] + outcome_gap_years,
+        "outcome_end_available": ledger["origin"] + outcome_gap_years + horizon_years,
+    }
+    result = ledger.copy()
+    for column, year in years.items():
+        keys = pd.MultiIndex.from_arrays([result["city_id"], year])
+        result[column] = keys.isin(available)
+    result["complete_required_years"] = result[list(years)].all(axis=1)
+    return result
+
+
+def _first_false_reason(frame: pd.DataFrame, rules: list[tuple[str, str]]) -> pd.Series:
+    conditions = [~frame[column] for column, _ in rules]
+    choices = [reason for _, reason in rules]
+    return pd.Series(
+        np.select(conditions, choices, default="included"), index=frame.index, dtype="string"
+    )
+
+
+def wup_forecast_selection_ledger(
+    population_panel: pd.DataFrame,
+    analytical_panel: pd.DataFrame,
+    origins: list[int],
+    *,
+    lookback_years: int = 5,
+    horizon_years: int = 5,
+    outcome_gap_years: int = 0,
+    estimate_end_year: int = 2025,
+) -> pd.DataFrame:
+    """Audit WUP threshold timing and complete-case selection at every origin.
+
+    The universe is every city exposed by F21, including cities whose first
+    nonblank value occurs only in the projection period. The analytical panel
+    is the stricter F21/F25/F30/F34 intersection used by forecast construction.
+    """
+    required = {
+        "city_id", "year", "population", "ISO3_Code", "City_Name",
+        "sample_entry_year", "sample_exit_year", "eligible_at_reference_year",
+        "observation_type",
+    }
+    require_columns(population_panel, required, source_name="WUP population panel")
+    reject_duplicate_keys(population_panel, ["city_id", "year"], source_name="WUP population")
+    years = _validate_origins(origins)
+    if min(lookback_years, horizon_years) <= 0 or outcome_gap_years < 0:
+        raise SourceSchemaError("Selection-audit lookback/horizon must be positive")
+    population_working = population_panel.copy()
+    population_working["_projection_period_observation"] = (
+        population_working["year"] > estimate_end_year
+    )
+    metadata = population_working.sort_values("year").groupby("city_id", as_index=False).agg(
+        country_code=("ISO3_Code", "first"),
+        city_name=("City_Name", "first"),
+        sample_entry_year=("sample_entry_year", "first"),
+        sample_exit_year=("sample_exit_year", "first"),
+        eligible_at_reference_year=("eligible_at_reference_year", "first"),
+        has_projection_period_observation=("_projection_period_observation", "any"),
+    )
+    universe = metadata.assign(_key=1).merge(
+        pd.DataFrame({"origin": years, "_key": 1}), on="_key", validate="many_to_many"
+    ).drop(columns="_key")
+    population_coverage = _coverage_flags(
+        universe,
+        population_panel,
+        lookback_years=lookback_years,
+        horizon_years=horizon_years,
+        outcome_gap_years=outcome_gap_years,
+    ).rename(
+        columns={
+            "lag_available": "population_lag_available",
+            "origin_available": "population_origin_available",
+            "outcome_start_available": "population_outcome_start_available",
+            "outcome_end_available": "population_outcome_end_available",
+            "complete_required_years": "population_complete_required_years",
+        }
+    )
+    analytical_coverage = _coverage_flags(
+        universe[["city_id", "origin"]],
+        analytical_panel,
+        lookback_years=lookback_years,
+        horizon_years=horizon_years,
+        outcome_gap_years=outcome_gap_years,
+    ).rename(
+        columns={
+            "lag_available": "analytical_lag_available",
+            "origin_available": "analytical_origin_available",
+            "outcome_start_available": "analytical_outcome_start_available",
+            "outcome_end_available": "analytical_outcome_end_available",
+            "complete_required_years": "analytical_complete_required_years",
+        }
+    )
+    analytical_columns = [
+        "city_id", "origin", "analytical_lag_available", "analytical_origin_available",
+        "analytical_outcome_start_available", "analytical_outcome_end_available",
+        "analytical_complete_required_years",
+    ]
+    result = population_coverage.merge(
+        analytical_coverage[analytical_columns],
+        on=["city_id", "origin"],
+        validate="one_to_one",
+    )
+    result["entry_occurs_after_forecast_origin"] = result["sample_entry_year"] > result["origin"]
+    result["entry_occurs_in_projection_period"] = result["sample_entry_year"] > estimate_end_year
+    result["not_eligible_at_2025_reference"] = ~result[
+        "eligible_at_reference_year"
+    ].astype(bool)
+    result["future_projection_selected"] = (
+        result["not_eligible_at_2025_reference"]
+        & result["has_projection_period_observation"]
+    )
+    result["outcome_is_estimate"] = (
+        result["origin"] + outcome_gap_years + horizon_years <= estimate_end_year
+    )
+    result["included"] = result["analytical_complete_required_years"] & result[
+        "outcome_is_estimate"
+    ]
+    result["primary_exclusion_reason"] = _first_false_reason(
+        result,
+        [
+            ("population_lag_available", "population_lag_missing_threshold_blank"),
+            ("population_origin_available", "population_origin_missing_threshold_blank"),
+            (
+                "population_outcome_start_available",
+                "population_outcome_start_missing_threshold_blank",
+            ),
+            ("population_outcome_end_available", "population_outcome_end_missing_threshold_blank"),
+            ("outcome_is_estimate", "projection_outcome_not_allowed"),
+            ("analytical_lag_available", "lag_covariates_missing"),
+            ("analytical_origin_available", "origin_covariates_missing"),
+            ("analytical_outcome_start_available", "outcome_start_covariates_missing"),
+            ("analytical_outcome_end_available", "outcome_end_covariates_missing"),
+        ],
+    )
+    result["source_stream"] = "WUP_2025_DEGURBA_cities"
+    result["geographic_comparability"] = "publisher_city_definition_not_fixed_polygon"
+    reject_duplicate_keys(result, ["city_id", "origin"], source_name="WUP selection ledger")
+    return result.sort_values(["origin", "country_code", "city_id"]).reset_index(drop=True)
+
+
+def ghsl_forecast_selection_ledger(
+    panel: pd.DataFrame,
+    origins: list[int],
+    *,
+    boundary_mode: str,
+    lookback_years: int = 5,
+    horizon_years: int = 5,
+    outcome_gap_years: int = 0,
+) -> pd.DataFrame:
+    """Audit fixed or dynamic GHSL city-origin coverage without pooling streams."""
+    required = {"city_id", "year", "boundary_mode", "GC_CNT_GAD_2025"}
+    require_columns(panel, required, source_name="GHSL selection panel")
+    if boundary_mode not in {"fixed", "dynamic"}:
+        raise SourceSchemaError("GHSL selection audit requires fixed or dynamic mode")
+    if panel["boundary_mode"].ne(boundary_mode).any():
+        raise SourceSchemaError("GHSL selection panel mixes boundary modes")
+    years = _validate_origins(origins)
+    metadata_aggregations: dict[str, tuple[str, str]] = {
+        "country_code": ("GC_CNT_GAD_2025", "first")
+    }
+    for source, target in [
+        ("GC_UCB_YOB _2025", "trajectory_birth_year"),
+        ("GC_UCB_YOD _2025", "trajectory_death_year"),
+        ("quality_controlled_2025", "quality_controlled_2025"),
+    ]:
+        if source in panel.columns:
+            metadata_aggregations[target] = (source, "first")
+    metadata = panel.groupby("city_id", as_index=False).agg(**metadata_aggregations)
+    universe = metadata.assign(_key=1).merge(
+        pd.DataFrame({"origin": years, "_key": 1}), on="_key", validate="many_to_many"
+    ).drop(columns="_key")
+    result = _coverage_flags(
+        universe,
+        panel,
+        lookback_years=lookback_years,
+        horizon_years=horizon_years,
+        outcome_gap_years=outcome_gap_years,
+    )
+    if "quality_controlled_2025" not in result:
+        result["quality_controlled_2025"] = True
+    result["quality_controlled_2025"] = result["quality_controlled_2025"].fillna(False).astype(bool)
+    result["conditioned_on_2025_quality"] = boundary_mode == "dynamic"
+    result["uses_future_reference_polygon"] = boundary_mode == "fixed"
+    result["included"] = result["complete_required_years"] & result[
+        "quality_controlled_2025"
+    ]
+    result["primary_exclusion_reason"] = _first_false_reason(
+        result,
+        [
+            ("quality_controlled_2025", "not_quality_controlled_at_2025"),
+            ("lag_available", "trajectory_absent_at_lag"),
+            ("origin_available", "trajectory_absent_at_origin"),
+            ("outcome_start_available", "trajectory_absent_at_outcome_start"),
+            ("outcome_end_available", "trajectory_absent_at_outcome_end"),
+        ],
+    )
+    result["source_stream"] = f"GHSL_2024_{boundary_mode}_boundaries"
+    result["geographic_comparability"] = np.where(
+        boundary_mode == "fixed",
+        "fixed_2025_polygon_using_future_reference",
+        "changing_polygon_sensitivity_not_primary_estimand",
+    )
+    reject_duplicate_keys(result, ["city_id", "origin"], source_name="GHSL selection ledger")
+    return result.sort_values(["origin", "country_code", "city_id"]).reset_index(drop=True)
+
+
+def selection_summary(ledger: pd.DataFrame) -> pd.DataFrame:
+    """Summarize inclusion and exclusion counts without hiding the universe."""
+    required = {
+        "source_stream", "origin", "country_code", "included",
+        "primary_exclusion_reason", "geographic_comparability",
+    }
+    require_columns(ledger, required, source_name="selection ledger")
+    summary = ledger.groupby(
+        [
+            "source_stream", "geographic_comparability", "origin", "included",
+            "primary_exclusion_reason",
+        ],
+        dropna=False,
+        sort=True,
+    ).agg(
+        city_origin_rows=("city_id", "size"),
+        countries=("country_code", "nunique"),
+    ).reset_index()
+    totals = ledger.groupby(["source_stream", "origin"])["city_id"].transform("size")
+    working = ledger.assign(_origin_universe=totals)
+    denominators = working.groupby(["source_stream", "origin"])["_origin_universe"].first()
+    summary["origin_universe_rows"] = pd.MultiIndex.from_frame(
+        summary[["source_stream", "origin"]]
+    ).map(denominators)
+    summary["share_of_origin_universe"] = (
+        summary["city_origin_rows"] / summary["origin_universe_rows"]
+    )
+    return summary

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,0 +1,101 @@
+import pandas as pd
+import pytest
+
+from urban_growth.io import SourceSchemaError
+from urban_growth.selection import (
+    ghsl_forecast_selection_ledger,
+    selection_summary,
+    wup_forecast_selection_ledger,
+)
+
+
+def test_wup_ledger_exposes_threshold_and_future_projection_selection() -> None:
+    rows = []
+    for city_id, entry, eligible in [(1, 2015, True), (2, 2015, True), (3, 2030, False)]:
+        for year in range(entry, 2036, 5):
+            rows.append(
+                {
+                    "city_id": city_id,
+                    "year": year,
+                    "population": 50_000 + year,
+                    "ISO3_Code": "AAA",
+                    "City_Name": f"City {city_id}",
+                    "sample_entry_year": entry,
+                    "sample_exit_year": 2035,
+                    "eligible_at_reference_year": eligible,
+                    "observation_type": "estimate" if year <= 2025 else "projection",
+                }
+            )
+    population = pd.DataFrame(rows)
+    analytical = population.loc[population["city_id"].ne(2) | population["year"].ne(2020)]
+    ledger = wup_forecast_selection_ledger(population, analytical, [2020])
+    included = ledger.set_index("city_id")
+    assert included.loc[1, "included"]
+    assert included.loc[2, "primary_exclusion_reason"] == "origin_covariates_missing"
+    assert included.loc[3, "primary_exclusion_reason"] == (
+        "population_lag_missing_threshold_blank"
+    )
+    assert included.loc[3, "entry_occurs_in_projection_period"]
+    assert included.loc[3, "not_eligible_at_2025_reference"]
+    assert included.loc[3, "future_projection_selected"]
+
+
+def test_ghsl_ledgers_keep_fixed_and_dynamic_semantics_explicit() -> None:
+    fixed = pd.DataFrame(
+        {
+            "city_id": [1, 1, 1],
+            "year": [2015, 2020, 2025],
+            "boundary_mode": ["fixed"] * 3,
+            "GC_CNT_GAD_2025": ["AAA"] * 3,
+        }
+    )
+    fixed_ledger = ghsl_forecast_selection_ledger(fixed, [2020], boundary_mode="fixed")
+    assert fixed_ledger.loc[0, "included"]
+    assert fixed_ledger.loc[0, "uses_future_reference_polygon"]
+    assert fixed_ledger.loc[0, "geographic_comparability"] == (
+        "fixed_2025_polygon_using_future_reference"
+    )
+
+    dynamic = fixed.assign(
+        boundary_mode="dynamic",
+        quality_controlled_2025=False,
+        **{"GC_UCB_YOB _2025": 2015, "GC_UCB_YOD _2025": 2025},
+    )
+    dynamic_ledger = ghsl_forecast_selection_ledger(
+        dynamic, [2020], boundary_mode="dynamic"
+    )
+    assert not dynamic_ledger.loc[0, "included"]
+    assert dynamic_ledger.loc[0, "conditioned_on_2025_quality"]
+    assert dynamic_ledger.loc[0, "primary_exclusion_reason"] == (
+        "not_quality_controlled_at_2025"
+    )
+
+
+def test_selection_summary_uses_full_origin_universe() -> None:
+    ledger = pd.DataFrame(
+        {
+            "source_stream": ["x", "x"],
+            "geographic_comparability": ["fixed", "fixed"],
+            "origin": [2020, 2020],
+            "country_code": ["A", "B"],
+            "city_id": [1, 2],
+            "included": [True, False],
+            "primary_exclusion_reason": ["included", "missing"],
+        }
+    )
+    summary = selection_summary(ledger)
+    assert summary["origin_universe_rows"].eq(2).all()
+    assert summary["share_of_origin_universe"].tolist() == pytest.approx([0.5, 0.5])
+
+
+def test_selection_audit_rejects_duplicate_city_years() -> None:
+    panel = pd.DataFrame(
+        {
+            "city_id": [1, 1],
+            "year": [2020, 2020],
+            "boundary_mode": ["fixed", "fixed"],
+            "GC_CNT_GAD_2025": ["AAA", "AAA"],
+        }
+    )
+    with pytest.raises(SourceSchemaError, match="duplicate"):
+        ghsl_forecast_selection_ledger(panel, [2020], boundary_mode="fixed")


### PR DESCRIPTION
## Summary
- add source-specific city-origin inclusion ledgers for WUP, fixed GHSL, and dynamic GHSL
- record threshold blanks, analytical coverage, projection selection, future-reference fixed geography, and 2025 dynamic quality conditioning
- integrate detailed and summary audit outputs into the executable workflows
- document that balanced cohorts are not selection corrections and changing polygons remain sensitivity-only

## Validation
- `uv run --locked --extra dev pytest -q` — 66 passed
- `uv run --locked --extra dev ruff check .` — passed

## Empirical limitation
Raw registered source files are intentionally not committed, so this change adds the executable diagnostics but does not assert new numerical selection-adjusted results.