### PR TITLE
Add national population and DEGURBA context controls

### DIFF
--- a/docs/national-context.md
+++ b/docs/national-context.md
@@ -1,0 +1,63 @@
+# National demographic and settlement context
+
+## Purpose
+
+National population and the distribution of population across cities, towns and
+semi-dense areas, and rural areas are secondary forecast features. They test whether
+city persistence and size effects vary with national demographic scale and settlement
+structure. They are not causal treatments.
+
+The required source is the harmonized WUP 2025 country-level Degree of Urbanisation
+panel registered as un_wup_2025_country_degurb. National-definition urban shares may
+be used only as a separately labeled robustness comparison because their
+cross-country thresholds differ.
+
+## Transformation contract
+
+attach_national_context accepts normalized country-year-category populations and
+forecast intervals. For focal city i, country c, and origin t, it subtracts the city's
+population from both the national total and the national Cities category:
+
+    national_population_loo(c,t,i) = national_population(c,t) - city_population(i,t)
+    city_population_loo(c,t,i) = national_city_population(c,t) - city_population(i,t)
+
+The subtraction is repeated at t minus lookback_years. National growth and changes in
+settlement shares therefore contain neither the focal city's level nor its recent
+growth mechanically. No value after the forecast origin is selected.
+
+The function produces:
+
+- leave-one-city-out national population and log population at the origin;
+- annualized leave-one-city-out national population growth over the lookback window;
+- origin city, town, and rural population shares;
+- lookback-to-origin changes in all three shares;
+- explicit provenance and availability flags.
+
+All three shares are retained for diagnostics, but a regression with an intercept
+must omit one component. The default interpretation should use rural as the reference
+and include city and town shares. The town share is analytically important: an
+identical urban share can describe either a deep intermediate settlement system or
+concentration in a few large centres.
+
+## Required model ladder
+
+1. Keep the established persistence and country-mean baselines unchanged.
+2. Add log national population and recent national population growth.
+3. Add city and town shares, with rural omitted.
+4. Test interactions with initial city size and recent city growth only after the
+   additive model is evaluated out of sample.
+5. Compare against country-year fixed effects in explanatory work; the national
+   variables are absorbed in that specification.
+6. Report matched-row forecast error changes and coverage separately.
+
+The controls are origin-available within the WUP 2025 revised history, not
+vintage-real-time information. Any real-time commercial claim still requires the
+historical data revision that was available at each forecast origin.
+
+## Edge cases
+
+For a city-state or any record where subtracting the focal city leaves no positive
+national population, the row remains in the forecast panel but the derived national
+controls are missing and national_context_loo_available is false. Models requiring
+these controls must report the resulting coverage loss rather than silently changing
+the evaluation population.

--- a/src/urban_growth/national_context.py
+++ b/src/urban_growth/national_context.py
@@ -1,0 +1,166 @@
+"""Leakage-resistant national demographic and settlement-composition controls."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
+
+DEGURBA_CATEGORIES = ("city", "town_and_semi_dense", "rural")
+
+
+def attach_national_context(
+    intervals: pd.DataFrame,
+    national_panel: pd.DataFrame,
+    *,
+    lookback_years: int = 5,
+) -> pd.DataFrame:
+    """Attach origin-available, leave-one-city-out national context.
+
+    The national panel must contain one row per country, year, and harmonized
+    DEGURBA category. The focal city is removed from both the national total
+    and Cities-category population at the lookback and forecast-origin years.
+    Values after the forecast origin are never selected.
+
+    A city-state or other row with no positive residual national population is
+    retained with national_context_loo_available set false and missing derived
+    controls. This avoids changing the forecast sample silently.
+    """
+    require_columns(
+        intervals,
+        {
+            "city_id",
+            "country_code",
+            "period_start",
+            "population_lag",
+            "population_start",
+        },
+        source_name="forecast intervals",
+    )
+    require_columns(
+        national_panel,
+        {"country_code", "year", "category", "population"},
+        source_name="national DEGURBA panel",
+    )
+    if lookback_years <= 0:
+        raise SourceSchemaError("National-context lookback must be positive")
+
+    reject_duplicate_keys(
+        national_panel,
+        ["country_code", "year", "category"],
+        source_name="national DEGURBA panel",
+    )
+    unknown = sorted(set(national_panel["category"].dropna()) - set(DEGURBA_CATEGORIES))
+    if unknown:
+        raise SourceSchemaError(
+            f"National DEGURBA panel has unknown categories: {', '.join(map(str, unknown))}"
+        )
+    if national_panel[["country_code", "year", "category", "population"]].isna().any().any():
+        raise SourceSchemaError("National DEGURBA keys and populations cannot be null")
+    population = pd.to_numeric(national_panel["population"], errors="coerce")
+    if population.isna().any() or not np.isfinite(population).all():
+        raise SourceSchemaError("National DEGURBA population must be finite and numeric")
+    if (population < 0).any():
+        raise SourceSchemaError("National DEGURBA population cannot be negative")
+
+    normalized = national_panel.assign(population=population)
+    wide = normalized.pivot(
+        index=["country_code", "year"], columns="category", values="population"
+    )
+    missing_categories = [category for category in DEGURBA_CATEGORIES if category not in wide]
+    if missing_categories or wide[list(DEGURBA_CATEGORIES)].isna().any().any():
+        raise SourceSchemaError(
+            "National DEGURBA panel requires city, town_and_semi_dense, and rural "
+            "for every country-year"
+        )
+    wide = wide.loc[:, list(DEGURBA_CATEGORIES)]
+    wide["total"] = wide.sum(axis=1)
+    if (wide["total"] <= 0).any():
+        raise SourceSchemaError("National DEGURBA total population must be positive")
+
+    result = intervals.copy()
+    origin_year = pd.to_numeric(result["period_start"], errors="coerce")
+    if origin_year.isna().any() or not (origin_year % 1 == 0).all():
+        raise SourceSchemaError("Forecast origins must be whole numeric years")
+    lag_year = origin_year.astype(int) - lookback_years
+    origin_index = pd.MultiIndex.from_arrays(
+        [result["country_code"], origin_year.astype(int)],
+        names=["country_code", "year"],
+    )
+    lag_index = pd.MultiIndex.from_arrays(
+        [result["country_code"], lag_year],
+        names=["country_code", "year"],
+    )
+
+    origin = wide.reindex(origin_index).reset_index(drop=True)
+    lag = wide.reindex(lag_index).reset_index(drop=True)
+    if origin.isna().any().any() or lag.isna().any().any():
+        raise SourceSchemaError("National DEGURBA panel lacks a required country-year")
+
+    city_origin = pd.to_numeric(result["population_start"], errors="coerce").reset_index(drop=True)
+    city_lag = pd.to_numeric(result["population_lag"], errors="coerce").reset_index(drop=True)
+    if (
+        city_origin.isna().any()
+        or city_lag.isna().any()
+        or (city_origin <= 0).any()
+        or (city_lag <= 0).any()
+    ):
+        raise SourceSchemaError("Focal-city population endpoints must be positive and numeric")
+
+    # WUP tables display rounded persons. Tolerate at most one person's
+    # subtraction discrepancy, then fail rather than manufacture composition.
+    origin_city_residual = origin["city"] - city_origin
+    lag_city_residual = lag["city"] - city_lag
+    if (origin_city_residual < -1).any() or (lag_city_residual < -1).any():
+        raise SourceSchemaError("Focal-city population exceeds the national Cities category")
+    origin_city_residual = origin_city_residual.clip(lower=0)
+    lag_city_residual = lag_city_residual.clip(lower=0)
+    origin_total_residual = origin["total"] - city_origin
+    lag_total_residual = lag["total"] - city_lag
+    available = (origin_total_residual > 0) & (lag_total_residual > 0)
+
+    result["national_context_loo_available"] = available.to_numpy()
+    result["national_context_leave_one_city_out"] = True
+    result["national_context_uses_future_value"] = False
+    result["national_context_lookback_years"] = lookback_years
+
+    def assign_available(column: str, values: pd.Series | np.ndarray) -> None:
+        array = np.asarray(values, dtype=float)
+        result[column] = np.where(available.to_numpy(), array, np.nan)
+
+    assign_available("national_population_loo_at_origin", origin_total_residual)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        assign_available("log_national_population_loo_at_origin", np.log(origin_total_residual))
+        assign_available(
+            "national_population_recent_growth_loo",
+            (np.log(origin_total_residual) - np.log(lag_total_residual)) / lookback_years,
+        )
+
+    origin_components = {
+        "city": origin_city_residual,
+        "town": origin["town_and_semi_dense"],
+        "rural": origin["rural"],
+    }
+    lag_components = {
+        "city": lag_city_residual,
+        "town": lag["town_and_semi_dense"],
+        "rural": lag["rural"],
+    }
+    for label in ("city", "town", "rural"):
+        origin_share = origin_components[label] / origin_total_residual
+        lag_share = lag_components[label] / lag_total_residual
+        assign_available(f"national_{label}_share_loo_at_origin", origin_share)
+        assign_available(f"national_{label}_share_change_loo", origin_share - lag_share)
+
+    valid = result["national_context_loo_available"]
+    share_columns = [
+        "national_city_share_loo_at_origin",
+        "national_town_share_loo_at_origin",
+        "national_rural_share_loo_at_origin",
+    ]
+    if valid.any() and not np.allclose(
+        result.loc[valid, share_columns].sum(axis=1), 1.0, atol=1e-10
+    ):
+        raise SourceSchemaError("Leave-one-city-out national shares do not sum to one")
+    return result

--- a/tests/test_national_context.py
+++ b/tests/test_national_context.py
@@ -1,0 +1,95 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from urban_growth.io import SourceSchemaError
+from urban_growth.national_context import attach_national_context
+
+
+def national_panel() -> pd.DataFrame:
+    rows = []
+    values = {
+        2000: {"city": 500.0, "town_and_semi_dense": 250.0, "rural": 150.0},
+        2005: {"city": 600.0, "town_and_semi_dense": 260.0, "rural": 140.0},
+        # This deliberately extreme future value must never enter an origin-2005 control.
+        2010: {"city": 900_000.0, "town_and_semi_dense": 1.0, "rural": 1.0},
+    }
+    for year, categories in values.items():
+        for category, population in categories.items():
+            rows.append(
+                {
+                    "country_code": "X",
+                    "year": year,
+                    "category": category,
+                    "population": population,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def intervals() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "city_id": ["A"],
+            "country_code": ["X"],
+            "period_start": [2005],
+            "period_end": [2010],
+            "population_lag": [90.0],
+            "population_start": [100.0],
+        }
+    )
+
+
+def test_context_is_leave_one_city_out_and_origin_available() -> None:
+    result = attach_national_context(intervals(), national_panel())
+    row = result.iloc[0]
+
+    assert row["national_population_loo_at_origin"] == pytest.approx(900.0)
+    assert row["log_national_population_loo_at_origin"] == pytest.approx(np.log(900.0))
+    assert row["national_population_recent_growth_loo"] == pytest.approx(
+        (np.log(900.0) - np.log(810.0)) / 5
+    )
+    assert row["national_city_share_loo_at_origin"] == pytest.approx(500.0 / 900.0)
+    assert row["national_town_share_loo_at_origin"] == pytest.approx(260.0 / 900.0)
+    assert row["national_rural_share_loo_at_origin"] == pytest.approx(140.0 / 900.0)
+    assert not row["national_context_uses_future_value"]
+    assert row["national_context_leave_one_city_out"]
+
+
+def test_compositional_invariants_hold() -> None:
+    result = attach_national_context(intervals(), national_panel())
+    shares = result.filter(regex=r"national_(city|town|rural)_share_loo_at_origin$")
+    changes = result.filter(regex=r"national_(city|town|rural)_share_change_loo$")
+
+    assert shares.sum(axis=1).iloc[0] == pytest.approx(1.0)
+    assert changes.sum(axis=1).iloc[0] == pytest.approx(0.0)
+
+
+def test_incomplete_composition_fails() -> None:
+    source = national_panel()
+    source = source.loc[~((source["year"] == 2005) & (source["category"] == "rural"))]
+    with pytest.raises(SourceSchemaError, match="requires city"):
+        attach_national_context(intervals(), source)
+
+
+def test_focal_city_larger_than_national_city_category_fails() -> None:
+    frame = intervals()
+    frame["population_start"] = 700.0
+    with pytest.raises(SourceSchemaError, match="exceeds"):
+        attach_national_context(frame, national_panel())
+
+
+def test_zero_residual_country_is_flagged_without_dropping_row() -> None:
+    source = national_panel()
+    source.loc[source["category"] != "city", "population"] = 0.0
+    source.loc[source["year"] == 2000, "population"] = source.loc[
+        source["year"] == 2000, "category"
+    ].map({"city": 90.0, "town_and_semi_dense": 0.0, "rural": 0.0})
+    source.loc[source["year"] == 2005, "population"] = source.loc[
+        source["year"] == 2005, "category"
+    ].map({"city": 100.0, "town_and_semi_dense": 0.0, "rural": 0.0})
+
+    result = attach_national_context(intervals(), source)
+    assert len(result) == 1
+    assert not result.loc[0, "national_context_loo_available"]
+    assert np.isnan(result.loc[0, "national_city_share_loo_at_origin"])


### PR DESCRIPTION
## Summary

- add origin-available national population, growth, and city/town/rural composition features
- subtract the focal city at both lookback and origin to prevent mechanical self-inclusion
- preserve city-state edge cases with an explicit availability flag instead of silently dropping rows
- validate compositional completeness, category mapping, population bounds, and share identities
- document the model ladder and revised-history limitation

## Testing

Adds five focused tests covering focal-city subtraction, future-value exclusion, compositional identities, incomplete source data, invalid national totals, and zero-residual country handling.

## Scope

This does not alter existing baseline outputs. Model inclusion remains conditional on matched-row out-of-sample improvement.