### PR TITLE
Decompose WUP vintage comparability error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Decompose WUP 2018-to-2025 growth-score discrepancies into target and origin revision gaps.
+- Label retrospective persistence as a hindsight diagnostic rather than a like-for-like 2018 benchmark.
+
 ## 0.1.0 — 2026-08-28
 
 First reproducible research-foundation release.

--- a/docs/data-contract.md
+++ b/docs/data-contract.md
@@ -60,3 +60,19 @@ Global, region, subregion, and country historical means are computed only from
 training outcomes. Their leave-city-out versions subtract every prior outcome for
 the focal city before scoring, preventing the aggregation ladder from inheriting a
 mechanical city-history advantage.
+
+
+## Cross-revision forecast-error decomposition
+
+A WUP 2018 projected growth rate scored against WUP 2025 estimated growth is not
+identified as pure forecast error. The executable vintage workflow decomposes the
+reported growth discrepancy exactly into a target log gap minus an origin log gap.
+The target log gap remains an inseparable mixture of true forecast error, target
+revision and urban-definition change; the origin log gap contains origin revision
+and definition change. The identity residual must be numerically zero.
+
+Only the published 2018 projection and persistence calculated from WUP 2018 are
+eligible for a like-for-like 2018 predictor ranking. Persistence recalculated from
+WUP 2025 is labeled revised_2025_hindsight and is retained only to measure the
+advantage conferred by later revision. No output may label the cross-revision score
+as clean real-time forecast accuracy.

--- a/scripts/run_wup2018_vintage.py
+++ b/scripts/run_wup2018_vintage.py
@@ -16,6 +16,7 @@ from urban_growth.vintage import (
     reciprocal_nearest_crosswalk,
     vintage_country_weighting_diagnostics,
     vintage_crosswalk_coverage,
+    vintage_revision_decomposition,
 )
 
 
@@ -55,6 +56,16 @@ def main() -> None:
         type=Path,
         default=Path("outputs/wup2018_vintage_country_influence.csv"),
     )
+    parser.add_argument(
+        "--revision-decomposition-output",
+        type=Path,
+        default=Path("outputs/wup2018_vintage_revision_decomposition.csv"),
+    )
+    parser.add_argument(
+        "--revision-decomposition-summary-output",
+        type=Path,
+        default=Path("outputs/wup2018_vintage_revision_decomposition_summary.csv"),
+    )
     args = parser.parse_args()
     vintage = read_f22_2018_city_population(
         args.raw_dir / "WUP2018-F22-Cities_Over_300K_Annual.xls"
@@ -69,6 +80,8 @@ def main() -> None:
     )
     metric_frames = []
     bootstrap_frames = []
+    decomposition_frames = []
+    decomposition_summary_frames = []
     for horizon in range(1, 6):
         horizon_metrics, horizon_bootstrap = evaluate_wup2018_vintage(
             vintage, current, crosswalk, horizon_years=horizon
@@ -76,10 +89,17 @@ def main() -> None:
         horizon_bootstrap.insert(0, "horizon_years", horizon)
         horizon_bootstrap.insert(0, "target_end", 2018 + horizon)
         horizon_bootstrap.insert(0, "origin", 2018)
+        decomposition, decomposition_summary = vintage_revision_decomposition(
+            vintage, current, crosswalk, horizon_years=horizon
+        )
         metric_frames.append(horizon_metrics)
         bootstrap_frames.append(horizon_bootstrap)
+        decomposition_frames.append(decomposition)
+        decomposition_summary_frames.append(decomposition_summary)
     metrics = pd.concat(metric_frames, ignore_index=True)
     bootstrap = pd.concat(bootstrap_frames, ignore_index=True)
+    decomposition = pd.concat(decomposition_frames, ignore_index=True)
+    decomposition_summary = pd.concat(decomposition_summary_frames, ignore_index=True)
     for path, frame in [
         (args.metrics_output, metrics),
         (args.bootstrap_output, bootstrap),
@@ -88,6 +108,8 @@ def main() -> None:
         (args.country_coverage_output, country_coverage),
         (args.country_weighting_output, country_weighting),
         (args.country_influence_output, country_influence),
+        (args.revision_decomposition_output, decomposition),
+        (args.revision_decomposition_summary_output, decomposition_summary),
     ]:
         path.parent.mkdir(parents=True, exist_ok=True)
         frame.to_csv(path, index=False)

--- a/src/urban_growth/vintage.py
+++ b/src/urban_growth/vintage.py
@@ -228,6 +228,109 @@ def vintage_country_weighting_diagnostics(
     return summary, country
 
 
+def vintage_revision_decomposition(
+    vintage_panel: pd.DataFrame,
+    current_panel: pd.DataFrame,
+    crosswalk: pd.DataFrame,
+    *,
+    origin_year: int = 2018,
+    horizon_years: int = 5,
+    maximum_distance_km: float = 5.0,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Decompose the cross-revision growth-score discrepancy.
+
+    The target term remains a mixture of true forecast error, target revision,
+    and urban-definition change. No algebra using these two editions can identify
+    those components separately.
+    """
+    if horizon_years <= 0 or maximum_distance_km <= 0:
+        raise SourceSchemaError("Vintage decomposition horizon and distance must be positive")
+    target_year = origin_year + horizon_years
+    old = vintage_panel.loc[vintage_panel["year"].isin([origin_year, target_year])].pivot(
+        index="city_id", columns="year", values="population"
+    )
+    new = current_panel.loc[current_panel["year"].isin([origin_year, target_year])].pivot(
+        index="city_id", columns="year", values="population"
+    )
+    old = old.rename(columns={
+        origin_year: "vintage_origin_population",
+        target_year: "vintage_target_population",
+    })
+    new = new.rename(columns={
+        origin_year: "current_origin_population",
+        target_year: "current_target_population",
+    })
+    matched = crosswalk.loc[crosswalk["distance_km"].le(maximum_distance_km)].merge(
+        old, left_on="vintage_city_id", right_index=True, validate="one_to_one"
+    ).merge(new, left_on="current_city_id", right_index=True, validate="one_to_one")
+    values = [
+        "vintage_origin_population", "vintage_target_population",
+        "current_origin_population", "current_target_population",
+    ]
+    matched = matched.dropna(subset=values).copy()
+    if matched.empty or (matched[values] <= 0).any().any():
+        raise SourceSchemaError("Vintage decomposition requires positive complete populations")
+    matched["origin_revision_log_gap"] = (
+        np.log(matched["vintage_origin_population"])
+        - np.log(matched["current_origin_population"])
+    )
+    matched["target_total_log_gap"] = (
+        np.log(matched["vintage_target_population"])
+        - np.log(matched["current_target_population"])
+    )
+    matched["reported_growth_error"] = (
+        matched["target_total_log_gap"] - matched["origin_revision_log_gap"]
+    ) / horizon_years
+    published_growth = (
+        np.log(matched["vintage_target_population"])
+        - np.log(matched["vintage_origin_population"])
+    ) / horizon_years
+    revised_growth = (
+        np.log(matched["current_target_population"])
+        - np.log(matched["current_origin_population"])
+    ) / horizon_years
+    matched["direct_growth_error"] = published_growth - revised_growth
+    matched["decomposition_identity_residual"] = (
+        matched["reported_growth_error"] - matched["direct_growth_error"]
+    )
+    matched["target_component_identification"] = (
+        "forecast_error_plus_target_revision_plus_definition_change"
+    )
+    matched["origin_component_identification"] = (
+        "origin_revision_plus_definition_change"
+    )
+    matched["comparison_status"] = (
+        "cross_revision_cross_definition_not_clean_forecast_error"
+    )
+    summary = pd.DataFrame([{
+        "origin": origin_year,
+        "target_end": target_year,
+        "horizon_years": horizon_years,
+        "maximum_distance_km": maximum_distance_km,
+        "cities": len(matched),
+        "countries": matched["country_location_id"].nunique(),
+        "mean_origin_revision_log_gap": matched["origin_revision_log_gap"].mean(),
+        "mae_origin_revision_annualized": (
+            matched["origin_revision_log_gap"].abs().mean() / horizon_years
+        ),
+        "mean_target_total_log_gap": matched["target_total_log_gap"].mean(),
+        "mae_target_total_annualized": (
+            matched["target_total_log_gap"].abs().mean() / horizon_years
+        ),
+        "reported_growth_mae": matched["reported_growth_error"].abs().mean(),
+        "identity_residual_max_abs": (
+            matched["decomposition_identity_residual"].abs().max()
+        ),
+        "target_component_identification": (
+            "forecast_error_plus_target_revision_plus_definition_change"
+        ),
+        "comparison_status": (
+            "cross_revision_cross_definition_not_clean_forecast_error"
+        ),
+    }])
+    return matched.reset_index(drop=True), summary
+
+
 def evaluate_wup2018_vintage(
     vintage_panel: pd.DataFrame,
     current_panel: pd.DataFrame,
@@ -239,8 +342,11 @@ def evaluate_wup2018_vintage(
     distance_thresholds: tuple[float, ...] = (1.0, 5.0, 10.0),
     population_agreement_thresholds: tuple[float | None, ...] = (None, 0.1, 0.2, 0.5),
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Score the 2018 published projection against later revised estimates.
+    """Score 2018-vintage predictors against later revised estimates.
 
+    Only published projection versus vintage persistence is a like-for-like
+    predictor ranking. The target still changes revision and urban definition.
+    Retrospective persistence is a hindsight diagnostic, not a 2018 competitor.
     Population-agreement restrictions use later-revision information and are
     sensitivities, not valid real-time sample-selection rules.
     """
@@ -306,6 +412,15 @@ def evaluate_wup2018_vintage(
                         "origin_population_agreement": agreement_label,
                         "selection_uses_later_revision": agreement is not None,
                         "model": model,
+                        "predictor_information_set": (
+                            "revised_2025_hindsight"
+                            if model == "retrospective_persistence"
+                            else "available_in_2018"
+                        ),
+                        "eligible_for_like_for_like_2018_ranking": (
+                            model != "retrospective_persistence"
+                        ),
+                        "target_comparability": "cross_revision_cross_definition",
                         "n": metrics.n,
                         "countries": sample["country_location_id"].nunique(),
                         "mae": metrics.mae,

--- a/tests/test_vintage.py
+++ b/tests/test_vintage.py
@@ -5,6 +5,7 @@ from urban_growth.vintage import (
     reciprocal_nearest_crosswalk,
     vintage_country_weighting_diagnostics,
     vintage_crosswalk_coverage,
+    vintage_revision_decomposition,
 )
 
 
@@ -76,6 +77,40 @@ def test_vintage_evaluation_separates_published_and_retrospective_inputs() -> No
     }
     assert bootstrap["distance_threshold_km"].unique().tolist() == [5.0]
     assert bootstrap["clusters"].eq(2).all()
+
+
+def test_vintage_revision_decomposition_closes_identity_without_overclaim() -> None:
+    vintage = _vintage_panel()
+    current = _current_panel()
+    crosswalk = reciprocal_nearest_crosswalk(vintage, current)
+    detail, summary = vintage_revision_decomposition(
+        vintage, current, crosswalk, maximum_distance_km=5.0
+    )
+    assert detail["decomposition_identity_residual"].abs().max() < 1e-12
+    assert summary.loc[0, "identity_residual_max_abs"] < 1e-12
+    assert detail["comparison_status"].eq(
+        "cross_revision_cross_definition_not_clean_forecast_error"
+    ).all()
+    assert summary.loc[0, "target_component_identification"] == (
+        "forecast_error_plus_target_revision_plus_definition_change"
+    )
+
+
+def test_vintage_metrics_label_hindsight_benchmark() -> None:
+    vintage = _vintage_panel()
+    current = _current_panel()
+    crosswalk = reciprocal_nearest_crosswalk(vintage, current)
+    metrics, _ = evaluate_wup2018_vintage(
+        vintage,
+        current,
+        crosswalk,
+        distance_thresholds=(5.0,),
+        population_agreement_thresholds=(None,),
+    )
+    hindsight = metrics.loc[metrics["model"].eq("retrospective_persistence")].iloc[0]
+    assert hindsight["predictor_information_set"] == "revised_2025_hindsight"
+    assert not hindsight["eligible_for_like_for_like_2018_ranking"]
+    assert metrics["target_comparability"].eq("cross_revision_cross_definition").all()
 
 
 def test_vintage_crosswalk_coverage_reports_excluded_universe() -> None:


### PR DESCRIPTION
## Summary
- decompose the WUP 2018-to-2025 growth-score discrepancy into target and origin log gaps
- enforce the exact algebraic identity with a numerical residual
- label the target component as unresolved forecast error plus target revision plus definition change
- mark WUP-2025 retrospective persistence as a hindsight diagnostic, not a like-for-like 2018 competitor
- emit detailed and summary decomposition outputs for each 2019–2023 target horizon

## Methodological boundary
This does not claim to identify pure forecast error. The available editions cannot separate true forecast error from later target revision and urban-definition change.

## Validation
Two unit tests cover the decomposition identity and benchmark labels. GitHub Actions should run the full locked test and lint suite.