### PR TITLE
Exclude focal city from national comparator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add a focal-city-excluded WUP F01 national Cities-category comparator and retain the inclusive version only as a diagnostic.
+
 - Decompose WUP 2018-to-2025 growth-score discrepancies into target and origin revision gaps.
 - Label retrospective persistence as a hindsight diagnostic rather than a like-for-like 2018 benchmark.
 

--- a/docs/data-contract.md
+++ b/docs/data-contract.md
@@ -76,3 +76,18 @@ eligible for a like-for-like 2018 predictor ranking. Persistence recalculated fr
 WUP 2025 is labeled revised_2025_hindsight and is retained only to measure the
 advantage conferred by later revision. No output may label the cross-revision score
 as clean real-time forecast accuracy.
+
+
+## Focal-city exclusion from national Cities-category growth
+
+The primary WUP F01 national comparator subtracts the focal F21 city population from
+both the lag and origin national Cities-category totals before calculating growth.
+The unadjusted national comparator is retained only as a mechanical self-inclusion
+diagnostic. Residual national totals must remain strictly positive or the workflow
+fails.
+
+This subtraction uses F21 and F01 from the same WUP 2025 revision, but direct
+component membership is assumed rather than independently crosswalk-validated.
+Outputs therefore carry national_focal_component_membership_assumed. The diagnostic
+removes arithmetic self-inclusion; it does not create causal exogeneity or make the
+revised history vintage-correct.

--- a/docs/research-status.md
+++ b/docs/research-status.md
@@ -185,6 +185,12 @@ This does not overturn the 2020 finding. A single-origin comparison has no acros
 
 ## National demographic comparator
 
+**Superseded pending regeneration:** the numerical results immediately below use the
+inclusive F01 national Cities-category comparator and should not be treated as the
+primary national baseline. The corrected workflow now subtracts the focal F21 city
+at both endpoints. New empirical values and expected-output hashes must be generated
+from the registered raw files before this section is updated.
+
 The acquired WUP F01 national control now supplies a baseline that was previously
 missing: each country's observed growth in the harmonized Cities category over the
 five years ending at the forecast origin is carried forward to its sampled cities.

--- a/src/urban_growth/forecast.py
+++ b/src/urban_growth/forecast.py
@@ -46,11 +46,15 @@ def attach_national_city_category_baseline(
     """Attach pre-origin national Cities-category growth from WUP F01.
 
     This is a revised-history demographic comparator. Both endpoints precede
-    or equal the city forecast origin; no future national value is used.
+    or equal the city forecast origin; no future national value is used. The
+    primary variant subtracts the focal F21 city from both F01 national endpoints.
+    The inclusive variant is retained only to measure mechanical self-inclusion.
     """
     require_columns(
         intervals,
-        {"country_code", "period_start"},
+        {
+            "country_code", "period_start", "population_lag", "population_start",
+        },
         source_name="forecast intervals",
     )
     require_columns(
@@ -104,8 +108,45 @@ def attach_national_city_category_baseline(
         how="left",
         validate="many_to_one",
     )
+    result["national_city_category_recent_growth_inclusive"] = result[
+        "national_city_category_recent_growth"
+    ]
+    national_origin = result["country_code"].map(
+        national_panel.loc[national_panel["year"].eq(0)]
+        .set_index("country_code")["national_city_category_population"]
+    )
+    national_lookup = national_panel.set_index(["country_code", "year"])[
+        "national_city_category_population"
+    ]
+    origin_lookup = pd.MultiIndex.from_frame(
+        result.rename(columns={"period_start": "year"})[["country_code", "year"]]
+    )
+    lag_result = result.assign(year=result["period_start"] - lookback_years)
+    lag_lookup = pd.MultiIndex.from_frame(lag_result[["country_code", "year"]])
+    national_origin = national_lookup.reindex(origin_lookup).to_numpy()
+    national_lag = national_lookup.reindex(lag_lookup).to_numpy()
+    residual_origin = national_origin - result["population_start"].to_numpy()
+    residual_lag = national_lag - result["population_lag"].to_numpy()
+    if (residual_origin <= 0).any() or (residual_lag <= 0).any():
+        raise SourceSchemaError(
+            "Focal city is not a strictly smaller positive component of national Cities totals"
+        )
+    result["national_city_category_recent_growth_leave_city_out"] = (
+        np.log(residual_origin) - np.log(residual_lag)
+    ) / lookback_years
+    result["national_focal_share_origin"] = (
+        result["population_start"].to_numpy() / national_origin
+    )
+    result["national_focal_share_lag"] = (
+        result["population_lag"].to_numpy() / national_lag
+    )
     result["national_baseline_revision_semantics"] = "WUP_2025_revised_history"
     result["national_baseline_uses_future_value"] = False
+    result["national_baseline_focal_city_excluded"] = True
+    result["national_focal_component_membership_assumed"] = True
+    result["national_focal_subtraction_semantics"] = (
+        "F21_city_subtracted_from_F01_Cities_same_revision"
+    )
     return result
 
 
@@ -420,8 +461,13 @@ def baseline_predictions(
     predictions["country_mean"] = test["country_code"].map(country_means).fillna(global_mean)
     national_column = "national_city_category_recent_growth"
     if national_column in test.columns:
-        predictions["national_city_category_persistence"] = pd.to_numeric(
+        predictions["national_city_category_persistence_inclusive"] = pd.to_numeric(
             test[national_column], errors="coerce"
+        )
+    national_loo_column = "national_city_category_recent_growth_leave_city_out"
+    if national_loo_column in test.columns:
+        predictions["national_city_category_persistence_leave_city_out"] = pd.to_numeric(
+            test[national_loo_column], errors="coerce"
         )
     if "city_id" in train.columns and "city_id" in test.columns:
         country_totals = valid_train.groupby("country_code")[outcome_column].agg(["sum", "count"])

--- a/src/urban_growth/forecast.py
+++ b/src/urban_growth/forecast.py
@@ -111,10 +111,6 @@ def attach_national_city_category_baseline(
     result["national_city_category_recent_growth_inclusive"] = result[
         "national_city_category_recent_growth"
     ]
-    national_origin = result["country_code"].map(
-        national_panel.loc[national_panel["year"].eq(0)]
-        .set_index("country_code")["national_city_category_population"]
-    )
     national_lookup = national_panel.set_index(["country_code", "year"])[
         "national_city_category_population"
     ]

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -199,7 +199,13 @@ def test_baselines_use_training_country_mean_and_global_fallback() -> None:
 
 def test_national_city_category_baseline_uses_only_pre_origin_values() -> None:
     intervals = pd.DataFrame(
-        {"country_code": ["A"], "period_start": [2020], "future_growth": [0.01]}
+        {
+            "country_code": ["A"],
+            "period_start": [2020],
+            "population_lag": [10.0],
+            "population_start": [20.0],
+            "future_growth": [0.01],
+        }
     )
     national = pd.DataFrame(
         {
@@ -218,10 +224,44 @@ def test_national_city_category_baseline_uses_only_pre_origin_values() -> None:
     assert attached["national_city_category_recent_growth"].iloc[0] == pytest.approx(
         expected
     )
+    expected_loo = (np.log(90.0) - np.log(90.0)) / 5
+    assert attached[
+        "national_city_category_recent_growth_leave_city_out"
+    ].iloc[0] == pytest.approx(expected_loo)
+    assert attached["national_focal_share_lag"].iloc[0] == pytest.approx(0.10)
+    assert attached["national_focal_share_origin"].iloc[0] == pytest.approx(20 / 110)
+    assert attached["national_baseline_focal_city_excluded"].iloc[0]
+    assert attached["national_focal_component_membership_assumed"].iloc[0]
     assert not attached["national_baseline_uses_future_value"].iloc[0]
     assert attached["subregion_id"].tolist() == [10]
     assert attached["region_id"].tolist() == [1]
 
+
+
+
+def test_national_leave_city_out_rejects_invalid_component_subtraction() -> None:
+    intervals = pd.DataFrame(
+        {
+            "country_code": ["A"],
+            "period_start": [2020],
+            "population_lag": [100.0],
+            "population_start": [120.0],
+        }
+    )
+    national = pd.DataFrame(
+        {
+            "country_code": ["A", "A"],
+            "year": [2015, 2020],
+            "national_city_category_population": [100.0, 110.0],
+            "revision_semantics": ["WUP_2025_revised_history"] * 2,
+            "subregion_id": [10] * 2,
+            "subregion_name": ["Example subregion"] * 2,
+            "region_id": [1] * 2,
+            "region_name": ["Example region"] * 2,
+        }
+    )
+    with pytest.raises(SourceSchemaError, match="strictly smaller positive component"):
+        attach_national_city_category_baseline(intervals, national)
 
 def test_baselines_include_attached_national_demographic_comparator() -> None:
     train = pd.DataFrame({"country_code": ["A"], "future_growth": [0.01]})
@@ -230,10 +270,14 @@ def test_baselines_include_attached_national_demographic_comparator() -> None:
             "country_code": ["A"],
             "recent_growth": [0.02],
             "national_city_category_recent_growth": [0.03],
+            "national_city_category_recent_growth_leave_city_out": [0.025],
         }
     )
     result = baseline_predictions(train, test)
-    assert result["national_city_category_persistence"].tolist() == [0.03]
+    assert result["national_city_category_persistence_inclusive"].tolist() == [0.03]
+    assert result[
+        "national_city_category_persistence_leave_city_out"
+    ].tolist() == [0.025]
 
 
 def test_baselines_include_leave_city_out_region_ladder() -> None:


### PR DESCRIPTION
## Summary
- calculate a leave-focal-city-out WUP F01 Cities-category growth comparator by subtracting the focal F21 city at both endpoints
- retain the inclusive national comparator only as a mechanical self-inclusion diagnostic
- fail when subtraction does not leave strictly positive national residuals
- report focal-city shares and explicit same-revision component-membership assumptions
- label the previously reported inclusive national results as superseded pending empirical regeneration

## Econometric boundary
This removes arithmetic self-inclusion. It does not establish causal exogeneity, independently verify that every F21 city is an exact F01 component, or make WUP 2025 revised history vintage-correct.

## Required empirical follow-up
The registered raw files are not committed. After merge, regenerate the WUP outputs and expected hashes before updating numerical national-comparator conclusions.