### PR TITLE
Add equal-origin forecast estimands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add equal-origin and equal-country-within-origin forecast estimands to prevent changing temporal coverage from silently determining pooled results.
+
 - Add a focal-city-excluded WUP F01 national Cities-category comparator and retain the inclusive version only as a diagnostic.
 
 - Decompose WUP 2018-to-2025 growth-score discrepancies into target and origin revision gaps.

--- a/docs/data-contract.md
+++ b/docs/data-contract.md
@@ -91,3 +91,18 @@ component membership is assumed rather than independently crosswalk-validated.
 Outputs therefore carry national_focal_component_membership_assumed. The diagnostic
 removes arithmetic self-inclusion; it does not create causal exogeneity or make the
 revised history vintage-correct.
+
+
+## Temporal and geographic weighting estimands
+
+Pooled forecast metrics must identify their weighting estimand. City-origin weighting
+answers the average scored-city case but gives origins with more eligible cities more
+influence. Equal-origin metrics first calculate error within each origin and then
+average origins. Equal-country-origin metrics first give every country equal weight
+within an origin and then give every origin equal weight.
+
+These are distinct decision targets, not interchangeable robustness labels. Reports
+must present city-origin and equal-origin results together whenever source coverage
+changes across time. Equal-country-origin results are additionally required before
+calling a result globally representative. RMSE is calculated from the correspondingly
+weighted mean squared error, not by averaging origin-specific RMSE values.

--- a/docs/research-status.md
+++ b/docs/research-status.md
@@ -166,6 +166,14 @@ The 2020 reversal is robust: all six size-bin intervals are entirely above zero,
 
 Within WUP, this defeats universal H1 because one broad and statistically supported period reversal is enough to violate “consistent across periods.” The fixed-polygon GHSL result does not reproduce that reversal, so the cross-source conclusion is sensitivity, not a settled global failure or success.
 
+## Pooled point-estimate weighting
+
+**Pending regeneration:** existing pooled point estimates are city-origin weighted,
+so WUP origins with more eligible cities receive more influence. The workflow now
+emits equal-origin and equal-country-within-origin point estimates. Until those
+outputs and expected hashes are regenerated, pooled claims should be described by
+their city-origin weighting rather than as generic global performance.
+
 ## Joint country-and-time uncertainty
 
 The two-way pigeonhole bootstrap independently resamples countries and forecast origins, applying the product of their resampling weights to each country-origin cell. It retains all city errors within a cell and uses the same 2,000 repetitions and seed. This targets sensitivity to both geographic composition and which historical periods were realized.

--- a/scripts/run_ghsl_fixed_baselines.py
+++ b/scripts/run_ghsl_fixed_baselines.py
@@ -14,10 +14,10 @@ from urban_growth.adapters.ghsl_ucdb import (
 )
 from urban_growth.forecast import (
     build_ghsl_fixed_forecast_intervals,
-    evaluate_rolling_baselines,
-    evaluate_rolling_hierarchy_models,
     equal_country_origin_forecast_metrics,
     equal_origin_forecast_metrics,
+    evaluate_rolling_baselines,
+    evaluate_rolling_hierarchy_models,
     rolling_baseline_errors,
     temporal_reversal_diagnostics,
 )

--- a/scripts/run_ghsl_fixed_baselines.py
+++ b/scripts/run_ghsl_fixed_baselines.py
@@ -16,6 +16,8 @@ from urban_growth.forecast import (
     build_ghsl_fixed_forecast_intervals,
     evaluate_rolling_baselines,
     evaluate_rolling_hierarchy_models,
+    equal_country_origin_forecast_metrics,
+    equal_origin_forecast_metrics,
     rolling_baseline_errors,
     temporal_reversal_diagnostics,
 )
@@ -68,6 +70,16 @@ def main() -> None:
         type=Path,
         default=Path("outputs/ghsl_fixed_hierarchy_model_metrics.csv"),
     )
+    parser.add_argument(
+        "--equal-origin-output",
+        type=Path,
+        default=Path("outputs/ghsl_fixed_equal_origin_metrics.csv"),
+    )
+    parser.add_argument(
+        "--equal-country-origin-output",
+        type=Path,
+        default=Path("outputs/ghsl_fixed_equal_country_origin_metrics.csv"),
+    )
     args = parser.parse_args()
     fixed = fixed_2025_theme_panel(read_ghsl_theme_csv(str(args.input)))
     dynamic = multitemporal_boundary_panel(read_ghsl_mtuc_csv(str(args.dynamic_input)))
@@ -78,6 +90,8 @@ def main() -> None:
     origins = list(range(1985, 2025, 5))
     metrics = evaluate_rolling_baselines(intervals, origins)
     errors = rolling_baseline_errors(intervals, origins)
+    equal_origin = equal_origin_forecast_metrics(errors)
+    equal_country_origin = equal_country_origin_forecast_metrics(errors)
     temporal = temporal_reversal_diagnostics(intervals)
     gapped_intervals = build_ghsl_fixed_forecast_intervals(
         fixed,
@@ -98,6 +112,8 @@ def main() -> None:
         (args.gapped_metrics_output, gapped_metrics),
         (args.gapped_temporal_output, gapped_temporal),
         (args.hierarchy_output, hierarchy),
+        (args.equal_origin_output, equal_origin),
+        (args.equal_country_origin_output, equal_country_origin),
     ]:
         path.parent.mkdir(parents=True, exist_ok=True)
         frame.to_csv(path, index=False)

--- a/scripts/run_wup_baselines.py
+++ b/scripts/run_wup_baselines.py
@@ -20,6 +20,8 @@ from urban_growth.forecast import (
     build_forecast_intervals,
     cluster_bootstrap_paired_difference,
     equal_country_forecast_metrics,
+    equal_country_origin_forecast_metrics,
+    equal_origin_forecast_metrics,
     evaluate_rolling_baselines,
     evaluate_rolling_hierarchy_models,
     leave_one_cluster_out_paired_difference,
@@ -108,6 +110,16 @@ def main() -> None:
         default=Path("outputs/wup_equal_country_pooled_metrics.csv"),
     )
     parser.add_argument(
+        "--equal-origin-output",
+        type=Path,
+        default=Path("outputs/wup_equal_origin_metrics.csv"),
+    )
+    parser.add_argument(
+        "--equal-country-origin-output",
+        type=Path,
+        default=Path("outputs/wup_equal_country_origin_metrics.csv"),
+    )
+    parser.add_argument(
         "--balanced-pooled-equal-country-output",
         type=Path,
         default=Path("outputs/wup_balanced_equal_country_pooled_metrics.csv"),
@@ -183,6 +195,8 @@ def main() -> None:
         balanced_errors, group_columns=["origin"]
     )
     pooled_equal_country = equal_country_forecast_metrics(errors)
+    equal_origin = equal_origin_forecast_metrics(errors)
+    equal_country_origin = equal_country_origin_forecast_metrics(errors)
     balanced_pooled_equal_country = equal_country_forecast_metrics(balanced_errors)
     country_time_bootstrap = two_way_cluster_bootstrap_paired_difference(errors)
     country_time_size_bootstrap = two_way_cluster_bootstrap_paired_difference(
@@ -246,6 +260,10 @@ def main() -> None:
     balanced_equal_country.to_csv(args.balanced_equal_country_output, index=False)
     args.pooled_equal_country_output.parent.mkdir(parents=True, exist_ok=True)
     pooled_equal_country.to_csv(args.pooled_equal_country_output, index=False)
+    args.equal_origin_output.parent.mkdir(parents=True, exist_ok=True)
+    equal_origin.to_csv(args.equal_origin_output, index=False)
+    args.equal_country_origin_output.parent.mkdir(parents=True, exist_ok=True)
+    equal_country_origin.to_csv(args.equal_country_origin_output, index=False)
     args.balanced_pooled_equal_country_output.parent.mkdir(parents=True, exist_ok=True)
     balanced_pooled_equal_country.to_csv(
         args.balanced_pooled_equal_country_output, index=False
@@ -279,6 +297,8 @@ def main() -> None:
     print(args.equal_country_output)
     print(args.balanced_equal_country_output)
     print(args.pooled_equal_country_output)
+    print(args.equal_origin_output)
+    print(args.equal_country_origin_output)
     print(args.balanced_pooled_equal_country_output)
     print(args.country_time_bootstrap_output)
     print(args.country_time_size_bootstrap_output)

--- a/src/urban_growth/forecast.py
+++ b/src/urban_growth/forecast.py
@@ -744,6 +744,88 @@ def equal_country_forecast_metrics(
     return result.sort_values(result_keys).reset_index(drop=True)
 
 
+def equal_origin_forecast_metrics(
+    errors: pd.DataFrame,
+    *,
+    group_columns: list[str] | None = None,
+) -> pd.DataFrame:
+    """Score models with every forecast origin receiving equal weight."""
+    groups = group_columns or []
+    required = {"origin", "model", "error", "absolute_error", *groups}
+    require_columns(errors, required, source_name="row-level forecast errors")
+    working = errors.copy()
+    if not np.isfinite(working[["error", "absolute_error"]]).all().all():
+        raise SourceSchemaError("Equal-origin metrics require finite errors")
+    working["squared_error"] = working["error"] ** 2
+    origin_keys = [*groups, "model", "origin"]
+    origin = working.groupby(origin_keys, observed=True).agg(
+        origin_mae=("absolute_error", "mean"),
+        origin_mse=("squared_error", "mean"),
+        origin_bias=("error", "mean"),
+        origin_rows=("error", "size"),
+    ).reset_index()
+    result_keys = [*groups, "model"]
+    result = origin.groupby(result_keys, observed=True).agg(
+        origins=("origin", "nunique"),
+        n_rows=("origin_rows", "sum"),
+        equal_origin_mae=("origin_mae", "mean"),
+        equal_origin_mse=("origin_mse", "mean"),
+        equal_origin_bias=("origin_bias", "mean"),
+        minimum_origin_rows=("origin_rows", "min"),
+        maximum_origin_rows=("origin_rows", "max"),
+    ).reset_index()
+    result["equal_origin_rmse"] = np.sqrt(result.pop("equal_origin_mse"))
+    result["estimand"] = "origins_equal_cities_equal_within_origin"
+    return result.sort_values(result_keys).reset_index(drop=True)
+
+
+def equal_country_origin_forecast_metrics(
+    errors: pd.DataFrame,
+    *,
+    group_columns: list[str] | None = None,
+) -> pd.DataFrame:
+    """Give countries equal weight within origin, then origins equal weight."""
+    groups = group_columns or []
+    required = {
+        "origin", "model", "country_code", "error", "absolute_error", *groups,
+    }
+    require_columns(errors, required, source_name="row-level forecast errors")
+    working = errors.copy()
+    if not np.isfinite(working[["error", "absolute_error"]]).all().all():
+        raise SourceSchemaError("Equal-country-origin metrics require finite errors")
+    working["squared_error"] = working["error"] ** 2
+    country_origin_keys = [*groups, "model", "origin", "country_code"]
+    country_origin = working.groupby(country_origin_keys, observed=True).agg(
+        country_origin_mae=("absolute_error", "mean"),
+        country_origin_mse=("squared_error", "mean"),
+        country_origin_bias=("error", "mean"),
+        country_origin_rows=("error", "size"),
+    ).reset_index()
+    origin_keys = [*groups, "model", "origin"]
+    origin = country_origin.groupby(origin_keys, observed=True).agg(
+        origin_equal_country_mae=("country_origin_mae", "mean"),
+        origin_equal_country_mse=("country_origin_mse", "mean"),
+        origin_equal_country_bias=("country_origin_bias", "mean"),
+        countries=("country_code", "nunique"),
+        origin_rows=("country_origin_rows", "sum"),
+    ).reset_index()
+    result_keys = [*groups, "model"]
+    result = origin.groupby(result_keys, observed=True).agg(
+        origins=("origin", "nunique"),
+        n_rows=("origin_rows", "sum"),
+        equal_country_origin_mae=("origin_equal_country_mae", "mean"),
+        equal_country_origin_mse=("origin_equal_country_mse", "mean"),
+        equal_country_origin_bias=("origin_equal_country_bias", "mean"),
+        minimum_countries_per_origin=("countries", "min"),
+        maximum_countries_per_origin=("countries", "max"),
+    ).reset_index()
+    result["equal_country_origin_rmse"] = np.sqrt(
+        result.pop("equal_country_origin_mse")
+    )
+    result["estimand"] = "origins_equal_countries_equal_within_origin"
+    return result.sort_values(result_keys).reset_index(drop=True)
+
+
 def paired_error_comparison(
     errors: pd.DataFrame,
     *,

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -11,6 +11,8 @@ from urban_growth.forecast import (
     build_ghsl_fixed_forecast_intervals,
     cluster_bootstrap_paired_difference,
     equal_country_forecast_metrics,
+    equal_country_origin_forecast_metrics,
+    equal_origin_forecast_metrics,
     evaluate_rolling_baselines,
     evaluate_rolling_hierarchy_models,
     leave_one_cluster_out_paired_difference,
@@ -383,6 +385,42 @@ def test_balanced_cohort_and_equal_country_weighting() -> None:
     result = equal_country_forecast_metrics(errors)
     assert result.loc[0, "equal_country_mae"] == pytest.approx(0.06)
     assert result.loc[0, "countries"] == 2
+
+
+def test_equal_origin_metrics_do_not_let_larger_origins_dominate() -> None:
+    errors = pd.DataFrame(
+        {
+            "origin": [2000, 2000, 2005],
+            "model": ["m", "m", "m"],
+            "country_code": ["A", "B", "A"],
+            "error": [0.10, 0.10, 0.30],
+            "absolute_error": [0.10, 0.10, 0.30],
+        }
+    )
+    result = equal_origin_forecast_metrics(errors)
+    assert result.loc[0, "equal_origin_mae"] == pytest.approx(0.20)
+    assert result.loc[0, "origins"] == 2
+    assert result.loc[0, "minimum_origin_rows"] == 1
+    assert result.loc[0, "maximum_origin_rows"] == 2
+
+
+def test_equal_country_origin_metrics_apply_both_weighting_stages() -> None:
+    errors = pd.DataFrame(
+        {
+            "origin": [2000, 2000, 2000, 2005],
+            "model": ["m"] * 4,
+            "country_code": ["A", "A", "B", "A"],
+            "error": [0.10, 0.30, 0.50, 0.10],
+            "absolute_error": [0.10, 0.30, 0.50, 0.10],
+        }
+    )
+    result = equal_country_origin_forecast_metrics(errors)
+    assert result.loc[0, "equal_country_origin_mae"] == pytest.approx(0.225)
+    assert result.loc[0, "minimum_countries_per_origin"] == 1
+    assert result.loc[0, "maximum_countries_per_origin"] == 2
+    assert result.loc[0, "estimand"] == (
+        "origins_equal_countries_equal_within_origin"
+    )
 
 
 def test_country_cluster_bootstrap_is_reproducible() -> None:


### PR DESCRIPTION
## Summary
- add equal-origin forecast MAE, RMSE, and bias so origins with more eligible cities do not silently dominate pooled results
- add equal-country-within-origin metrics followed by equal weighting across origins
- report minimum and maximum origin rows/country counts to expose changing support
- integrate both estimands into WUP and fixed-GHSL workflows
- document city-origin, equal-origin, and equal-country-origin results as distinct decision targets

## Econometric rationale
City-origin weighting estimates error for the average scored city case. Equal-origin weighting estimates performance across historical forecast origins. Equal-country-origin weighting additionally prevents countries with more observed cities from determining each period. None is universally correct; the output must name the estimand.

## Empirical follow-up
Existing numerical pooled claims remain city-origin weighted until the registered raw workflows regenerate the new outputs and expected hashes.