### PR TITLE
Separate model selection from locked-origin evaluation

### DIFF
--- a/docs/research-design.md
+++ b/docs/research-design.md
@@ -61,6 +61,22 @@ Forecasting does not require causal exogeneity, but interpretation of coefficien
 - Use paired block bootstrap intervals clustered at minimum by country; add time blocks when periods overlap.
 - Use leave-one-country-out and influential-city diagnostics.
 
+### Model selection and the exhausted 2020 holdout
+
+Model comparisons must separate origins used to select a specification from the origin
+used to estimate its final performance. The WUP workflow now selects the lowest-MAE
+candidate using pre-2020 origins and reports its 2020 MAE, rank and regret relative to
+the hindsight-best 2020 model. The hindsight-best model is diagnostic only and cannot
+replace the pre-2020 selection.
+
+This calculation does **not** restore 2020 as a pristine holdout. The project inspected
+2020 repeatedly while developing predictors, comparators and sensitivity tests, so the
+candidate set itself reflects knowledge of that outcome. Report the new table as a
+specification-search audit, not unbiased final generalization error. A defensible final
+performance claim requires freezing the data contract, candidate models, metric and
+weighting rule before evaluating a genuinely untouched later vintage or outcome period.
+Until then, all 2020 superiority claims remain development evidence.
+
 ### Vintage limitation
 
 A chronological holdout within WUP 2025 is **retrospective pseudo-out-of-sample validation**. It does not recreate a forecast made in an earlier year because the 2025 revision incorporates later censuses, revised methods, boundaries and national totals. Use “real-time” or “vintage-correct” only when each training input is drawn from the edition actually available at that forecast origin. Report current-revision holdouts and vintage tests separately.

--- a/scripts/run_wup_baselines.py
+++ b/scripts/run_wup_baselines.py
@@ -25,6 +25,7 @@ from urban_growth.forecast import (
     evaluate_rolling_baselines,
     evaluate_rolling_hierarchy_models,
     leave_one_cluster_out_paired_difference,
+    locked_origin_model_evaluation,
     paired_error_comparison,
     rolling_baseline_errors,
     temporal_reversal_diagnostics,
@@ -140,6 +141,11 @@ def main() -> None:
         default=Path("outputs/wup_balanced_country_time_bootstrap_overall.csv"),
     )
     parser.add_argument(
+        "--locked-origin-output",
+        type=Path,
+        default=Path("outputs/wup_2020_locked_origin_evaluation.csv"),
+    )
+    parser.add_argument(
         "--aggregation-bootstrap-output",
         type=Path,
         default=Path("outputs/wup_aggregation_bootstrap_by_origin.csv"),
@@ -198,6 +204,7 @@ def main() -> None:
     equal_origin = equal_origin_forecast_metrics(errors)
     equal_country_origin = equal_country_origin_forecast_metrics(errors)
     balanced_pooled_equal_country = equal_country_forecast_metrics(balanced_errors)
+    locked_origin = locked_origin_model_evaluation(errors, locked_origin=2020)
     country_time_bootstrap = two_way_cluster_bootstrap_paired_difference(errors)
     country_time_size_bootstrap = two_way_cluster_bootstrap_paired_difference(
         errors,
@@ -268,6 +275,8 @@ def main() -> None:
     balanced_pooled_equal_country.to_csv(
         args.balanced_pooled_equal_country_output, index=False
     )
+    args.locked_origin_output.parent.mkdir(parents=True, exist_ok=True)
+    locked_origin.to_csv(args.locked_origin_output, index=False)
     args.country_time_bootstrap_output.parent.mkdir(parents=True, exist_ok=True)
     country_time_bootstrap.to_csv(args.country_time_bootstrap_output, index=False)
     args.country_time_size_bootstrap_output.parent.mkdir(parents=True, exist_ok=True)
@@ -300,6 +309,7 @@ def main() -> None:
     print(args.equal_origin_output)
     print(args.equal_country_origin_output)
     print(args.balanced_pooled_equal_country_output)
+    print(args.locked_origin_output)
     print(args.country_time_bootstrap_output)
     print(args.country_time_size_bootstrap_output)
     print(args.balanced_country_time_bootstrap_output)

--- a/src/urban_growth/forecast.py
+++ b/src/urban_growth/forecast.py
@@ -826,6 +826,95 @@ def equal_country_origin_forecast_metrics(
     return result.sort_values(result_keys).reset_index(drop=True)
 
 
+
+def locked_origin_model_evaluation(
+    errors: pd.DataFrame,
+    *,
+    locked_origin: int,
+    development_origins: list[int] | None = None,
+) -> pd.DataFrame:
+    """Select on earlier origins and evaluate once on a declared locked origin.
+
+    The locked-origin best model is reported only as a hindsight diagnostic. It
+    must not replace the model selected from development origins.
+    """
+    required = {"origin", "model", "absolute_error"}
+    require_columns(errors, required, source_name="row-level forecast errors")
+    working = errors.copy()
+    if not np.isfinite(working["absolute_error"]).all():
+        raise SourceSchemaError("Locked-origin evaluation requires finite absolute errors")
+    available = set(working["origin"].unique())
+    if locked_origin not in available:
+        raise SourceSchemaError("Locked origin is absent from forecast errors")
+    if development_origins is None:
+        development = sorted(origin for origin in available if origin < locked_origin)
+    else:
+        if not development_origins or len(set(development_origins)) != len(
+            development_origins
+        ):
+            raise SourceSchemaError("Development origins must be unique and non-empty")
+        development = sorted(development_origins)
+        if locked_origin in development:
+            raise SourceSchemaError("Locked origin cannot be used for model selection")
+        if any(origin >= locked_origin for origin in development):
+            raise SourceSchemaError("Development origins must precede the locked origin")
+        missing = set(development) - available
+        if missing:
+            raise SourceSchemaError("A declared development origin is absent")
+    if not development:
+        raise SourceSchemaError("No development origins precede the locked origin")
+
+    development_rows = working.loc[working["origin"].isin(development)]
+    locked_rows = working.loc[working["origin"].eq(locked_origin)]
+    development_scores = development_rows.groupby("model", observed=True).agg(
+        development_mae=("absolute_error", "mean"),
+        development_n=("absolute_error", "size"),
+        development_origins=("origin", "nunique"),
+    )
+    locked_scores = locked_rows.groupby("model", observed=True).agg(
+        locked_mae=("absolute_error", "mean"),
+        locked_n=("absolute_error", "size"),
+    )
+    common = development_scores.join(locked_scores, how="inner")
+    if common.empty:
+        raise SourceSchemaError("No model is available in both development and locked origins")
+    common = common.reset_index().sort_values(
+        ["development_mae", "model"], kind="stable"
+    )
+    selected = common.iloc[0]
+    locked_order = common.sort_values(["locked_mae", "model"], kind="stable").reset_index(
+        drop=True
+    )
+    locked_order["locked_rank"] = np.arange(1, len(locked_order) + 1)
+    selected_locked_rank = int(
+        locked_order.loc[locked_order["model"].eq(selected["model"]), "locked_rank"].iloc[0]
+    )
+    hindsight_best = locked_order.iloc[0]
+    return pd.DataFrame(
+        [
+            {
+                "locked_origin": locked_origin,
+                "development_origin_start": min(development),
+                "development_origin_end": max(development),
+                "development_origins": int(selected["development_origins"]),
+                "selected_model": selected["model"],
+                "selection_metric": "pooled_city_origin_mae",
+                "development_mae": float(selected["development_mae"]),
+                "development_n": int(selected["development_n"]),
+                "locked_mae": float(selected["locked_mae"]),
+                "locked_n": int(selected["locked_n"]),
+                "locked_rank": selected_locked_rank,
+                "hindsight_best_model": hindsight_best["model"],
+                "hindsight_best_locked_mae": float(hindsight_best["locked_mae"]),
+                "selection_regret": float(
+                    selected["locked_mae"] - hindsight_best["locked_mae"]
+                ),
+                "hindsight_best_is_diagnostic_only": True,
+            }
+        ]
+    )
+
+
 def paired_error_comparison(
     errors: pd.DataFrame,
     *,

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -16,6 +16,7 @@ from urban_growth.forecast import (
     evaluate_rolling_baselines,
     evaluate_rolling_hierarchy_models,
     leave_one_cluster_out_paired_difference,
+    locked_origin_model_evaluation,
     matched_boundary_forecast_panels,
     paired_error_comparison,
     rolling_baseline_errors,
@@ -497,3 +498,33 @@ def test_leave_one_country_out_identifies_influential_cluster() -> None:
     assert result.loc[0, "country_code"] == "A"
     assert result.loc[0, "excluded_mean_difference"] == pytest.approx(-0.03)
     assert result.loc[0, "exclusion_shift"] == pytest.approx(-0.0266666667)
+
+
+def test_locked_origin_selection_does_not_choose_on_locked_outcome() -> None:
+    errors = pd.DataFrame(
+        {
+            "origin": [2000, 2005, 2010] * 2,
+            "model": ["stable"] * 3 + ["shock_winner"] * 3,
+            "absolute_error": [0.10, 0.10, 0.30, 0.20, 0.20, 0.01],
+        }
+    )
+    result = locked_origin_model_evaluation(errors, locked_origin=2010)
+    assert result.loc[0, "selected_model"] == "stable"
+    assert result.loc[0, "hindsight_best_model"] == "shock_winner"
+    assert result.loc[0, "locked_rank"] == 2
+    assert result.loc[0, "selection_regret"] == pytest.approx(0.29)
+    assert result.loc[0, "hindsight_best_is_diagnostic_only"]
+
+
+def test_locked_origin_cannot_enter_development_set() -> None:
+    errors = pd.DataFrame(
+        {
+            "origin": [2005, 2010],
+            "model": ["m", "m"],
+            "absolute_error": [0.10, 0.20],
+        }
+    )
+    with pytest.raises(SourceSchemaError, match="cannot be used"):
+        locked_origin_model_evaluation(
+            errors, locked_origin=2010, development_origins=[2005, 2010]
+        )


### PR DESCRIPTION
## Methodology issue

Repeatedly comparing specifications on the same 2020 outcome creates adaptive overfitting and winner's-curse bias. A model that looks best after inspection does not have an unbiased out-of-sample performance estimate.

## Changes

- add a development-origin model-selection and locked-origin evaluation ledger;
- reject any attempt to include the locked origin in the declared development set;
- report the selected model's locked-origin rank and regret;
- label the locked-origin best model as hindsight-only;
- generate the audit in the WUP workflow;
- document that 2020 is already an exhausted holdout and cannot be made pristine retroactively;
- add tests for separation and leakage rejection.

## Interpretation

This improves auditability but does not rehabilitate 2020 as untouched evidence. Final performance claims still require a frozen protocol and a genuinely uninspected later vintage or outcome period.