### PR TITLE
Audit outcome-dependent forecast attrition

### DIFF
--- a/docs/research-design.md
+++ b/docs/research-design.md
@@ -119,6 +119,17 @@ Applied to five-year origins from 1980–2020, the exact-year rule yields 72,857
 | Spatial dependence | Compare country, region, distance, accessibility, border, and island specifications. |
 | COVID shock | Prespecify pre-COVID, shock, and post-shock evaluations. |
 
+The executable WUP selection ledger now separates late entry from outcome
+attrition. Outcome attrition is defined as a city with population observed at the
+forecast origin but missing at the required estimate outcome year. Its rate is reported
+against all origin-observed cities, rather than only against complete forecast rows.
+This missingness is plausibly outcome-dependent near the publication threshold, so
+complete-case accuracy must be described as conditional on remaining observable.
+Neither balanced cohorts nor equal weighting identify the errors of cities that
+disappear. The ledger also cannot distinguish genuine decline below 50,000 from a
+definition change or other publisher removal; those mechanisms require external
+stable-polygon population data.
+
 WUP F21 reports blank annual cells while a city is below 50,000. Therefore, WUP alone cannot identify behavior immediately below the threshold. Analyses must report entry cohorts and balanced samples; any regression-discontinuity-style interpretation around 50,000 is invalid without a separate source that observes both sides consistently.
 
 ## Commercial decision rule

--- a/scripts/run_wup_baselines.py
+++ b/scripts/run_wup_baselines.py
@@ -31,6 +31,11 @@ from urban_growth.forecast import (
     temporal_reversal_diagnostics,
     two_way_cluster_bootstrap_paired_difference,
 )
+from urban_growth.selection import (
+    outcome_attrition_summary,
+    selection_summary,
+    wup_forecast_selection_ledger,
+)
 from urban_growth.wup_panel import build_wup_city_year_panel
 
 
@@ -39,6 +44,21 @@ def main() -> None:
     parser.add_argument("--raw-dir", type=Path, default=Path("data/raw"))
     parser.add_argument(
         "--output", type=Path, default=Path("outputs/wup_baseline_metrics.csv")
+    )
+    parser.add_argument(
+        "--selection-ledger-output",
+        type=Path,
+        default=Path("outputs/wup_selection_ledger.csv"),
+    )
+    parser.add_argument(
+        "--selection-summary-output",
+        type=Path,
+        default=Path("outputs/wup_selection_summary.csv"),
+    )
+    parser.add_argument(
+        "--outcome-attrition-output",
+        type=Path,
+        default=Path("outputs/wup_outcome_attrition.csv"),
     )
     parser.add_argument(
         "--paired-output",
@@ -169,6 +189,11 @@ def main() -> None:
         raw / "WUP2025-F34-DEGURBA-Cities_Pop_density.xlsx"
     )
     city_year = build_wup_city_year_panel(population, area, built, density)
+    selection_ledger = wup_forecast_selection_ledger(
+        population, city_year, list(range(1980, 2025, 5))
+    )
+    selection_audit_summary = selection_summary(selection_ledger)
+    attrition = outcome_attrition_summary(selection_ledger)
     intervals = build_forecast_intervals(city_year, list(range(1980, 2025, 5)))
     intervals = attach_national_city_category_baseline(intervals, national)
     metrics = evaluate_rolling_baselines(intervals, list(range(1985, 2025, 5)))
@@ -239,6 +264,12 @@ def main() -> None:
     )
     args.output.parent.mkdir(parents=True, exist_ok=True)
     metrics.to_csv(args.output, index=False)
+    args.selection_ledger_output.parent.mkdir(parents=True, exist_ok=True)
+    selection_ledger.to_csv(args.selection_ledger_output, index=False)
+    args.selection_summary_output.parent.mkdir(parents=True, exist_ok=True)
+    selection_audit_summary.to_csv(args.selection_summary_output, index=False)
+    args.outcome_attrition_output.parent.mkdir(parents=True, exist_ok=True)
+    attrition.to_csv(args.outcome_attrition_output, index=False)
     args.paired_output.parent.mkdir(parents=True, exist_ok=True)
     paired.to_csv(args.paired_output, index=False)
     args.bootstrap_output.parent.mkdir(parents=True, exist_ok=True)
@@ -292,6 +323,9 @@ def main() -> None:
     args.aggregation_country_time_output.parent.mkdir(parents=True, exist_ok=True)
     aggregation_country_time.to_csv(args.aggregation_country_time_output, index=False)
     print(args.output)
+    print(args.selection_ledger_output)
+    print(args.selection_summary_output)
+    print(args.outcome_attrition_output)
     print(args.paired_output)
     print(args.bootstrap_output)
     print(args.pooled_paired_output)

--- a/src/urban_growth/selection.py
+++ b/src/urban_growth/selection.py
@@ -1,0 +1,298 @@
+"""Machine-readable audits of forecast-sample construction."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
+
+
+def _validate_origins(origins: list[int]) -> list[int]:
+    if not origins or any(not isinstance(year, int) for year in origins):
+        raise SourceSchemaError("Selection-audit origins must be non-empty integer years")
+    if len(origins) != len(set(origins)):
+        raise SourceSchemaError("Selection-audit origins must be unique")
+    return sorted(origins)
+
+
+def _coverage_flags(
+    ledger: pd.DataFrame,
+    panel: pd.DataFrame,
+    *,
+    lookback_years: int,
+    horizon_years: int,
+    outcome_gap_years: int,
+) -> pd.DataFrame:
+    require_columns(panel, {"city_id", "year"}, source_name="selection-audit panel")
+    reject_duplicate_keys(panel, ["city_id", "year"], source_name="selection-audit panel")
+    available = pd.MultiIndex.from_frame(panel[["city_id", "year"]])
+    years = {
+        "lag_available": ledger["origin"] - lookback_years,
+        "origin_available": ledger["origin"],
+        "outcome_start_available": ledger["origin"] + outcome_gap_years,
+        "outcome_end_available": ledger["origin"] + outcome_gap_years + horizon_years,
+    }
+    result = ledger.copy()
+    for column, year in years.items():
+        keys = pd.MultiIndex.from_arrays([result["city_id"], year])
+        result[column] = keys.isin(available)
+    result["complete_required_years"] = result[list(years)].all(axis=1)
+    return result
+
+
+def _first_false_reason(frame: pd.DataFrame, rules: list[tuple[str, str]]) -> pd.Series:
+    conditions = [~frame[column] for column, _ in rules]
+    choices = [reason for _, reason in rules]
+    return pd.Series(
+        np.select(conditions, choices, default="included"), index=frame.index, dtype="string"
+    )
+
+
+def wup_forecast_selection_ledger(
+    population_panel: pd.DataFrame,
+    analytical_panel: pd.DataFrame,
+    origins: list[int],
+    *,
+    lookback_years: int = 5,
+    horizon_years: int = 5,
+    outcome_gap_years: int = 0,
+    estimate_end_year: int = 2025,
+) -> pd.DataFrame:
+    """Audit WUP threshold timing and complete-case selection at every origin.
+
+    The universe is every city exposed by F21, including cities whose first
+    nonblank value occurs only in the projection period. The analytical panel
+    is the stricter F21/F25/F30/F34 intersection used by forecast construction.
+    """
+    required = {
+        "city_id", "year", "population", "ISO3_Code", "City_Name",
+        "sample_entry_year", "sample_exit_year", "eligible_at_reference_year",
+        "observation_type",
+    }
+    require_columns(population_panel, required, source_name="WUP population panel")
+    reject_duplicate_keys(population_panel, ["city_id", "year"], source_name="WUP population")
+    years = _validate_origins(origins)
+    if min(lookback_years, horizon_years) <= 0 or outcome_gap_years < 0:
+        raise SourceSchemaError("Selection-audit lookback/horizon must be positive")
+    population_working = population_panel.copy()
+    population_working["_projection_period_observation"] = (
+        population_working["year"] > estimate_end_year
+    )
+    metadata = population_working.sort_values("year").groupby("city_id", as_index=False).agg(
+        country_code=("ISO3_Code", "first"),
+        city_name=("City_Name", "first"),
+        sample_entry_year=("sample_entry_year", "first"),
+        sample_exit_year=("sample_exit_year", "first"),
+        eligible_at_reference_year=("eligible_at_reference_year", "first"),
+        has_projection_period_observation=("_projection_period_observation", "any"),
+    )
+    universe = metadata.assign(_key=1).merge(
+        pd.DataFrame({"origin": years, "_key": 1}), on="_key", validate="many_to_many"
+    ).drop(columns="_key")
+    population_coverage = _coverage_flags(
+        universe,
+        population_panel,
+        lookback_years=lookback_years,
+        horizon_years=horizon_years,
+        outcome_gap_years=outcome_gap_years,
+    ).rename(
+        columns={
+            "lag_available": "population_lag_available",
+            "origin_available": "population_origin_available",
+            "outcome_start_available": "population_outcome_start_available",
+            "outcome_end_available": "population_outcome_end_available",
+            "complete_required_years": "population_complete_required_years",
+        }
+    )
+    analytical_coverage = _coverage_flags(
+        universe[["city_id", "origin"]],
+        analytical_panel,
+        lookback_years=lookback_years,
+        horizon_years=horizon_years,
+        outcome_gap_years=outcome_gap_years,
+    ).rename(
+        columns={
+            "lag_available": "analytical_lag_available",
+            "origin_available": "analytical_origin_available",
+            "outcome_start_available": "analytical_outcome_start_available",
+            "outcome_end_available": "analytical_outcome_end_available",
+            "complete_required_years": "analytical_complete_required_years",
+        }
+    )
+    analytical_columns = [
+        "city_id", "origin", "analytical_lag_available", "analytical_origin_available",
+        "analytical_outcome_start_available", "analytical_outcome_end_available",
+        "analytical_complete_required_years",
+    ]
+    result = population_coverage.merge(
+        analytical_coverage[analytical_columns],
+        on=["city_id", "origin"],
+        validate="one_to_one",
+    )
+    result["entry_occurs_after_forecast_origin"] = result["sample_entry_year"] > result["origin"]
+    result["entry_occurs_in_projection_period"] = result["sample_entry_year"] > estimate_end_year
+    result["not_eligible_at_2025_reference"] = ~result[
+        "eligible_at_reference_year"
+    ].astype(bool)
+    result["future_projection_selected"] = (
+        result["not_eligible_at_2025_reference"]
+        & result["has_projection_period_observation"]
+    )
+    result["outcome_is_estimate"] = (
+        result["origin"] + outcome_gap_years + horizon_years <= estimate_end_year
+    )
+    result["eligible_for_outcome_attrition"] = (
+        result["population_origin_available"] & result["outcome_is_estimate"]
+    )
+    result["outcome_attrition"] = (
+        result["eligible_for_outcome_attrition"]
+        & ~result["population_outcome_end_available"]
+    )
+    result["included"] = result["analytical_complete_required_years"] & result[
+        "outcome_is_estimate"
+    ]
+    result["primary_exclusion_reason"] = _first_false_reason(
+        result,
+        [
+            ("population_lag_available", "population_lag_missing_threshold_blank"),
+            ("population_origin_available", "population_origin_missing_threshold_blank"),
+            (
+                "population_outcome_start_available",
+                "population_outcome_start_missing_threshold_blank",
+            ),
+            ("population_outcome_end_available", "population_outcome_end_missing_threshold_blank"),
+            ("outcome_is_estimate", "projection_outcome_not_allowed"),
+            ("analytical_lag_available", "lag_covariates_missing"),
+            ("analytical_origin_available", "origin_covariates_missing"),
+            ("analytical_outcome_start_available", "outcome_start_covariates_missing"),
+            ("analytical_outcome_end_available", "outcome_end_covariates_missing"),
+        ],
+    )
+    result["source_stream"] = "WUP_2025_DEGURBA_cities"
+    result["geographic_comparability"] = "publisher_city_definition_not_fixed_polygon"
+    reject_duplicate_keys(result, ["city_id", "origin"], source_name="WUP selection ledger")
+    return result.sort_values(["origin", "country_code", "city_id"]).reset_index(drop=True)
+
+
+def ghsl_forecast_selection_ledger(
+    panel: pd.DataFrame,
+    origins: list[int],
+    *,
+    boundary_mode: str,
+    lookback_years: int = 5,
+    horizon_years: int = 5,
+    outcome_gap_years: int = 0,
+) -> pd.DataFrame:
+    """Audit fixed or dynamic GHSL city-origin coverage without pooling streams."""
+    required = {"city_id", "year", "boundary_mode", "GC_CNT_GAD_2025"}
+    require_columns(panel, required, source_name="GHSL selection panel")
+    if boundary_mode not in {"fixed", "dynamic"}:
+        raise SourceSchemaError("GHSL selection audit requires fixed or dynamic mode")
+    if panel["boundary_mode"].ne(boundary_mode).any():
+        raise SourceSchemaError("GHSL selection panel mixes boundary modes")
+    years = _validate_origins(origins)
+    metadata_aggregations: dict[str, tuple[str, str]] = {
+        "country_code": ("GC_CNT_GAD_2025", "first")
+    }
+    for source, target in [
+        ("GC_UCB_YOB _2025", "trajectory_birth_year"),
+        ("GC_UCB_YOD _2025", "trajectory_death_year"),
+        ("quality_controlled_2025", "quality_controlled_2025"),
+    ]:
+        if source in panel.columns:
+            metadata_aggregations[target] = (source, "first")
+    metadata = panel.groupby("city_id", as_index=False).agg(**metadata_aggregations)
+    universe = metadata.assign(_key=1).merge(
+        pd.DataFrame({"origin": years, "_key": 1}), on="_key", validate="many_to_many"
+    ).drop(columns="_key")
+    result = _coverage_flags(
+        universe,
+        panel,
+        lookback_years=lookback_years,
+        horizon_years=horizon_years,
+        outcome_gap_years=outcome_gap_years,
+    )
+    if "quality_controlled_2025" not in result:
+        result["quality_controlled_2025"] = True
+    result["quality_controlled_2025"] = result["quality_controlled_2025"].fillna(False).astype(bool)
+    result["conditioned_on_2025_quality"] = boundary_mode == "dynamic"
+    result["uses_future_reference_polygon"] = boundary_mode == "fixed"
+    result["included"] = result["complete_required_years"] & result[
+        "quality_controlled_2025"
+    ]
+    result["primary_exclusion_reason"] = _first_false_reason(
+        result,
+        [
+            ("quality_controlled_2025", "not_quality_controlled_at_2025"),
+            ("lag_available", "trajectory_absent_at_lag"),
+            ("origin_available", "trajectory_absent_at_origin"),
+            ("outcome_start_available", "trajectory_absent_at_outcome_start"),
+            ("outcome_end_available", "trajectory_absent_at_outcome_end"),
+        ],
+    )
+    result["source_stream"] = f"GHSL_2024_{boundary_mode}_boundaries"
+    result["geographic_comparability"] = np.where(
+        boundary_mode == "fixed",
+        "fixed_2025_polygon_using_future_reference",
+        "changing_polygon_sensitivity_not_primary_estimand",
+    )
+    reject_duplicate_keys(result, ["city_id", "origin"], source_name="GHSL selection ledger")
+    return result.sort_values(["origin", "country_code", "city_id"]).reset_index(drop=True)
+
+
+def selection_summary(ledger: pd.DataFrame) -> pd.DataFrame:
+    """Summarize inclusion and exclusion counts without hiding the universe."""
+    required = {
+        "source_stream", "origin", "country_code", "included",
+        "primary_exclusion_reason", "geographic_comparability",
+    }
+    require_columns(ledger, required, source_name="selection ledger")
+    summary = ledger.groupby(
+        [
+            "source_stream", "geographic_comparability", "origin", "included",
+            "primary_exclusion_reason",
+        ],
+        dropna=False,
+        sort=True,
+    ).agg(
+        city_origin_rows=("city_id", "size"),
+        countries=("country_code", "nunique"),
+    ).reset_index()
+    totals = ledger.groupby(["source_stream", "origin"])["city_id"].transform("size")
+    working = ledger.assign(_origin_universe=totals)
+    denominators = working.groupby(["source_stream", "origin"])["_origin_universe"].first()
+    summary["origin_universe_rows"] = pd.MultiIndex.from_frame(
+        summary[["source_stream", "origin"]]
+    ).map(denominators)
+    summary["share_of_origin_universe"] = (
+        summary["city_origin_rows"] / summary["origin_universe_rows"]
+    )
+    return summary
+
+
+def outcome_attrition_summary(ledger: pd.DataFrame) -> pd.DataFrame:
+    """Report disappearance after an observed origin, separately from entry gaps."""
+    required = {
+        "source_stream", "geographic_comparability", "origin", "country_code",
+        "eligible_for_outcome_attrition", "outcome_attrition",
+    }
+    require_columns(ledger, required, source_name="selection ledger")
+    eligible = ledger.loc[ledger["eligible_for_outcome_attrition"]].copy()
+    if eligible.empty:
+        raise SourceSchemaError("No origin-observed rows are eligible for attrition analysis")
+    result = eligible.groupby(
+        ["source_stream", "geographic_comparability", "origin"],
+        sort=True,
+    ).agg(
+        cities_observed_at_origin=("city_id", "size"),
+        countries_observed_at_origin=("country_code", "nunique"),
+        cities_missing_at_outcome=("outcome_attrition", "sum"),
+    ).reset_index()
+    result["outcome_attrition_rate"] = (
+        result["cities_missing_at_outcome"] / result["cities_observed_at_origin"]
+    )
+    result["interpretation"] = (
+        "outcome_missing_after_observed_origin_not_assumed_random"
+    )
+    return result

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,0 +1,132 @@
+import pandas as pd
+import pytest
+
+from urban_growth.io import SourceSchemaError
+from urban_growth.selection import (
+    ghsl_forecast_selection_ledger,
+    outcome_attrition_summary,
+    selection_summary,
+    wup_forecast_selection_ledger,
+)
+
+
+def test_wup_ledger_exposes_threshold_and_future_projection_selection() -> None:
+    rows = []
+    for city_id, entry, eligible in [(1, 2015, True), (2, 2015, True), (3, 2030, False)]:
+        for year in range(entry, 2036, 5):
+            rows.append(
+                {
+                    "city_id": city_id,
+                    "year": year,
+                    "population": 50_000 + year,
+                    "ISO3_Code": "AAA",
+                    "City_Name": f"City {city_id}",
+                    "sample_entry_year": entry,
+                    "sample_exit_year": 2035,
+                    "eligible_at_reference_year": eligible,
+                    "observation_type": "estimate" if year <= 2025 else "projection",
+                }
+            )
+    population = pd.DataFrame(rows)
+    analytical = population.loc[population["city_id"].ne(2) | population["year"].ne(2020)]
+    ledger = wup_forecast_selection_ledger(population, analytical, [2020])
+    included = ledger.set_index("city_id")
+    assert included.loc[1, "included"]
+    assert included.loc[2, "primary_exclusion_reason"] == "origin_covariates_missing"
+    assert included.loc[3, "primary_exclusion_reason"] == (
+        "population_lag_missing_threshold_blank"
+    )
+    assert included.loc[3, "entry_occurs_in_projection_period"]
+    assert included.loc[3, "not_eligible_at_2025_reference"]
+    assert included.loc[3, "future_projection_selected"]
+
+
+def test_ghsl_ledgers_keep_fixed_and_dynamic_semantics_explicit() -> None:
+    fixed = pd.DataFrame(
+        {
+            "city_id": [1, 1, 1],
+            "year": [2015, 2020, 2025],
+            "boundary_mode": ["fixed"] * 3,
+            "GC_CNT_GAD_2025": ["AAA"] * 3,
+        }
+    )
+    fixed_ledger = ghsl_forecast_selection_ledger(fixed, [2020], boundary_mode="fixed")
+    assert fixed_ledger.loc[0, "included"]
+    assert fixed_ledger.loc[0, "uses_future_reference_polygon"]
+    assert fixed_ledger.loc[0, "geographic_comparability"] == (
+        "fixed_2025_polygon_using_future_reference"
+    )
+
+    dynamic = fixed.assign(
+        boundary_mode="dynamic",
+        quality_controlled_2025=False,
+        **{"GC_UCB_YOB _2025": 2015, "GC_UCB_YOD _2025": 2025},
+    )
+    dynamic_ledger = ghsl_forecast_selection_ledger(
+        dynamic, [2020], boundary_mode="dynamic"
+    )
+    assert not dynamic_ledger.loc[0, "included"]
+    assert dynamic_ledger.loc[0, "conditioned_on_2025_quality"]
+    assert dynamic_ledger.loc[0, "primary_exclusion_reason"] == (
+        "not_quality_controlled_at_2025"
+    )
+
+
+def test_selection_summary_uses_full_origin_universe() -> None:
+    ledger = pd.DataFrame(
+        {
+            "source_stream": ["x", "x"],
+            "geographic_comparability": ["fixed", "fixed"],
+            "origin": [2020, 2020],
+            "country_code": ["A", "B"],
+            "city_id": [1, 2],
+            "included": [True, False],
+            "primary_exclusion_reason": ["included", "missing"],
+        }
+    )
+    summary = selection_summary(ledger)
+    assert summary["origin_universe_rows"].eq(2).all()
+    assert summary["share_of_origin_universe"].tolist() == pytest.approx([0.5, 0.5])
+
+
+def test_selection_audit_rejects_duplicate_city_years() -> None:
+    panel = pd.DataFrame(
+        {
+            "city_id": [1, 1],
+            "year": [2020, 2020],
+            "boundary_mode": ["fixed", "fixed"],
+            "GC_CNT_GAD_2025": ["AAA", "AAA"],
+        }
+    )
+    with pytest.raises(SourceSchemaError, match="duplicate"):
+        ghsl_forecast_selection_ledger(panel, [2020], boundary_mode="fixed")
+
+
+def test_wup_attrition_separates_post_origin_exit_from_late_entry() -> None:
+    population = pd.DataFrame(
+        [
+            {
+                "city_id": city_id, "year": year, "population": 60_000,
+                "ISO3_Code": "AAA", "City_Name": f"City {city_id}",
+                "sample_entry_year": entry, "sample_exit_year": exit_year,
+                "eligible_at_reference_year": eligible,
+                "observation_type": "estimate",
+            }
+            for city_id, entry, exit_year, eligible, years in [
+                (1, 2015, 2025, True, [2015, 2020, 2025]),
+                (2, 2015, 2020, False, [2015, 2020]),
+                (3, 2025, 2025, True, [2025]),
+            ]
+            for year in years
+        ]
+    )
+    ledger = wup_forecast_selection_ledger(population, population, [2020])
+    by_city = ledger.set_index("city_id")
+    assert not by_city.loc[1, "outcome_attrition"]
+    assert by_city.loc[2, "outcome_attrition"]
+    assert not by_city.loc[3, "eligible_for_outcome_attrition"]
+    assert not by_city.loc[3, "outcome_attrition"]
+    summary = outcome_attrition_summary(ledger)
+    assert summary.loc[0, "cities_observed_at_origin"] == 2
+    assert summary.loc[0, "cities_missing_at_outcome"] == 1
+    assert summary.loc[0, "outcome_attrition_rate"] == pytest.approx(0.5)


### PR DESCRIPTION
## Methodology issue

WUP forecast scoring requires a reported future population. A city observed at the forecast origin but absent at the outcome date is silently excluded. Near the 50,000 publication threshold, that missingness can depend on decline, making complete-case forecast accuracy optimistic for small cities.

## Changes

- add machine-readable source-specific selection ledgers;
- distinguish late entry from post-origin outcome attrition;
- report origin-observed denominators, missing-outcome counts, and attrition rates;
- integrate detailed, summarized, and attrition outputs into the WUP workflow;
- test that late entrants are not mislabeled as attrition;
- document that balanced cohorts and weighting do not recover missing outcomes.

## Limitation

A WUP disappearance is not proven population decline. It may reflect threshold crossing, definition change, or publisher removal. External stable-polygon population data are required to identify the mechanism and score those missing outcomes.