### PR TITLE
Add sequential forecast-interval calibration

### DIFF
--- a/docs/research-design.md
+++ b/docs/research-design.md
@@ -61,6 +61,24 @@ Forecasting does not require causal exogeneity, but interpretation of coefficien
 - Use paired block bootstrap intervals clustered at minimum by country; add time blocks when periods overlap.
 - Use leave-one-country-out and influential-city diagnostics.
 
+### Sequential prediction-interval calibration
+
+Point-error rankings do not establish usable uncertainty. The WUP and fixed-GHSL
+workflows now construct symmetric 90% empirical error bands for each model and
+forecast origin using absolute errors from strictly earlier origins only. The finite-
+sample quantile is rounded upward. Outputs report interval radius and width, city-
+weighted realized coverage, equal-country realized coverage, coverage error, and the
+latest calibration origin. Size-stratified tables use only prior errors in the same
+size bin.
+
+These are retrospective sequential calibration diagnostics, not guaranteed conformal
+prediction intervals. Standard marginal coverage requires exchangeability; repeated
+cities, country clustering, changing samples and temporal shocks violate that premise.
+A band is commercially credible only if coverage remains near nominal across later
+origins, size groups and equal-country summaries. Do not repair undercoverage by
+recalibrating on the origin being evaluated, and do not pool WUP with GHSL to enlarge
+the calibration sample.
+
 ### Model selection and the exhausted 2020 holdout
 
 Model comparisons must separate origins used to select a specification from the origin

--- a/scripts/run_ghsl_fixed_baselines.py
+++ b/scripts/run_ghsl_fixed_baselines.py
@@ -19,6 +19,7 @@ from urban_growth.forecast import (
     evaluate_rolling_baselines,
     evaluate_rolling_hierarchy_models,
     rolling_baseline_errors,
+    sequential_interval_calibration,
     temporal_reversal_diagnostics,
 )
 
@@ -71,6 +72,16 @@ def main() -> None:
         default=Path("outputs/ghsl_fixed_hierarchy_model_metrics.csv"),
     )
     parser.add_argument(
+        "--interval-calibration-output",
+        type=Path,
+        default=Path("outputs/ghsl_fixed_sequential_interval_calibration.csv"),
+    )
+    parser.add_argument(
+        "--interval-calibration-by-size-output",
+        type=Path,
+        default=Path("outputs/ghsl_fixed_sequential_interval_calibration_by_size.csv"),
+    )
+    parser.add_argument(
         "--equal-origin-output",
         type=Path,
         default=Path("outputs/ghsl_fixed_equal_origin_metrics.csv"),
@@ -92,6 +103,10 @@ def main() -> None:
     errors = rolling_baseline_errors(intervals, origins)
     equal_origin = equal_origin_forecast_metrics(errors)
     equal_country_origin = equal_country_origin_forecast_metrics(errors)
+    interval_calibration = sequential_interval_calibration(errors)
+    interval_calibration_by_size = sequential_interval_calibration(
+        errors, group_columns=["size_bin"]
+    )
     temporal = temporal_reversal_diagnostics(intervals)
     gapped_intervals = build_ghsl_fixed_forecast_intervals(
         fixed,
@@ -114,6 +129,8 @@ def main() -> None:
         (args.hierarchy_output, hierarchy),
         (args.equal_origin_output, equal_origin),
         (args.equal_country_origin_output, equal_country_origin),
+        (args.interval_calibration_output, interval_calibration),
+        (args.interval_calibration_by_size_output, interval_calibration_by_size),
     ]:
         path.parent.mkdir(parents=True, exist_ok=True)
         frame.to_csv(path, index=False)

--- a/scripts/run_wup_baselines.py
+++ b/scripts/run_wup_baselines.py
@@ -28,6 +28,7 @@ from urban_growth.forecast import (
     locked_origin_model_evaluation,
     paired_error_comparison,
     rolling_baseline_errors,
+    sequential_interval_calibration,
     temporal_reversal_diagnostics,
     two_way_cluster_bootstrap_paired_difference,
 )
@@ -146,6 +147,16 @@ def main() -> None:
         default=Path("outputs/wup_balanced_equal_country_pooled_metrics.csv"),
     )
     parser.add_argument(
+        "--interval-calibration-output",
+        type=Path,
+        default=Path("outputs/wup_sequential_interval_calibration.csv"),
+    )
+    parser.add_argument(
+        "--interval-calibration-by-size-output",
+        type=Path,
+        default=Path("outputs/wup_sequential_interval_calibration_by_size.csv"),
+    )
+    parser.add_argument(
         "--country-time-bootstrap-output",
         type=Path,
         default=Path("outputs/wup_country_time_bootstrap_overall.csv"),
@@ -230,6 +241,10 @@ def main() -> None:
     equal_country_origin = equal_country_origin_forecast_metrics(errors)
     balanced_pooled_equal_country = equal_country_forecast_metrics(balanced_errors)
     locked_origin = locked_origin_model_evaluation(errors, locked_origin=2020)
+    interval_calibration = sequential_interval_calibration(errors)
+    interval_calibration_by_size = sequential_interval_calibration(
+        errors, group_columns=["size_bin"]
+    )
     country_time_bootstrap = two_way_cluster_bootstrap_paired_difference(errors)
     country_time_size_bootstrap = two_way_cluster_bootstrap_paired_difference(
         errors,
@@ -308,6 +323,12 @@ def main() -> None:
     )
     args.locked_origin_output.parent.mkdir(parents=True, exist_ok=True)
     locked_origin.to_csv(args.locked_origin_output, index=False)
+    args.interval_calibration_output.parent.mkdir(parents=True, exist_ok=True)
+    interval_calibration.to_csv(args.interval_calibration_output, index=False)
+    args.interval_calibration_by_size_output.parent.mkdir(parents=True, exist_ok=True)
+    interval_calibration_by_size.to_csv(
+        args.interval_calibration_by_size_output, index=False
+    )
     args.country_time_bootstrap_output.parent.mkdir(parents=True, exist_ok=True)
     country_time_bootstrap.to_csv(args.country_time_bootstrap_output, index=False)
     args.country_time_size_bootstrap_output.parent.mkdir(parents=True, exist_ok=True)
@@ -344,6 +365,8 @@ def main() -> None:
     print(args.equal_country_origin_output)
     print(args.balanced_pooled_equal_country_output)
     print(args.locked_origin_output)
+    print(args.interval_calibration_output)
+    print(args.interval_calibration_by_size_output)
     print(args.country_time_bootstrap_output)
     print(args.country_time_size_bootstrap_output)
     print(args.balanced_country_time_bootstrap_output)

--- a/src/urban_growth/forecast.py
+++ b/src/urban_growth/forecast.py
@@ -827,6 +827,92 @@ def equal_country_origin_forecast_metrics(
 
 
 
+
+def sequential_interval_calibration(
+    errors: pd.DataFrame,
+    *,
+    miscoverage: float = 0.10,
+    minimum_calibration_rows: int = 100,
+    minimum_calibration_origins: int = 2,
+    group_columns: list[str] | None = None,
+) -> pd.DataFrame:
+    """Audit symmetric empirical error bands using strictly earlier origins.
+
+    These are sequential retrospective calibration bands. Coverage guarantees
+    still require exchangeability, which temporal drift and clustered cities may
+    violate; the output therefore reports realized coverage rather than claiming
+    distribution-free validity.
+    """
+    groups = group_columns or []
+    required = {
+        "origin", "model", "country_code", "absolute_error", *groups,
+    }
+    require_columns(errors, required, source_name="row-level forecast errors")
+    if not 0 < miscoverage < 1:
+        raise SourceSchemaError("Interval miscoverage must be between zero and one")
+    if minimum_calibration_rows < 1 or minimum_calibration_origins < 1:
+        raise SourceSchemaError("Calibration minimums must be positive")
+    working = errors.copy()
+    if not np.isfinite(working["absolute_error"]).all():
+        raise SourceSchemaError("Interval calibration requires finite absolute errors")
+    keys = [*groups, "model"]
+    rows: list[dict[str, float | int | str]] = []
+    grouper: str | list[str] = keys[0] if len(keys) == 1 else keys
+    for key, model_group in working.groupby(grouper, observed=True, sort=True):
+        key_values = (key,) if len(keys) == 1 else key
+        labels = dict(zip(keys, key_values, strict=True))
+        for origin in sorted(model_group["origin"].unique()):
+            calibration = model_group.loc[model_group["origin"] < origin]
+            calibration_origin_count = calibration["origin"].nunique()
+            if (
+                len(calibration) < minimum_calibration_rows
+                or calibration_origin_count < minimum_calibration_origins
+            ):
+                continue
+            test = model_group.loc[model_group["origin"].eq(origin)]
+            if test.empty:
+                continue
+            quantile_level = min(
+                1.0,
+                np.ceil((len(calibration) + 1) * (1 - miscoverage))
+                / len(calibration),
+            )
+            radius = float(
+                np.quantile(
+                    calibration["absolute_error"], quantile_level, method="higher"
+                )
+            )
+            covered = test["absolute_error"].le(radius)
+            country_coverage = covered.groupby(test["country_code"]).mean()
+            row: dict[str, float | int | str] = dict(labels)
+            row.update(
+                {
+                    "origin": int(origin),
+                    "nominal_coverage": 1 - miscoverage,
+                    "empirical_city_coverage": float(covered.mean()),
+                    "equal_country_coverage": float(country_coverage.mean()),
+                    "coverage_gap": float(covered.mean() - (1 - miscoverage)),
+                    "interval_radius": radius,
+                    "interval_width": 2 * radius,
+                    "test_rows": len(test),
+                    "test_countries": int(test["country_code"].nunique()),
+                    "calibration_rows": len(calibration),
+                    "calibration_origins": int(calibration_origin_count),
+                    "calibration_origin_end": int(calibration["origin"].max()),
+                    "calibration_uses_current_or_future_origin": False,
+                    "interval_semantics": (
+                        "symmetric_pre_origin_empirical_absolute_error_band"
+                    ),
+                }
+            )
+            rows.append(row)
+    if not rows:
+        raise SourceSchemaError("No origin had enough prior errors for interval calibration")
+    return pd.DataFrame(rows).sort_values([*groups, "origin", "model"]).reset_index(
+        drop=True
+    )
+
+
 def locked_origin_model_evaluation(
     errors: pd.DataFrame,
     *,

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -22,6 +22,7 @@ from urban_growth.forecast import (
     rolling_baseline_errors,
     rolling_origin_splits,
     score_forecast,
+    sequential_interval_calibration,
     temporal_reversal_diagnostics,
     two_way_cluster_bootstrap_paired_difference,
 )
@@ -528,3 +529,46 @@ def test_locked_origin_cannot_enter_development_set() -> None:
         locked_origin_model_evaluation(
             errors, locked_origin=2010, development_origins=[2005, 2010]
         )
+
+
+def test_sequential_intervals_use_only_prior_origins() -> None:
+    errors = pd.DataFrame(
+        {
+            "origin": [2000, 2000, 2005, 2005, 2010, 2010],
+            "model": ["m"] * 6,
+            "country_code": ["A", "B"] * 3,
+            "absolute_error": [0.10, 0.20, 0.20, 0.30, 99.0, 99.0],
+        }
+    )
+    result = sequential_interval_calibration(
+        errors,
+        miscoverage=0.25,
+        minimum_calibration_rows=2,
+        minimum_calibration_origins=1,
+    )
+    at_2005 = result.loc[result["origin"].eq(2005)].iloc[0]
+    assert at_2005["interval_radius"] == pytest.approx(0.20)
+    assert at_2005["calibration_origin_end"] == 2000
+    assert not at_2005["calibration_uses_current_or_future_origin"]
+
+
+def test_sequential_intervals_report_city_and_equal_country_coverage() -> None:
+    errors = pd.DataFrame(
+        {
+            "origin": [2000] * 4 + [2005] * 3,
+            "model": ["m"] * 7,
+            "country_code": ["A", "A", "B", "B", "A", "A", "B"],
+            "absolute_error": [0.10, 0.10, 0.10, 0.10, 0.05, 0.20, 0.20],
+        }
+    )
+    result = sequential_interval_calibration(
+        errors,
+        miscoverage=0.50,
+        minimum_calibration_rows=4,
+        minimum_calibration_origins=1,
+    )
+    row = result.iloc[0]
+    assert row["interval_radius"] == pytest.approx(0.10)
+    assert row["empirical_city_coverage"] == pytest.approx(1 / 3)
+    assert row["equal_country_coverage"] == pytest.approx(0.25)
+    assert row["interval_width"] == pytest.approx(0.20)


### PR DESCRIPTION
## Methodology issue

Point MAE and RMSE do not show whether forecast uncertainty is calibrated. This is binding for small-city and municipal-finance applications, where risk bands matter more than a single estimate.

## Changes

- construct symmetric empirical error bands using strictly earlier rolling-origin errors;
- apply the upward finite-sample quantile correction;
- report city-weighted and equal-country coverage, interval width, calibration depth, and coverage gaps;
- generate overall and size-stratified outputs separately for WUP and fixed-polygon GHSL;
- test that current and future origins cannot enter calibration;
- document the exchangeability limitation and prohibit cross-source pooling.

## Interpretation

These are sequential retrospective calibration diagnostics, not automatically valid conformal intervals. Temporal drift, repeated cities, changing samples, and country clustering can break nominal coverage. The output measures that failure instead of assuming it away.