### PR TITLE
Correct finite-sample interval calibration rank

### DIFF
--- a/docs/research-design.md
+++ b/docs/research-design.md
@@ -65,8 +65,10 @@ Forecasting does not require causal exogeneity, but interpretation of coefficien
 
 Point-error rankings do not establish usable uncertainty. The WUP and fixed-GHSL
 workflows now construct symmetric 90% empirical error bands for each model and
-forecast origin using absolute errors from strictly earlier origins only. The finite-
-sample quantile is rounded upward. Outputs report interval radius and width, city-
+forecast origin using absolute errors from strictly earlier origins only. The radius is the exact
+order statistic at rank \(\lceil(n+1)(1-\alpha)\rceil\); origins with too few
+calibration rows to realize that rank are not reported. Outputs report the chosen
+rank, interval radius and width, city-
 weighted realized coverage, equal-country realized coverage, coverage error, and the
 latest calibration origin. Size-stratified tables use only prior errors in the same
 size bin.

--- a/src/urban_growth/forecast.py
+++ b/src/urban_growth/forecast.py
@@ -872,16 +872,13 @@ def sequential_interval_calibration(
             test = model_group.loc[model_group["origin"].eq(origin)]
             if test.empty:
                 continue
-            quantile_level = min(
-                1.0,
+            conformal_rank = int(
                 np.ceil((len(calibration) + 1) * (1 - miscoverage))
-                / len(calibration),
             )
-            radius = float(
-                np.quantile(
-                    calibration["absolute_error"], quantile_level, method="higher"
-                )
-            )
+            if conformal_rank > len(calibration):
+                continue
+            ordered_errors = np.sort(calibration["absolute_error"].to_numpy())
+            radius = float(ordered_errors[conformal_rank - 1])
             covered = test["absolute_error"].le(radius)
             country_coverage = covered.groupby(test["country_code"]).mean()
             row: dict[str, float | int | str] = dict(labels)
@@ -897,6 +894,7 @@ def sequential_interval_calibration(
                     "test_rows": len(test),
                     "test_countries": int(test["country_code"].nunique()),
                     "calibration_rows": len(calibration),
+                    "calibration_order_statistic_rank": conformal_rank,
                     "calibration_origins": int(calibration_origin_count),
                     "calibration_origin_end": int(calibration["origin"].max()),
                     "calibration_uses_current_or_future_origin": False,

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -542,7 +542,7 @@ def test_sequential_intervals_use_only_prior_origins() -> None:
     )
     result = sequential_interval_calibration(
         errors,
-        miscoverage=0.25,
+        miscoverage=0.50,
         minimum_calibration_rows=2,
         minimum_calibration_origins=1,
     )
@@ -572,3 +572,22 @@ def test_sequential_intervals_report_city_and_equal_country_coverage() -> None:
     assert row["empirical_city_coverage"] == pytest.approx(1 / 3)
     assert row["equal_country_coverage"] == pytest.approx(0.25)
     assert row["interval_width"] == pytest.approx(0.20)
+
+
+def test_sequential_interval_uses_exact_conformal_order_statistic() -> None:
+    errors = pd.DataFrame(
+        {
+            "origin": [2000] * 4 + [2005],
+            "model": ["m"] * 5,
+            "country_code": ["A", "B", "C", "D", "A"],
+            "absolute_error": [0.10, 0.20, 0.30, 0.40, 0.25],
+        }
+    )
+    result = sequential_interval_calibration(
+        errors,
+        miscoverage=0.50,
+        minimum_calibration_rows=4,
+        minimum_calibration_origins=1,
+    )
+    assert result.loc[0, "calibration_order_statistic_rank"] == 3
+    assert result.loc[0, "interval_radius"] == pytest.approx(0.30)


### PR DESCRIPTION
## Methodology defect

The sequential interval audit computed the conformal rank correctly but passed its normalized value to NumPy's `method="higher"` quantile rule. NumPy indexes that rule against `n - 1`, so it can select a higher residual than the intended finite-sample order statistic. The resulting bands are overly wide and their apparent coverage is inflated.

## Changes

- select the exact sorted residual at rank `ceil((n + 1)(1 - alpha))`;
- omit evaluations whose calibration sample cannot realize the required rank;
- expose the selected rank in generated output;
- add a regression test where the previous implementation chose the fourth residual instead of the required third;
- align the research-design formula with the implementation.

## Scope

This fixes the finite-sample arithmetic only. Exchangeability and adaptive-stratification risks remain separate issues.