### PR TITLE
Audit directional prediction-interval failures

### DIFF
--- a/docs/research-design.md
+++ b/docs/research-design.md
@@ -70,8 +70,12 @@ order statistic at rank \(\lceil(n+1)(1-\alpha)\rceil\); origins with too few
 calibration rows to realize that rank are not reported. Outputs report the chosen
 rank, interval radius and width, city-
 weighted realized coverage, equal-country realized coverage, coverage error, and the
-latest calibration origin. Size-stratified tables use only prior errors in the same
-size bin. The executable workflows use two versioned policies:
+latest calibration origin. They also report lower-tail misses (actual growth below
+the band), upper-tail misses (actual growth above the band), their imbalance, and
+equal-country tail rates. Size-stratified tables use only prior errors in the same
+size bin. Aggregate coverage is inadequate when misses concentrate directionally:
+such a band can meet its nominal rate while systematically understating decline risk
+or upside growth. The executable workflows use two versioned policies:
 `overall_90_v1` and `size_bin_90_v1`, each fixing nominal coverage, minimum
 calibration rows, minimum prior origins and grouping before outputs are opened.
 Registered outputs carry the policy identifier and a prespecification flag. Arbitrary

--- a/src/urban_growth/forecast.py
+++ b/src/urban_growth/forecast.py
@@ -863,7 +863,7 @@ def sequential_interval_calibration(
     """
     groups = group_columns or []
     required = {
-        "origin", "model", "country_code", "absolute_error", *groups,
+        "origin", "model", "country_code", "error", "absolute_error", *groups,
     }
     require_columns(errors, required, source_name="row-level forecast errors")
     if not 0 < miscoverage < 1:
@@ -871,8 +871,8 @@ def sequential_interval_calibration(
     if minimum_calibration_rows < 1 or minimum_calibration_origins < 1:
         raise SourceSchemaError("Calibration minimums must be positive")
     working = errors.copy()
-    if not np.isfinite(working["absolute_error"]).all():
-        raise SourceSchemaError("Interval calibration requires finite absolute errors")
+    if not np.isfinite(working[["error", "absolute_error"]]).all().all():
+        raise SourceSchemaError("Interval calibration requires finite errors")
     keys = [*groups, "model"]
     rows: list[dict[str, float | int | str]] = []
     grouper: str | list[str] = keys[0] if len(keys) == 1 else keys
@@ -898,7 +898,11 @@ def sequential_interval_calibration(
             ordered_errors = np.sort(calibration["absolute_error"].to_numpy())
             radius = float(ordered_errors[conformal_rank - 1])
             covered = test["absolute_error"].le(radius)
+            lower_tail_miss = test["error"].gt(radius)
+            upper_tail_miss = test["error"].lt(-radius)
             country_coverage = covered.groupby(test["country_code"]).mean()
+            country_lower_tail = lower_tail_miss.groupby(test["country_code"]).mean()
+            country_upper_tail = upper_tail_miss.groupby(test["country_code"]).mean()
             row: dict[str, float | int | str] = dict(labels)
             row.update(
                 {
@@ -907,6 +911,17 @@ def sequential_interval_calibration(
                     "empirical_city_coverage": float(covered.mean()),
                     "equal_country_coverage": float(country_coverage.mean()),
                     "coverage_gap": float(covered.mean() - (1 - miscoverage)),
+                    "lower_tail_miss_rate": float(lower_tail_miss.mean()),
+                    "upper_tail_miss_rate": float(upper_tail_miss.mean()),
+                    "tail_miss_imbalance": float(
+                        lower_tail_miss.mean() - upper_tail_miss.mean()
+                    ),
+                    "equal_country_lower_tail_miss_rate": float(
+                        country_lower_tail.mean()
+                    ),
+                    "equal_country_upper_tail_miss_rate": float(
+                        country_upper_tail.mean()
+                    ),
                     "interval_radius": radius,
                     "interval_width": 2 * radius,
                     "test_rows": len(test),

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -538,6 +538,7 @@ def test_sequential_intervals_use_only_prior_origins() -> None:
             "origin": [2000, 2000, 2005, 2005, 2010, 2010],
             "model": ["m"] * 6,
             "country_code": ["A", "B"] * 3,
+            "error": [0.10, -0.20, 0.20, -0.30, 99.0, -99.0],
             "absolute_error": [0.10, 0.20, 0.20, 0.30, 99.0, 99.0],
         }
     )
@@ -559,6 +560,7 @@ def test_sequential_intervals_report_city_and_equal_country_coverage() -> None:
             "origin": [2000] * 4 + [2005] * 3,
             "model": ["m"] * 7,
             "country_code": ["A", "A", "B", "B", "A", "A", "B"],
+            "error": [0.10, -0.10, 0.10, -0.10, 0.05, 0.20, -0.20],
             "absolute_error": [0.10, 0.10, 0.10, 0.10, 0.05, 0.20, 0.20],
         }
     )
@@ -573,6 +575,11 @@ def test_sequential_intervals_report_city_and_equal_country_coverage() -> None:
     assert row["empirical_city_coverage"] == pytest.approx(1 / 3)
     assert row["equal_country_coverage"] == pytest.approx(0.25)
     assert row["interval_width"] == pytest.approx(0.20)
+    assert row["lower_tail_miss_rate"] == pytest.approx(1 / 3)
+    assert row["upper_tail_miss_rate"] == pytest.approx(1 / 3)
+    assert row["tail_miss_imbalance"] == pytest.approx(0.0)
+    assert row["equal_country_lower_tail_miss_rate"] == pytest.approx(0.25)
+    assert row["equal_country_upper_tail_miss_rate"] == pytest.approx(0.50)
 
 
 def test_sequential_interval_uses_exact_conformal_order_statistic() -> None:
@@ -581,6 +588,7 @@ def test_sequential_interval_uses_exact_conformal_order_statistic() -> None:
             "origin": [2000] * 4 + [2005],
             "model": ["m"] * 5,
             "country_code": ["A", "B", "C", "D", "A"],
+            "error": [0.10, -0.20, 0.30, -0.40, 0.25],
             "absolute_error": [0.10, 0.20, 0.30, 0.40, 0.25],
         }
     )
@@ -604,6 +612,7 @@ def test_registered_interval_policy_freezes_strata_and_parameters() -> None:
                     "model": "m",
                     "country_code": f"C{city_id % 10}",
                     "size_bin": "50–150k",
+                    "error": 0.01 + city_id / 100_000,
                     "absolute_error": 0.01 + city_id / 100_000,
                 }
             )


### PR DESCRIPTION
## Methodology issue

Marginal interval coverage hides the direction of forecast failures. A symmetric band can attain its nominal coverage while nearly all misses occur below the lower bound or above the upper bound. For municipal risk, those are not interchangeable errors.

## Changes

- require signed forecast errors in interval calibration;
- report lower-tail and upper-tail miss rates;
- report their directional imbalance;
- report equal-country lower- and upper-tail rates so large national samples do not dominate;
- extend tests with deliberately balanced directional misses;
- document why aggregate coverage alone is insufficient.

## Interpretation

This diagnoses asymmetry; it does not silently replace the registered symmetric bands with post-hoc asymmetric intervals. Any asymmetric policy would require separate prespecification and validation.