### PR TITLE
Stress-test stale interval calibration residuals

### DIFF
--- a/docs/research-design.md
+++ b/docs/research-design.md
@@ -75,9 +75,14 @@ the band), upper-tail misses (actual growth above the band), their imbalance, an
 equal-country tail rates. Size-stratified tables use only prior errors in the same
 size bin. Aggregate coverage is inadequate when misses concentrate directionally:
 such a band can meet its nominal rate while systematically understating decline risk
-or upside growth. The executable workflows use two versioned policies:
-`overall_90_v1` and `size_bin_90_v1`, each fixing nominal coverage, minimum
-calibration rows, minimum prior origins and grouping before outputs are opened.
+or upside growth. The executable workflows report four versioned policies. `overall_90_v1`
+and `size_bin_90_v1` use all prior origins; `overall_90_recent3_v1` and
+`size_bin_90_recent3_v1` retain only the three most recent eligible origins.
+Each fixes nominal coverage, minimum calibration rows, minimum prior origins,
+maximum prior origins and grouping before outputs are opened. The recent-window
+variants are sensitivity tests for residual-distribution drift, not alternatives to
+select after comparing coverage. Material disagreement means the expanding
+exchangeability assumption is not credible.
 Registered outputs carry the policy identifier and a prespecification flag. Arbitrary
 groupings produced by the lower-level function are labeled `ad_hoc_unregistered`
 and cannot be presented as confirmatory conditional-coverage tests.

--- a/scripts/run_ghsl_fixed_baselines.py
+++ b/scripts/run_ghsl_fixed_baselines.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+import pandas as pd
+
 from urban_growth.adapters.ghsl_ucdb import (
     fixed_2025_theme_panel,
     multitemporal_boundary_panel,
@@ -103,11 +105,27 @@ def main() -> None:
     errors = rolling_baseline_errors(intervals, origins)
     equal_origin = equal_origin_forecast_metrics(errors)
     equal_country_origin = equal_country_origin_forecast_metrics(errors)
-    interval_calibration = registered_sequential_interval_calibration(
-        errors, policy_id="overall_90_v1"
+    interval_calibration = pd.concat(
+        [
+            registered_sequential_interval_calibration(
+                errors, policy_id="overall_90_v1"
+            ),
+            registered_sequential_interval_calibration(
+                errors, policy_id="overall_90_recent3_v1"
+            ),
+        ],
+        ignore_index=True,
     )
-    interval_calibration_by_size = registered_sequential_interval_calibration(
-        errors, policy_id="size_bin_90_v1"
+    interval_calibration_by_size = pd.concat(
+        [
+            registered_sequential_interval_calibration(
+                errors, policy_id="size_bin_90_v1"
+            ),
+            registered_sequential_interval_calibration(
+                errors, policy_id="size_bin_90_recent3_v1"
+            ),
+        ],
+        ignore_index=True,
     )
     temporal = temporal_reversal_diagnostics(intervals)
     gapped_intervals = build_ghsl_fixed_forecast_intervals(

--- a/scripts/run_wup_baselines.py
+++ b/scripts/run_wup_baselines.py
@@ -241,11 +241,27 @@ def main() -> None:
     equal_country_origin = equal_country_origin_forecast_metrics(errors)
     balanced_pooled_equal_country = equal_country_forecast_metrics(balanced_errors)
     locked_origin = locked_origin_model_evaluation(errors, locked_origin=2020)
-    interval_calibration = registered_sequential_interval_calibration(
-        errors, policy_id="overall_90_v1"
+    interval_calibration = pd.concat(
+        [
+            registered_sequential_interval_calibration(
+                errors, policy_id="overall_90_v1"
+            ),
+            registered_sequential_interval_calibration(
+                errors, policy_id="overall_90_recent3_v1"
+            ),
+        ],
+        ignore_index=True,
     )
-    interval_calibration_by_size = registered_sequential_interval_calibration(
-        errors, policy_id="size_bin_90_v1"
+    interval_calibration_by_size = pd.concat(
+        [
+            registered_sequential_interval_calibration(
+                errors, policy_id="size_bin_90_v1"
+            ),
+            registered_sequential_interval_calibration(
+                errors, policy_id="size_bin_90_recent3_v1"
+            ),
+        ],
+        ignore_index=True,
     )
     country_time_bootstrap = two_way_cluster_bootstrap_paired_difference(errors)
     country_time_size_bootstrap = two_way_cluster_bootstrap_paired_difference(

--- a/src/urban_growth/forecast.py
+++ b/src/urban_growth/forecast.py
@@ -27,12 +27,28 @@ REGISTERED_INTERVAL_CALIBRATION_POLICIES = {
         "miscoverage": 0.10,
         "minimum_calibration_rows": 100,
         "minimum_calibration_origins": 2,
+        "maximum_calibration_origins": None,
+        "group_columns": [],
+    },
+    "overall_90_recent3_v1": {
+        "miscoverage": 0.10,
+        "minimum_calibration_rows": 100,
+        "minimum_calibration_origins": 2,
+        "maximum_calibration_origins": 3,
         "group_columns": [],
     },
     "size_bin_90_v1": {
         "miscoverage": 0.10,
         "minimum_calibration_rows": 100,
         "minimum_calibration_origins": 2,
+        "maximum_calibration_origins": None,
+        "group_columns": ["size_bin"],
+    },
+    "size_bin_90_recent3_v1": {
+        "miscoverage": 0.10,
+        "minimum_calibration_rows": 100,
+        "minimum_calibration_origins": 2,
+        "maximum_calibration_origins": 3,
         "group_columns": ["size_bin"],
     },
 }
@@ -850,6 +866,7 @@ def sequential_interval_calibration(
     miscoverage: float = 0.10,
     minimum_calibration_rows: int = 100,
     minimum_calibration_origins: int = 2,
+    maximum_calibration_origins: int | None = None,
     group_columns: list[str] | None = None,
     policy_id: str = "ad_hoc_unregistered",
     stratification_prespecified: bool = False,
@@ -870,6 +887,8 @@ def sequential_interval_calibration(
         raise SourceSchemaError("Interval miscoverage must be between zero and one")
     if minimum_calibration_rows < 1 or minimum_calibration_origins < 1:
         raise SourceSchemaError("Calibration minimums must be positive")
+    if maximum_calibration_origins is not None and maximum_calibration_origins < 1:
+        raise SourceSchemaError("Maximum calibration origins must be positive")
     working = errors.copy()
     if not np.isfinite(working[["error", "absolute_error"]]).all().all():
         raise SourceSchemaError("Interval calibration requires finite errors")
@@ -881,6 +900,12 @@ def sequential_interval_calibration(
         labels = dict(zip(keys, key_values, strict=True))
         for origin in sorted(model_group["origin"].unique()):
             calibration = model_group.loc[model_group["origin"] < origin]
+            if maximum_calibration_origins is not None:
+                eligible_origins = sorted(calibration["origin"].unique())
+                retained_origins = eligible_origins[-maximum_calibration_origins:]
+                calibration = calibration.loc[
+                    calibration["origin"].isin(retained_origins)
+                ]
             calibration_origin_count = calibration["origin"].nunique()
             if (
                 len(calibration) < minimum_calibration_rows
@@ -929,7 +954,9 @@ def sequential_interval_calibration(
                     "calibration_rows": len(calibration),
                     "calibration_order_statistic_rank": conformal_rank,
                     "calibration_origins": int(calibration_origin_count),
+                    "calibration_origin_start": int(calibration["origin"].min()),
                     "calibration_origin_end": int(calibration["origin"].max()),
+                    "maximum_calibration_origins": maximum_calibration_origins,
                     "calibration_uses_current_or_future_origin": False,
                     "interval_semantics": (
                         "symmetric_pre_origin_empirical_absolute_error_band"
@@ -961,6 +988,7 @@ def registered_sequential_interval_calibration(
         miscoverage=float(policy["miscoverage"]),
         minimum_calibration_rows=int(policy["minimum_calibration_rows"]),
         minimum_calibration_origins=int(policy["minimum_calibration_origins"]),
+        maximum_calibration_origins=policy["maximum_calibration_origins"],
         group_columns=list(policy["group_columns"]),
         policy_id=policy_id,
         stratification_prespecified=True,

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -638,3 +638,34 @@ def test_registered_interval_policy_rejects_analyst_defined_name() -> None:
         registered_sequential_interval_calibration(
             errors, policy_id="post_hoc_underperforming_region"
         )
+
+
+def test_recent_origin_calibration_excludes_stale_residuals() -> None:
+    rows = []
+    for origin, error in [
+        (1990, 9.0),
+        (1995, 8.0),
+        (2000, 0.10),
+        (2005, 0.20),
+        (2010, 0.30),
+        (2015, 0.25),
+    ]:
+        for city_id in range(100):
+            rows.append(
+                {
+                    "origin": origin,
+                    "model": "m",
+                    "country_code": f"C{city_id % 10}",
+                    "error": error,
+                    "absolute_error": error,
+                }
+            )
+    result = registered_sequential_interval_calibration(
+        pd.DataFrame(rows), policy_id="overall_90_recent3_v1"
+    )
+    final = result.loc[result["origin"].eq(2015)].iloc[0]
+    assert final["calibration_origin_start"] == 2000
+    assert final["calibration_origin_end"] == 2010
+    assert final["calibration_origins"] == 3
+    assert final["maximum_calibration_origins"] == 3
+    assert final["interval_radius"] == pytest.approx(0.30)


### PR DESCRIPTION
## Methodology issue

Expanding calibration assumes early forecast residuals remain relevant to later forecasts. That is doubtful when training samples, city coverage, data revisions, and shock regimes change. Old high-error periods can widen current bands; old low-error periods can cause undercoverage.

## Changes

- add a maximum-prior-origin calibration window;
- register frozen recent-three-origin policies overall and by size;
- retain the expanding policies as the primary comparison rather than choosing a winner;
- report calibration-window start, end, and maximum length;
- generate expanding and recent-window results side by side for WUP and fixed-GHSL;
- test that stale early residuals are excluded exactly as declared.

## Interpretation

Material disagreement between expanding and recent-window results is evidence against a stable residual distribution. The recent window is a prespecified sensitivity, not a replacement selected after viewing coverage.