### PR TITLE
Add country-balanced interval calibration sensitivity

### DIFF
--- a/docs/research-design.md
+++ b/docs/research-design.md
@@ -82,7 +82,13 @@ Each fixes nominal coverage, minimum calibration rows, minimum prior origins,
 maximum prior origins and grouping before outputs are opened. The recent-window
 variants are sensitivity tests for residual-distribution drift, not alternatives to
 select after comparing coverage. Material disagreement means the expanding
-exchangeability assumption is not credible.
+exchangeability assumption is not credible. Two additional registered sensitivities,
+`overall_90_equal_country_v1` and `size_bin_90_equal_country_v1`, give every
+country equal total weight in the calibration residual distribution. They test
+whether countries with many reported cities determine the radius. These weighted
+empirical quantiles do not receive the ordinary finite-sample conformal rank guarantee
+and are labeled accordingly; they must be compared with, not substituted for, the
+city-weighted policies.
 Registered outputs carry the policy identifier and a prespecification flag. Arbitrary
 groupings produced by the lower-level function are labeled `ad_hoc_unregistered`
 and cannot be presented as confirmatory conditional-coverage tests.

--- a/scripts/run_ghsl_fixed_baselines.py
+++ b/scripts/run_ghsl_fixed_baselines.py
@@ -113,6 +113,9 @@ def main() -> None:
             registered_sequential_interval_calibration(
                 errors, policy_id="overall_90_recent3_v1"
             ),
+            registered_sequential_interval_calibration(
+                errors, policy_id="overall_90_equal_country_v1"
+            ),
         ],
         ignore_index=True,
     )
@@ -123,6 +126,9 @@ def main() -> None:
             ),
             registered_sequential_interval_calibration(
                 errors, policy_id="size_bin_90_recent3_v1"
+            ),
+            registered_sequential_interval_calibration(
+                errors, policy_id="size_bin_90_equal_country_v1"
             ),
         ],
         ignore_index=True,

--- a/scripts/run_wup_baselines.py
+++ b/scripts/run_wup_baselines.py
@@ -249,6 +249,9 @@ def main() -> None:
             registered_sequential_interval_calibration(
                 errors, policy_id="overall_90_recent3_v1"
             ),
+            registered_sequential_interval_calibration(
+                errors, policy_id="overall_90_equal_country_v1"
+            ),
         ],
         ignore_index=True,
     )
@@ -259,6 +262,9 @@ def main() -> None:
             ),
             registered_sequential_interval_calibration(
                 errors, policy_id="size_bin_90_recent3_v1"
+            ),
+            registered_sequential_interval_calibration(
+                errors, policy_id="size_bin_90_equal_country_v1"
             ),
         ],
         ignore_index=True,

--- a/src/urban_growth/forecast.py
+++ b/src/urban_growth/forecast.py
@@ -25,6 +25,7 @@ class ForecastMetrics:
 REGISTERED_INTERVAL_CALIBRATION_POLICIES = {
     "overall_90_v1": {
         "miscoverage": 0.10,
+        "calibration_weighting": "city",
         "minimum_calibration_rows": 100,
         "minimum_calibration_origins": 2,
         "maximum_calibration_origins": None,
@@ -32,6 +33,7 @@ REGISTERED_INTERVAL_CALIBRATION_POLICIES = {
     },
     "overall_90_recent3_v1": {
         "miscoverage": 0.10,
+        "calibration_weighting": "city",
         "minimum_calibration_rows": 100,
         "minimum_calibration_origins": 2,
         "maximum_calibration_origins": 3,
@@ -39,6 +41,7 @@ REGISTERED_INTERVAL_CALIBRATION_POLICIES = {
     },
     "size_bin_90_v1": {
         "miscoverage": 0.10,
+        "calibration_weighting": "city",
         "minimum_calibration_rows": 100,
         "minimum_calibration_origins": 2,
         "maximum_calibration_origins": None,
@@ -46,9 +49,26 @@ REGISTERED_INTERVAL_CALIBRATION_POLICIES = {
     },
     "size_bin_90_recent3_v1": {
         "miscoverage": 0.10,
+        "calibration_weighting": "city",
         "minimum_calibration_rows": 100,
         "minimum_calibration_origins": 2,
         "maximum_calibration_origins": 3,
+        "group_columns": ["size_bin"],
+    },
+    "overall_90_equal_country_v1": {
+        "miscoverage": 0.10,
+        "calibration_weighting": "equal_country",
+        "minimum_calibration_rows": 100,
+        "minimum_calibration_origins": 2,
+        "maximum_calibration_origins": None,
+        "group_columns": [],
+    },
+    "size_bin_90_equal_country_v1": {
+        "miscoverage": 0.10,
+        "calibration_weighting": "equal_country",
+        "minimum_calibration_rows": 100,
+        "minimum_calibration_origins": 2,
+        "maximum_calibration_origins": None,
         "group_columns": ["size_bin"],
     },
 }
@@ -867,6 +887,7 @@ def sequential_interval_calibration(
     minimum_calibration_rows: int = 100,
     minimum_calibration_origins: int = 2,
     maximum_calibration_origins: int | None = None,
+    calibration_weighting: str = "city",
     group_columns: list[str] | None = None,
     policy_id: str = "ad_hoc_unregistered",
     stratification_prespecified: bool = False,
@@ -889,6 +910,8 @@ def sequential_interval_calibration(
         raise SourceSchemaError("Calibration minimums must be positive")
     if maximum_calibration_origins is not None and maximum_calibration_origins < 1:
         raise SourceSchemaError("Maximum calibration origins must be positive")
+    if calibration_weighting not in {"city", "equal_country"}:
+        raise SourceSchemaError("Unknown calibration weighting")
     working = errors.copy()
     if not np.isfinite(working[["error", "absolute_error"]]).all().all():
         raise SourceSchemaError("Interval calibration requires finite errors")
@@ -915,13 +938,28 @@ def sequential_interval_calibration(
             test = model_group.loc[model_group["origin"].eq(origin)]
             if test.empty:
                 continue
-            conformal_rank = int(
-                np.ceil((len(calibration) + 1) * (1 - miscoverage))
-            )
-            if conformal_rank > len(calibration):
-                continue
-            ordered_errors = np.sort(calibration["absolute_error"].to_numpy())
-            radius = float(ordered_errors[conformal_rank - 1])
+            conformal_rank: int | None = None
+            if calibration_weighting == "city":
+                conformal_rank = int(
+                    np.ceil((len(calibration) + 1) * (1 - miscoverage))
+                )
+                if conformal_rank > len(calibration):
+                    continue
+                ordered_errors = np.sort(calibration["absolute_error"].to_numpy())
+                radius = float(ordered_errors[conformal_rank - 1])
+            else:
+                country_counts = calibration.groupby("country_code")[
+                    "absolute_error"
+                ].transform("size")
+                country_count = calibration["country_code"].nunique()
+                weights = 1 / (country_count * country_counts)
+                order = np.argsort(calibration["absolute_error"].to_numpy())
+                ordered_errors = calibration["absolute_error"].to_numpy()[order]
+                cumulative_weight = np.cumsum(weights.to_numpy()[order])
+                weighted_index = int(
+                    np.searchsorted(cumulative_weight, 1 - miscoverage, side="left")
+                )
+                radius = float(ordered_errors[min(weighted_index, len(ordered_errors) - 1)])
             covered = test["absolute_error"].le(radius)
             lower_tail_miss = test["error"].gt(radius)
             upper_tail_miss = test["error"].lt(-radius)
@@ -953,6 +991,13 @@ def sequential_interval_calibration(
                     "test_countries": int(test["country_code"].nunique()),
                     "calibration_rows": len(calibration),
                     "calibration_order_statistic_rank": conformal_rank,
+                    "calibration_weighting": calibration_weighting,
+                    "calibration_countries": int(
+                        calibration["country_code"].nunique()
+                    ),
+                    "finite_sample_conformal_rank_applied": (
+                        calibration_weighting == "city"
+                    ),
                     "calibration_origins": int(calibration_origin_count),
                     "calibration_origin_start": int(calibration["origin"].min()),
                     "calibration_origin_end": int(calibration["origin"].max()),
@@ -989,6 +1034,7 @@ def registered_sequential_interval_calibration(
         minimum_calibration_rows=int(policy["minimum_calibration_rows"]),
         minimum_calibration_origins=int(policy["minimum_calibration_origins"]),
         maximum_calibration_origins=policy["maximum_calibration_origins"],
+        calibration_weighting=str(policy["calibration_weighting"]),
         group_columns=list(policy["group_columns"]),
         policy_id=policy_id,
         stratification_prespecified=True,

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -669,3 +669,52 @@ def test_recent_origin_calibration_excludes_stale_residuals() -> None:
     assert final["calibration_origins"] == 3
     assert final["maximum_calibration_origins"] == 3
     assert final["interval_radius"] == pytest.approx(0.30)
+
+
+def test_equal_country_calibration_prevents_large_country_dominance() -> None:
+    rows = []
+    for origin in [2000, 2005]:
+        for city_id in range(50):
+            rows.append(
+                {
+                    "origin": origin,
+                    "model": "m",
+                    "country_code": "LARGE",
+                    "error": 0.10,
+                    "absolute_error": 0.10,
+                }
+            )
+        rows.append(
+            {
+                "origin": origin,
+                "model": "m",
+                "country_code": "SMALL",
+                "error": 1.00,
+                "absolute_error": 1.00,
+            }
+        )
+    rows.extend(
+        [
+            {
+                "origin": 2010,
+                "model": "m",
+                "country_code": country,
+                "error": 0.20,
+                "absolute_error": 0.20,
+            }
+            for country in ["LARGE", "SMALL"]
+        ]
+    )
+    errors = pd.DataFrame(rows)
+    city = registered_sequential_interval_calibration(
+        errors, policy_id="overall_90_v1"
+    )
+    country = registered_sequential_interval_calibration(
+        errors, policy_id="overall_90_equal_country_v1"
+    )
+    city_final = city.loc[city["origin"].eq(2010)].iloc[0]
+    country_final = country.loc[country["origin"].eq(2010)].iloc[0]
+    assert city_final["interval_radius"] == pytest.approx(0.10)
+    assert country_final["interval_radius"] == pytest.approx(1.00)
+    assert country_final["calibration_weighting"] == "equal_country"
+    assert not country_final["finite_sample_conformal_rank_applied"]


### PR DESCRIPTION
## Methodology issue

The interval radius is calibrated on city rows. Countries with extensive city coverage therefore dominate the residual distribution. Reporting equal-country coverage afterward diagnoses the result but does not change the radius that produced it.

## Changes

- add equal-country-weighted empirical residual quantiles;
- register overall and size-bin 90% country-balanced sensitivities;
- give every country equal total calibration weight;
- report weighting mode, calibration-country count, and whether the ordinary finite-sample conformal rank applies;
- generate these sensitivities separately for WUP and fixed-GHSL;
- test a case where one large national sample masks the small country's much larger errors.

## Interpretation

The equal-country radius is a weighted empirical sensitivity, not a distribution-free conformal interval. It must be reported beside the city-weighted policy, not substituted based on which looks better.