### PR TITLE
Implement locked empirical specification contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Adopt the 29 August 2026 locked empirical specification and encode its
+  forecast-origin tier, ILR, census-threshold, accessibility-band, and C1/C2/C3
+  form-timing contracts as tested utilities.
+- Register the Malaria Atlas Project 2015 accessibility layer explicitly as a
+  modern validation snapshot rather than a historical panel.
 - Add equal-origin and equal-country-within-origin forecast estimands to prevent changing temporal coverage from silently determining pooled results.
 
 - Add a focal-city-excluded WUP F01 national Cities-category comparator and retain the inclusive version only as a diagnostic.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ This repository currently supports the first two as research targets. It does no
 | H4 | National demography and urbanization stage explain more shared variation than broad global shocks. | Country-period, region-period, and global-period decompositions. | Higher aggregation performs as well out of sample and country components add little. |
 | H5 | Borders condition spatial spillovers beyond distance and accessibility. | Matched within/between-border comparisons and border-placebo tests. | Border terms vanish under comparable distance and accessibility specifications. |
 
-See [docs/research-design.md](docs/research-design.md) for estimands, validation rules, and test order.
+See [docs/locked-specification.md](docs/locked-specification.md) for the governing empirical
+contract and [docs/research-design.md](docs/research-design.md) for the accumulated estimands,
+validation results, and test order.
 
 ## Repository structure
 

--- a/data/sources.json
+++ b/data/sources.json
@@ -152,6 +152,25 @@
       "notes": "Use vintages available at each historical forecast origin when testing genuine real-time forecasts; the current revision is revised-history evidence."
     },
     {
+      "source_id": "map_accessibility_2015",
+      "priority": 3,
+      "status": "modern_validation",
+      "publisher": "Malaria Atlas Project",
+      "dataset": "A global map of travel time to cities to assess inequalities in accessibility in 2015",
+      "release": "2015 nominal year",
+      "landing_page": "https://malariaatlas.org/publication/a-global-map-of-travel-time-to-cities-to-assess-inequalities-in-accessibility-in-2015/",
+      "documentation_url": "https://www.nature.com/articles/nature25181",
+      "retrieval": "manual_large_raster",
+      "formats": ["geotiff"],
+      "coverage": "Global nominal 2015 travel time to cities",
+      "unit": "grid cell",
+      "role": "Modern-period accessibility validation and rival-mass bands",
+      "upstream_dependencies": [],
+      "redistribution": "review_before_commit",
+      "citation": "Weiss et al. (2018). A global map of travel time to cities to assess inequalities in accessibility in 2015. Nature.",
+      "notes": "Snapshot exposure, not a historical friction-surface panel. Do not assign this layer to 1975-2010 origins as if contemporaneous."
+    },
+    {
       "source_id": "oecd_fua",
       "priority": 3,
       "status": "mechanism",

--- a/docs/data-contract.md
+++ b/docs/data-contract.md
@@ -38,6 +38,38 @@ A WUP–GHSL crosswalk requires `wup_city_id`, `ghsl_city_id`, `match_status`, `
 
 The outcome is future annualized log growth. Lagged growth must end at or before `period_start`. Random row splits are prohibited because they leak adjacent periods and common shocks. Forecast evaluation uses chronological rolling origins, with country-aware diagnostics.
 
+## Forecast-origin hierarchy and ILR contract
+
+Absolute-size and relative-rank tiers are assigned from origin population before outcome
+availability is inspected and remain fixed through the forecast interval. Endpoint rank and
+realized tier cannot overwrite origin membership. Relative tiers are identity/count based;
+they are not groups holding a fixed share of national population.
+
+Compositional analysis uses ordered tier ILR balances. A country-origin with an empty tier
+needed by a balance is marked ineligible with `empty_origin_fixed_tier_cell`; the missing cell
+must not be replaced by zero. Per-city leave-one-out share outcomes are prohibited.
+
+## Census boundary-cohort contract
+
+A threshold-audit row requires a stable settlement ID, two direct or explicitly classified
+population endpoints, and geography status of `stable`, `official_crosswalk`, or
+`harmonized_common_geography`. Unresolved geography is excluded before growth or crossing is
+calculated. Threshold crossing and WUP entry are interval-censored. If their intervals are
+`(t0,t1)` and `(w0,w1)`, delay is `(w0-t1,w1-t0)`, open at both ends.
+
+## Modern accessibility contract
+
+Rival-city mass excludes the focal city and is aggregated into left-closed, mutually exclusive
+`[0,1)`, `[1,2)`, `[2,4)`, and `[4,8)` hour bands. Every exposure carries its nominal friction
+surface vintage. Snapshot products cannot be silently expanded into a historical panel.
+
+## Urban-form timing contract
+
+`C1` is contemporaneous population-growth/form-change association. `C2` uses prior-interval
+population growth to predict later form change. `C3` uses prior-interval form change to predict
+later population growth. Lead-lag rows require adjacent intervals for the same city; gaps do not
+qualify without a separately registered timing design.
+
 ## WUP assembled panel
 
 The WUP city-year assembly is strictly internal to the WUP `City_Code` namespace. It joins F21 population, F25 land area, F30 built-up area per capita, and F34 population density only after exact city-year coverage and the F21/F25/F34 density identity pass validation.

--- a/docs/locked-specification.md
+++ b/docs/locked-specification.md
@@ -1,0 +1,154 @@
+# Locked empirical specification
+
+Status: implementation contract adopted 29 August 2026. The architecture is locked;
+named feasibility gates remain open. This file governs code behavior when older design
+notes are less specific.
+
+## Module architecture
+
+| Module | Empirical object | Role |
+|---|---|---|
+| A — national envelope | National population by settlement class | Directly measure allocation to cities, towns and rural areas. |
+| B — within-country allocation | City growth conditional on country-period | Estimate which observed cities capture growth; country-by-period effects absorb the national envelope. |
+| C — urban form | Horizontal extent, density and cautiously used vertical measures | Test contemporaneous association and both lead-lag directions separately. |
+| D — accessibility | Modern travel-time rival mass | Validate spatial structure only for supported modern vintages; never backcast a 1975–2025 travel-time panel. |
+| E — census threshold | Locality census cohorts around 50,000 | Audit WUP entry, survivorship and threshold measurement; do not treat this as an RDD. |
+
+Modules A and B are linked but not a literal single regression. Module A uses national
+settlement-class observations. In retrospective Module B, country-by-period fixed effects
+absorb every national variable common to cities in that cell. A recovered-fixed-effect
+decomposition is diagnostic only and excludes sparse country-period cells.
+
+## Outcomes and timing
+
+City growth is annualized log growth over an exact interval. `decline_any` is growth below
+zero; `decline_material` is growth below -0.005 annually. Continuous origin population and
+rank are primary. Presentation tiers and ILR membership are fixed at the forecast origin.
+Endpoint rank, realized tier and future urban form cannot enter a forecast-origin model.
+
+The form module has three distinct specifications:
+
+- **C1:** population growth and form change measured over the same interval; association only.
+- **C2:** population growth over the preceding interval predicts later form change.
+- **C3:** form change over the preceding interval predicts later population growth.
+
+If C2 and C3 both predict, report joint dynamic adjustment rather than selecting a one-way
+causal story.
+
+## Module B model and estimator hierarchy
+
+The general retrospective template is:
+
+```text
+g_ict = alpha_ct + mu_i + rho g_ic,t-1 + beta' X_ic,t-1 + epsilon_ict
+```
+
+This is a template, not one fitted “primary” estimator. Active terms depend on the row below.
+
+| Tier | Specification | Purpose and limitation |
+|---|---|---|
+| 1 | Pooled dynamic model; omit `mu_i` | Primary predictive benchmark. It retains stable between-city signal and does not identify a within-city effect. |
+| 2 | City fixed effects; include `mu_i` | Within-city diagnostic. With a lagged outcome and short panels it is Nickell-biased. |
+| 3 | Finite-T bias-corrected city-FE dynamic model | Primary retrospective within-city estimate when implementation and simulation gates pass. |
+| 4 | Restricted dynamic GMM sensitivity | Use only with collapsed, limited instruments and explicit weak-instrument/proliferation diagnostics. |
+
+Run the first three on the same analytic sample. If conclusions disagree, report the
+disagreement. Do not choose the estimator that produces the preferred sign. Standard errors
+must account for country clustering and period dependence; add spatial diagnostics before
+claiming conventional inference is adequate.
+
+## Composition and settlement hierarchy
+
+Do not regress raw city shares as independent outcomes. The primary city-growth model uses
+country-by-period effects. Secondary compositional analysis uses ordered, fixed-tier ILR
+balances. Per-city leave-one-out share denominators are prohibited because they are unstable
+in primate systems.
+
+Absolute size and relative hierarchy are parallel classifications answering different
+questions. Absolute thresholds require a staleness audit; relative tiers are rank/count based,
+not defined by fixed population shares. Tier transitions are reported separately from growth
+within forecast-origin membership.
+
+## Census threshold audit
+
+The master cohort contains localities with origin population from 25,000 through 100,000,
+observed at two endpoints on stable or explicitly harmonized geography. It separately records:
+
+1. census crossing of 50,000;
+2. WUP entry;
+3. WUP exit;
+4. relative-hierarchy tier movement.
+
+Crossing and entry are interval-censored. If crossing is in `(t0, t1)` and entry is in
+`(w0, w1)`, delay is in the open interval `(w0 - t1, w1 - t0)`. Do not substitute an
+interpolated point year as observed fact. Run threshold-error sensitivity bands and distinguish
+direct enumeration from interpolation or projection.
+
+The audit sample and ILR sample may originate from the same census records but have different
+eligibility filters. The audit requires comparable endpoints; the ILR requires positive cells
+in every tier entering a balance. Never silently force one sample to equal the other.
+
+## Geography and lineage
+
+Population and form are measured on fixed, validated polygons within an analysis. Boundary
+events are logged; changing polygons are never represented as demographic growth. Baseline
+form is admissible as a predictor only when available at the origin. Variables derived from the
+population outcome or sharing built-up disaggregation inputs are tagged as lineage-entangled
+and cannot be described as independent confirmation.
+
+For precision: the 1975–2020 historical GHS-WUP population is informed by GHS-BUILT-V or
+related built layers; CRISP proper applies to the 2025–2100 projection workflow. The substantive
+lineage warning applies across the historical and projection windows even though the workflow
+names differ.
+
+## Accessibility
+
+Travel-time bands are mutually exclusive: `[0,1)`, `[1,2)`, `[2,4)` and `[4,8)` hours. Rival
+mass excludes the focal city. The 2015 MAP layer and later friction surfaces are modern-period
+validation data, not a historical series. Enter nested spatial constructs rather than five
+collinear variants simultaneously: geography and hierarchy; one registered market-potential
+or rival-mass construct; mutually exclusive bands; then dominance or fragmentation, one at a
+time.
+
+Positive spatial coefficients can reflect agglomeration or common location advantages;
+negative coefficients can reflect competition or congestion. Sign alone does not identify the
+mechanism.
+
+## Prediction and reporting
+
+Use chronological rolling origins, frozen candidate models, an untouched later vintage when
+available, and leave-country-out diagnostics. Report MAE, RMSE, median absolute error, bias,
+directional accuracy, calibrated intervals and coverage by size, geography and data quality.
+The inspected 2020 outcome is development evidence, not a pristine holdout.
+
+Claims must be labeled descriptive, predictive, temporal or causal. Current permitted language
+is that recent growth is the strongest reproducible predictor in the observed panel and initial
+size is associated with decline incidence. “Size protects cities” and “nearby cities compete for
+a fixed pool” are prohibited without separate identification.
+
+## Automated gates
+
+Code must fail on duplicate keys, nonpositive population, future leakage, endpoint-derived tier
+membership, cumulative travel-time bands, unresolved census geography, absent census endpoints,
+empty ILR cells represented as zero, and lineage-undisclosed form variables. Every exclusion
+receives a machine-readable reason.
+
+## Feasibility register
+
+| ID | Issue | Required output |
+|---|---|---|
+| O1 | Mexico locality concordance, 2000–2020 | Pilot feasibility report |
+| O2 | Brazil census-sector harmonization | Crosswalk coverage table |
+| O3 | South Africa and Ghana multiwave access | Access and coverage memo |
+| O4 | Absolute and relative tier definitions | Versioned tier registry |
+| O5 | Finite-T bias correction | Estimator simulation |
+| O6 | Spatial dependence | Inference memo |
+| O7 | Independent morphology pairing | Lineage validation matrix |
+| O8 | Modern accessibility window | Accessibility protocol |
+| O9 | Forecastable national envelope | Separate forecast-module specification |
+| O10 | India census scope | Test 2001–2011 as historical-only; defer modern validation until Census 2027 locality outputs and crosswave concordances exist |
+
+No shrinkage model can manufacture missing within-country information. The recovered
+country-period effect diagnostic excludes cells with fewer than three eligible cities and
+reports the city count and uncertainty; direct national settlement-class data remain the
+primary national-envelope analysis.

--- a/docs/research-status.md
+++ b/docs/research-status.md
@@ -1,5 +1,18 @@
 # Research status
 
+## Specification implementation status — 29 August 2026
+
+The consolidated quality-review specification is now the repository's governing contract.
+Executable utilities enforce forecast-origin-fixed absolute and relative tiers, ordered-tier
+ILR eligibility, open interval-censored WUP-entry delay bounds, comparable-geography census
+cohorts, mutually exclusive modern travel-time bands, and distinct C1/C2/C3 urban-form timing.
+
+This is implementation of design constraints, not completion of the empirical program. The
+finite-T estimator simulation, country census pilots, independent-lineage morphology matrix,
+modern accessibility raster build and national-envelope forecast module remain open gates in
+`docs/locked-specification.md`. No new numerical result or causal claim follows from merging
+the contract code.
+
 ## Evidence state
 
 The source and transformation pipeline is reproducible from registered local files, but all results remain **retrospective current-revision tests**. The WUP and GHSL exercises use different city definitions and must not be pooled. WUP supplies demographic city records without a verified stable-polygon restriction. GHSL supplies a balanced panel calculated inside fixed 2025 polygons, but that definition uses future geographic information and is not vintage-correct. Neither is sufficient for a commercial forecasting claim.

--- a/docs/source-library.md
+++ b/docs/source-library.md
@@ -10,6 +10,7 @@ The machine-readable catalog is `data/sources.json`. It records analytical role,
 | WUP 2025 country DEGURBA | National control | Cities/towns/rural totals and urbanization stage | Not an individual-city panel |
 | GHS-UCDB R2024A v1.2 | Spatial core | Dynamic footprint, fixed-boundary sensitivity, density, area change | Not independent of WUP/DEGURBA |
 | WPP 2024 | National control | National demographic benchmark | Current-vintage history is not a real-time forecast vintage |
+| MAP accessibility 2015 | Modern validation | Mutually exclusive travel-time rival-mass bands | A 2015 snapshot, not a historical panel |
 | OECD FUA | Mechanism | Urban core versus commuting zone | Restricted country/sample comparability |
 | WorldPop Global 2 | Robustness | Fine-grid population allocation | 2015-2030 is too short for the primary historical design |
 | Natural Earth Admin 0 | Spatial control | Borders and island geometry | Geometry does not measure migration-policy restrictiveness |

--- a/src/urban_growth/accessibility.py
+++ b/src/urban_growth/accessibility.py
@@ -1,0 +1,41 @@
+"""Modern-period accessibility exposure construction."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from urban_growth.io import SourceSchemaError, require_columns
+
+TRAVEL_TIME_BANDS = ((0, 1), (1, 2), (2, 4), (4, 8))
+
+
+def mutually_exclusive_rival_mass(
+    pairs: pd.DataFrame,
+    *,
+    nominal_vintage: int,
+    focal_column: str = "focal_city_id",
+    travel_time_column: str = "travel_time_hours",
+    rival_population_column: str = "rival_population",
+) -> pd.DataFrame:
+    """Aggregate other-centre mass into non-overlapping 0-1/1-2/2-4/4-8h bands."""
+    require_columns(
+        pairs,
+        {focal_column, "rival_city_id", travel_time_column, rival_population_column},
+        source_name="accessibility pairs",
+    )
+    if nominal_vintage < 2000:
+        raise SourceSchemaError("Accessibility is a modern validation module, not a long panel")
+    if (pairs[focal_column] == pairs["rival_city_id"]).any():
+        raise SourceSchemaError("Rival mass must exclude the focal city")
+    if pairs[[travel_time_column, rival_population_column]].isna().any().any():
+        raise SourceSchemaError("Accessibility pairs cannot contain missing time or mass")
+    if (pairs[[travel_time_column, rival_population_column]] < 0).any().any():
+        raise SourceSchemaError("Travel time and rival population cannot be negative")
+    result = pd.DataFrame(index=pd.Index(pairs[focal_column].drop_duplicates(), name=focal_column))
+    for lower, upper in TRAVEL_TIME_BANDS:
+        mask = pairs[travel_time_column].ge(lower) & pairs[travel_time_column].lt(upper)
+        mass = pairs.loc[mask].groupby(focal_column)[rival_population_column].sum()
+        result[f"rival_mass_{lower}_{upper}h"] = mass.reindex(result.index, fill_value=0.0)
+    result["accessibility_nominal_vintage"] = nominal_vintage
+    result["band_definition"] = "mutually_exclusive_left_closed"
+    return result.reset_index()

--- a/src/urban_growth/census_threshold.py
+++ b/src/urban_growth/census_threshold.py
@@ -1,0 +1,68 @@
+"""National-census validation primitives around the WUP observation threshold."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+from urban_growth.io import SourceSchemaError, require_columns
+
+
+@dataclass(frozen=True)
+class DelayInterval:
+    """Open interval containing WUP-entry delay relative to census crossing."""
+
+    lower: float
+    upper: float
+
+
+def entry_delay_interval(
+    *, crossing_lower: float, crossing_upper: float, entry_lower: float, entry_upper: float
+) -> DelayInterval:
+    """Return the sharp open bounds (w0 - t1, w1 - t0)."""
+    if crossing_lower >= crossing_upper or entry_lower >= entry_upper:
+        raise SourceSchemaError("Crossing and entry intervals must have positive width")
+    return DelayInterval(entry_lower - crossing_upper, entry_upper - crossing_lower)
+
+
+def classify_threshold_measurement_band(
+    population: pd.Series, *, threshold: float = 50_000, tolerance: float = 2_500
+) -> pd.Categorical:
+    """Flag observations whose census measurement could plausibly cross the threshold."""
+    if threshold <= 0 or tolerance < 0:
+        raise SourceSchemaError("Threshold must be positive and tolerance non-negative")
+    if population.isna().any() or (population <= 0).any():
+        raise SourceSchemaError("Census population must be positive and non-null")
+    labels = pd.cut(
+        population,
+        bins=(-float("inf"), threshold - tolerance, threshold + tolerance, float("inf")),
+        labels=("clearly_below", "threshold_uncertain", "clearly_above"),
+        include_lowest=True,
+        right=False,
+    )
+    return labels
+
+
+def validate_boundary_cohort(frame: pd.DataFrame) -> None:
+    """Enforce the two-endpoint, comparable-geography audit contract."""
+    required = {
+        "settlement_id",
+        "country_code",
+        "origin_year",
+        "endpoint_year",
+        "population_origin",
+        "population_endpoint",
+        "geography_status",
+    }
+    require_columns(frame, required, source_name="census boundary cohort")
+    if frame.duplicated(["settlement_id", "origin_year", "endpoint_year"]).any():
+        raise SourceSchemaError("Census boundary cohort keys must be unique")
+    if (frame["endpoint_year"] <= frame["origin_year"]).any():
+        raise SourceSchemaError("Census endpoint must follow origin")
+    comparable = {"stable", "official_crosswalk", "harmonized_common_geography"}
+    invalid = ~frame["geography_status"].isin(comparable)
+    if invalid.any():
+        raise SourceSchemaError("Boundary cohort contains unresolved or incomparable geography")
+    if frame[["population_origin", "population_endpoint"]].isna().any().any():
+        raise SourceSchemaError("Boundary cohort requires both population endpoints")

--- a/src/urban_growth/form_timing.py
+++ b/src/urban_growth/form_timing.py
@@ -1,0 +1,32 @@
+"""Timing-safe data preparation for population and urban-form lead-lag tests."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from urban_growth.io import SourceSchemaError, require_columns
+
+
+def build_form_timing_rows(frame: pd.DataFrame) -> dict[str, pd.DataFrame]:
+    """Return the locked C1, C2 and C3 samples without implying causality.
+
+    C1 is contemporaneous association. C2 tests population growth in the prior
+    interval against later form change. C3 reverses that lead-lag ordering.
+    """
+    required = {"city_id", "period_start", "period_end", "population_growth", "form_change"}
+    require_columns(frame, required, source_name="form timing panel")
+    if frame.duplicated(["city_id", "period_start", "period_end"]).any():
+        raise SourceSchemaError("Form timing panel keys must be unique")
+    ordered = frame.sort_values(["city_id", "period_start", "period_end"]).copy()
+    group = ordered.groupby("city_id", sort=False)
+    ordered["prior_period_end"] = group["period_end"].shift()
+    ordered["prior_population_growth"] = group["population_growth"].shift()
+    ordered["prior_form_change"] = group["form_change"].shift()
+    adjacent = ordered["prior_period_end"].eq(ordered["period_start"])
+    c1 = ordered.copy()
+    c1["timing_specification"] = "C1_contemporaneous"
+    c2 = ordered.loc[adjacent & ordered["prior_population_growth"].notna()].copy()
+    c2["timing_specification"] = "C2_population_leads_form"
+    c3 = ordered.loc[adjacent & ordered["prior_form_change"].notna()].copy()
+    c3["timing_specification"] = "C3_form_leads_population"
+    return {"C1": c1, "C2": c2, "C3": c3}

--- a/src/urban_growth/hierarchy.py
+++ b/src/urban_growth/hierarchy.py
@@ -1,0 +1,130 @@
+"""Forecast-origin settlement tiers and compositional balances."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import numpy as np
+import pandas as pd
+
+from urban_growth.io import SourceSchemaError, require_columns
+
+DEFAULT_ABSOLUTE_THRESHOLDS = (50_000, 100_000, 250_000, 500_000, 1_000_000)
+DEFAULT_ABSOLUTE_LABELS = ("<50k", "50-100k", "100-250k", "250-500k", "500k-1m", "1m+")
+
+
+def assign_origin_tiers(
+    frame: pd.DataFrame,
+    *,
+    population_column: str = "population_start",
+    city_column: str = "city_id",
+    country_column: str = "country_code",
+    origin_column: str = "period_start",
+    rank_groups: Mapping[str, tuple[int, int | None]] | None = None,
+) -> pd.DataFrame:
+    """Assign absolute and relative tiers using information at forecast origin only.
+
+    Relative tiers are identity/count based, not population-share based.  Membership
+    is copied onto the forecast interval and must not be recomputed at its endpoint.
+    """
+    require_columns(
+        frame,
+        {city_column, population_column, country_column, origin_column},
+        source_name="tier input",
+    )
+    if frame[population_column].isna().any() or (frame[population_column] <= 0).any():
+        raise SourceSchemaError("Tier population must be positive and non-null")
+    result = frame.copy()
+    if result.duplicated([city_column, origin_column]).any():
+        raise SourceSchemaError("Tier input city-origin keys must be unique")
+    result["tier_abs_origin"] = pd.cut(
+        result[population_column],
+        bins=(-np.inf, *DEFAULT_ABSOLUTE_THRESHOLDS, np.inf),
+        labels=DEFAULT_ABSOLUTE_LABELS,
+        right=False,
+    )
+    groups = rank_groups or {
+        "primate": (1, 1),
+        "other_top5": (2, 5),
+        "rank_6_20": (6, 20),
+        "rank_21_plus": (21, None),
+    }
+    ranked = result.sort_values(
+        [country_column, origin_column, population_column, city_column],
+        ascending=[True, True, False, True],
+    )
+    ranked["_rank_origin"] = ranked.groupby(
+        [country_column, origin_column], observed=True
+    ).cumcount() + 1
+    rank = ranked["_rank_origin"].reindex(result.index)
+    result["rank_origin"] = rank.astype(int)
+    result["tier_rel_origin"] = pd.Series(index=result.index, dtype="object")
+    for label, (lower, upper) in groups.items():
+        mask = rank.ge(lower) if upper is None else rank.between(lower, upper)
+        result.loc[mask, "tier_rel_origin"] = label
+    if result["tier_rel_origin"].isna().any():
+        raise SourceSchemaError("Relative tier registry does not cover every origin rank")
+    result["tier_assignment_timing"] = "forecast_origin_fixed"
+    return result
+
+
+def fixed_membership_ilr_balance(
+    frame: pd.DataFrame,
+    *,
+    tier_column: str,
+    origin_population_column: str = "population_start",
+    endpoint_population_column: str = "population_end",
+    country_column: str = "country_code",
+    origin_column: str = "period_start",
+    balance_name: str = "tier_ilr_change",
+) -> pd.DataFrame:
+    """Calculate adjacent-tier ILR changes with membership fixed at origin.
+
+    For K ordered tiers this returns K-1 sequential balances. Empty or non-positive
+    tier cells are not zero-filled; they are excluded and identified explicitly.
+    """
+    required = {
+        tier_column,
+        origin_population_column,
+        endpoint_population_column,
+        country_column,
+        origin_column,
+    }
+    require_columns(frame, required, source_name="ILR input")
+    if (frame[[origin_population_column, endpoint_population_column]] <= 0).any().any():
+        raise SourceSchemaError("ILR populations must be strictly positive")
+    if not isinstance(frame[tier_column].dtype, pd.CategoricalDtype):
+        raise SourceSchemaError("ILR tier must be an ordered categorical with fixed labels")
+    if not frame[tier_column].cat.ordered:
+        raise SourceSchemaError("ILR tier categories must be ordered")
+    tiers = list(frame[tier_column].cat.categories)
+    grouped = frame.groupby([country_column, origin_column, tier_column], observed=False)[
+        [origin_population_column, endpoint_population_column]
+    ].sum(min_count=1)
+    wide0 = grouped[origin_population_column].unstack(tier_column).reindex(columns=tiers)
+    wide1 = grouped[endpoint_population_column].unstack(tier_column).reindex(columns=tiers)
+    rows: list[dict[str, object]] = []
+    for key in wide0.index:
+        start = wide0.loc[key]
+        end = wide1.loc[key]
+        for split in range(1, len(tiers)):
+            left = tiers[:split]
+            right = tiers[split:]
+            valid = start[left + right].notna().all() and end[left + right].notna().all()
+            row = {
+                country_column: key[0],
+                origin_column: key[1],
+                "balance_index": split,
+                "left_tiers": "|".join(map(str, left)),
+                "right_tiers": "|".join(map(str, right)),
+                "ilr_eligible": bool(valid),
+                "exclusion_reason": None if valid else "empty_origin_fixed_tier_cell",
+                balance_name: np.nan,
+            }
+            if valid:
+                scale = np.sqrt(len(left) * len(right) / (len(left) + len(right)))
+                ilr0 = scale * (np.log(start[left]).mean() - np.log(start[right]).mean())
+                ilr1 = scale * (np.log(end[left]).mean() - np.log(end[right]).mean())
+                row[balance_name] = ilr1 - ilr0
+            rows.append(row)
+    return pd.DataFrame(rows)

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -1,0 +1,34 @@
+import pandas as pd
+import pytest
+
+from urban_growth.accessibility import mutually_exclusive_rival_mass
+from urban_growth.io import SourceSchemaError
+
+
+def test_rival_mass_bands_are_mutually_exclusive() -> None:
+    pairs = pd.DataFrame(
+        {
+            "focal_city_id": ["a"] * 5,
+            "rival_city_id": ["b", "c", "d", "e", "f"],
+            "travel_time_hours": [0.5, 1.0, 1.99, 2.0, 7.99],
+            "rival_population": [10, 20, 30, 40, 50],
+        }
+    )
+    result = mutually_exclusive_rival_mass(pairs, nominal_vintage=2015).iloc[0]
+    assert result["rival_mass_0_1h"] == 10
+    assert result["rival_mass_1_2h"] == 50
+    assert result["rival_mass_2_4h"] == 40
+    assert result["rival_mass_4_8h"] == 50
+
+
+def test_accessibility_rejects_historical_vintage() -> None:
+    pairs = pd.DataFrame(
+        {
+            "focal_city_id": ["a"],
+            "rival_city_id": ["b"],
+            "travel_time_hours": [1.0],
+            "rival_population": [10],
+        }
+    )
+    with pytest.raises(SourceSchemaError, match="modern validation"):
+        mutually_exclusive_rival_mass(pairs, nominal_vintage=1990)

--- a/tests/test_census_threshold.py
+++ b/tests/test_census_threshold.py
@@ -1,0 +1,43 @@
+import pandas as pd
+import pytest
+
+from urban_growth.census_threshold import (
+    classify_threshold_measurement_band,
+    entry_delay_interval,
+    validate_boundary_cohort,
+)
+from urban_growth.io import SourceSchemaError
+
+
+def test_entry_delay_bounds_are_open_and_correct() -> None:
+    interval = entry_delay_interval(
+        crossing_lower=2000, crossing_upper=2010, entry_lower=2005, entry_upper=2015
+    )
+    assert interval.lower == -5
+    assert interval.upper == 15
+
+
+def test_threshold_uncertainty_band() -> None:
+    result = classify_threshold_measurement_band(pd.Series([47_499, 47_500, 52_499, 52_500]))
+    assert result.astype(str).tolist() == [
+        "clearly_below",
+        "threshold_uncertain",
+        "threshold_uncertain",
+        "clearly_above",
+    ]
+
+
+def test_boundary_cohort_rejects_unresolved_geography() -> None:
+    frame = pd.DataFrame(
+        {
+            "settlement_id": ["a"],
+            "country_code": ["X"],
+            "origin_year": [2000],
+            "endpoint_year": [2010],
+            "population_origin": [40_000],
+            "population_endpoint": [60_000],
+            "geography_status": ["unresolved"],
+        }
+    )
+    with pytest.raises(SourceSchemaError, match="unresolved"):
+        validate_boundary_cohort(frame)

--- a/tests/test_form_timing.py
+++ b/tests/test_form_timing.py
@@ -1,0 +1,20 @@
+import pandas as pd
+
+from urban_growth.form_timing import build_form_timing_rows
+
+
+def test_form_timing_separates_contemporaneous_and_lead_lag_rows() -> None:
+    frame = pd.DataFrame(
+        {
+            "city_id": ["a", "a", "a"],
+            "period_start": [2000, 2005, 2015],
+            "period_end": [2005, 2010, 2020],
+            "population_growth": [0.01, 0.02, 0.03],
+            "form_change": [0.02, 0.03, 0.04],
+        }
+    )
+    result = build_form_timing_rows(frame)
+    assert len(result["C1"]) == 3
+    assert result["C2"]["period_start"].tolist() == [2005]
+    assert result["C3"]["period_start"].tolist() == [2005]
+    assert result["C3"]["timing_specification"].eq("C3_form_leads_population").all()

--- a/tests/test_hierarchy.py
+++ b/tests/test_hierarchy.py
@@ -1,0 +1,70 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from urban_growth.hierarchy import assign_origin_tiers, fixed_membership_ilr_balance
+from urban_growth.io import SourceSchemaError
+
+
+def test_origin_tiers_do_not_use_endpoint_population() -> None:
+    frame = pd.DataFrame(
+        {
+            "city_id": ["a", "b", "c"],
+            "country_code": ["X"] * 3,
+            "period_start": [2000] * 3,
+            "population_start": [1_000_000, 200_000, 40_000],
+            "population_end": [10_000, 300_000, 2_000_000],
+        }
+    )
+    result = assign_origin_tiers(frame)
+    assert result["rank_origin"].tolist() == [1, 2, 3]
+    assert result["tier_abs_origin"].astype(str).tolist() == ["1m+", "100-250k", "<50k"]
+    assert result["tier_assignment_timing"].eq("forecast_origin_fixed").all()
+
+
+def test_origin_rank_ties_break_on_stable_city_id() -> None:
+    frame = pd.DataFrame(
+        {
+            "city_id": ["b", "a"],
+            "country_code": ["X", "X"],
+            "period_start": [2000, 2000],
+            "population_start": [100_000, 100_000],
+        }
+    )
+    result = assign_origin_tiers(frame).set_index("city_id")
+    assert result.loc["a", "rank_origin"] == 1
+    assert result.loc["b", "rank_origin"] == 2
+
+
+def test_ilr_uses_fixed_membership_and_reports_empty_cells() -> None:
+    frame = pd.DataFrame(
+        {
+            "country_code": ["X", "X"],
+            "period_start": [2000, 2000],
+            "tier": pd.Categorical(["large", "small"], categories=["large", "small"], ordered=True),
+            "population_start": [100.0, 100.0],
+            "population_end": [200.0, 100.0],
+        }
+    )
+    result = fixed_membership_ilr_balance(frame, tier_column="tier")
+    assert result.loc[0, "tier_ilr_change"] == pytest.approx(np.log(2) / np.sqrt(2))
+    assert bool(result.loc[0, "ilr_eligible"])
+
+    sparse = frame.loc[frame["tier"] == "large"]
+    result = fixed_membership_ilr_balance(sparse, tier_column="tier")
+    assert not bool(result.loc[0, "ilr_eligible"])
+    assert result.loc[0, "exclusion_reason"] == "empty_origin_fixed_tier_cell"
+
+
+def test_ilr_rejects_unordered_tier() -> None:
+    frame = pd.DataFrame(
+        {
+            "country_code": ["X"],
+            "period_start": [2000],
+            "tier": ["large"],
+            "population_start": [100.0],
+            "population_end": [110.0],
+        }
+    )
+    with pytest.raises(SourceSchemaError, match="ordered categorical"):
+        fixed_membership_ilr_balance(frame, tier_column="tier")

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -13,11 +13,14 @@ from urban_growth.sources import (
 
 def test_repository_catalog_is_valid() -> None:
     catalog = load_catalog("data/sources.json")
-    assert len(catalog["sources"]) == 9
+    assert len(catalog["sources"]) == 10
     ghsl = source_by_id(catalog, "ec_ghsl_ucdb_r2024a_v1_2")
     wup = source_by_id(catalog, "un_wup_2025_cities")
     assert "ec_ghsl_degurb_r2023a" in ghsl["upstream_dependencies"]
     assert "ec_ghsl_degurb_r2023a" in wup["upstream_dependencies"]
+    accessibility = source_by_id(catalog, "map_accessibility_2015")
+    assert accessibility["release"] == "2015 nominal year"
+    assert accessibility["status"] == "modern_validation"
 
 
 def test_duplicate_source_ids_fail() -> None:


### PR DESCRIPTION
## Summary
- adopts the 29 August 2026 quality-review specification as the governing empirical contract
- adds tested forecast-origin hierarchy and ILR utilities
- adds census-threshold interval-censoring and geography gates
- adds modern mutually exclusive accessibility bands and C1/C2/C3 form timing
- registers MAP 2015 as a modern snapshot and records the India historical-only/deferred feasibility decision

## Validation
- `uv run --locked --extra dev ruff check .`
- `uv run --locked --extra dev pytest -q` — 96 passed
- `git diff --check`

## Scope boundary
This merges design enforcement and unit-tested transformations. It does not fabricate unavailable census concordances, historical travel-time data, independent morphology lineage, or a completed finite-T estimator simulation.