### PR TITLE
Add lean collaboration and review baseline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Final review currently remains with the repository owner.
+* @danielastone
+
+# Changes to source rights need explicit owner review even when code is unchanged.
+/LICENSE @danielastone
+/THIRD_PARTY_DATA.md @danielastone
+/data/licenses.json @danielastone
+/data/sources.json @danielastone

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Implementation roadmap
+    url: https://github.com/danielastone/Global-Urban-Growth-Lab/issues/33
+    about: Check priorities, dependencies, and manual blocks before proposing work.

--- a/.github/ISSUE_TEMPLATE/implementation.yml
+++ b/.github/ISSUE_TEMPLATE/implementation.yml
@@ -1,0 +1,56 @@
+name: Implementation task
+description: Propose a bounded code, test, documentation, or reproducibility change.
+title: "[Implementation] "
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Use one issue for one bounded outcome. Do not use this form to bypass a manual
+        source, licensing, geography, or governance decision.
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: State the concrete outcome, not a broad topic.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence or failure being addressed
+      description: Link the result, test, specification section, or reproducible failure.
+    validations:
+      required: true
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Proposed implementation
+      description: Identify expected code, tests, and documentation changes.
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies and manual blocks
+      description: Name blocking issues and any required human decision or source acquisition.
+      placeholder: "None identified, or #issue and required evidence"
+    validations:
+      required: true
+  - type: textarea
+    id: done
+    attributes:
+      label: Definition of done
+      description: List observable completion and falsification criteria.
+    validations:
+      required: true
+  - type: checkboxes
+    id: safeguards
+    attributes:
+      label: Safeguards
+      options:
+        - label: I searched existing issues and pull requests for overlap.
+          required: true
+        - label: This issue does not require committing restricted or uncertain data.
+          required: true
+        - label: The proposed result language will not exceed the evidence.
+          required: true

--- a/.github/ISSUE_TEMPLATE/manual-block.yml
+++ b/.github/ISSUE_TEMPLATE/manual-block.yml
@@ -1,0 +1,46 @@
+name: Manual block or source decision
+description: Record work that cannot be resolved legitimately by code alone.
+title: "[Manual block] "
+body:
+  - type: dropdown
+    id: block_type
+    attributes:
+      label: Block type
+      options:
+        - Data acquisition or access
+        - Licensing or redistribution rights
+        - Geography or crosswave concordance
+        - Source-method or lineage review
+        - GitHub governance or permissions
+        - Future data or elapsed-time dependency
+    validations:
+      required: true
+  - type: textarea
+    id: decision
+    attributes:
+      label: Decision or evidence required
+      description: State exactly what a person must obtain, inspect, or approve.
+    validations:
+      required: true
+  - type: textarea
+    id: blocked
+    attributes:
+      label: Work and claims blocked
+      description: Link affected issues and identify claims that must remain unresolved.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptable
+    attributes:
+      label: Acceptable evidence
+      description: Define what must be attached or linked before the block can close.
+    validations:
+      required: true
+  - type: textarea
+    id: prohibited
+    attributes:
+      label: Prohibited workaround
+      description: Identify shortcuts that would create false completion.
+      placeholder: "For example: name-only boundary matching or assuming redistribution rights."
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+## Objective
+
+<!-- What bounded problem does this PR solve? -->
+
+Closes #
+
+Gate advanced:
+
+## Changes
+
+- 
+
+## Evidence
+
+<!-- Commands, simulations, output dimensions/hashes, or source-method evidence. -->
+
+## Review checklist
+
+- [ ] Scope is limited to one bounded issue.
+- [ ] Tests and lint pass locally.
+- [ ] New or changed behavior has tests.
+- [ ] Documentation and expected manifests are updated where needed.
+- [ ] Empirical comparisons use the declared common sample.
+- [ ] Null, conflicting, and sensitivity results are reported rather than selected away.
+- [ ] No restricted or redistribution-uncertain data is committed.
+- [ ] Source and license registries are updated for any new data dependency.
+- [ ] Generated outputs are reproducible from registered inputs.
+- [ ] Claim/status language does not exceed the evidence.
+
+## Manual review required
+
+<!-- List unresolved licensing, geography, source-method, or governance decisions. Use
+"None" only after checking. A manual block cannot be closed by placeholder code. -->
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .venv/
 __pycache__/
+*.egg-info/
 *.py[cod]
 .pytest_cache/
 .ruff_cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing
+
+This repository is a pre-conclusion research program. Contributions are welcome, but
+the priority is reproducible evidence—not feature volume or stronger-sounding claims.
+
+## Before starting
+
+1. Read the [implementation roadmap](https://github.com/danielastone/Global-Urban-Growth-Lab/issues/33).
+2. Search existing issues and pull requests before opening another.
+3. For substantial work, open or claim one bounded issue before writing code.
+4. Do not code around an issue marked **MANUAL BLOCK**. Attach the required source,
+   licensing, governance, or methodological evidence to the issue first.
+
+Work on synthetic tests and infrastructure may proceed while empirical inputs are
+blocked, but it must not be presented as an empirical result.
+
+## Development setup
+
+This project uses Python 3.11 or later and locks dependencies with `uv`.
+
+```bash
+uv sync --locked --extra dev
+uv run --locked --extra dev pytest -q
+uv run --locked --extra dev ruff check .
+uv run --locked --extra dev urban-growth-sources verify-licenses
+```
+
+## Pull requests
+
+- Keep one bounded issue per pull request.
+- Link the issue and state which research or implementation gate the change advances.
+- Use one analytic sample for estimator comparisons unless the specification explicitly
+  requires otherwise.
+- Add tests for code and machine-readable checks for data or metadata changes.
+- Update documentation, expected manifests, and the claim status when results change.
+- Report conflicting or null results. Do not select specifications by preferred sign.
+- Separate generated artifacts from source data and document how to reproduce them.
+
+A pull request is not complete merely because CI passes. Methodological judgment,
+source rights, and empirical interpretation may still require review.
+
+## Data and licensing
+
+Apache-2.0 covers repository software only. Before acquiring or using a dataset:
+
+1. Register the exact source and release in `data/sources.json`.
+2. Record the intended uses and controlling terms in `data/licenses.json`.
+3. Add acquired-file provenance and SHA-256 hashes to the local manifest.
+4. Run the license checks for the intended operation.
+
+Do not commit raw, restricted, employer-owned, personally identifiable, or
+redistribution-uncertain data. See [THIRD_PARTY_DATA.md](THIRD_PARTY_DATA.md).
+
+## Research claims
+
+Treat every result as provisional until its inputs, geography, timing, sample,
+estimator, and validation status are reproducible. A contribution that weakens a
+headline claim is useful if it is correct. A contribution that hides a failed gate is
+not acceptable.
+
+## Review ownership
+
+The repository owner currently performs final review. `CODEOWNERS` requests that
+review automatically; it does not replace branch protection or the required CI check.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Repository software is licensed under Apache-2.0. Third-party datasets are not.
 See [THIRD_PARTY_DATA.md](THIRD_PARTY_DATA.md) before acquiring, processing, or
 redistributing data.
 
+Contributions should begin with [CONTRIBUTING.md](CONTRIBUTING.md) and the
+[implementation roadmap](https://github.com/danielastone/Global-Urban-Growth-Lab/issues/33).
+The project accepts code, documentation, reproducibility, and falsification work, but
+manual data, licensing, geography, and governance blocks require evidence before code.
+
 ## Research question
 
 How much incremental out-of-sample forecasting value comes from a city's recent growth, initial size, hierarchy position, national demography, urbanization stage, spatial context, and common shocks?


### PR DESCRIPTION
## Objective

Create the minimum GitHub-native workflow needed for current and future collaborators while preserving the project’s evidence and manual-block discipline.

Closes #35

Gate advanced: collaboration readiness; supports the one-issue-per-PR discipline in #33.

## Changes

- add a contributor guide with setup, research-claim, data-rights, and PR rules
- add implementation and manual-block issue forms
- add a pull-request evidence checklist
- add CODEOWNERS for current owner review
- link the workflow from the README
- ignore generated `*.egg-info` metadata

## Evidence

- `uv run --locked --extra dev pytest -q` — 102 passed
- `uv run --locked --extra dev ruff check .` — passed
- `uv run --locked --extra dev urban-growth-sources verify-licenses` — 10 decisions valid; default deny
- all issue-template YAML files parsed successfully
- `git diff --check` — passed

## Manual review required

- #26 remains the manual branch-protection gate. CODEOWNERS does not enforce required review by itself.
- Confirm that `@danielastone` is the intended sole initial code owner.

## Deliberate exclusions

No broad label taxonomy, milestones, code of conduct, commercial governance, or private-repository architecture. Those do not currently justify their maintenance cost.