### PR TITLE
Update core GitHub Actions to v7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
## Objective

Update the two core GitHub Actions on a branch based on current `main`.

Closes #37

## Changes

- `actions/checkout`: v4 → v7
- `actions/setup-python`: v5 → v7

## Validation

GitHub Actions must run the repository’s lint, licensing-registry validation, and 102-test suite. This PR is also the acceptance test for #26: it must merge under the required `test` check without administrator bypass.

## Supersedes

Dependabot PRs #7 and #8, which are stale relative to `main`.