### PR TITLE
Flag undefined national focal-city subtraction

### DIFF
--- a/docs/data-contract.md
+++ b/docs/data-contract.md
@@ -115,14 +115,18 @@ as clean real-time forecast accuracy.
 The primary WUP F01 national comparator subtracts the focal F21 city population from
 both the lag and origin national Cities-category totals before calculating growth.
 The unadjusted national comparator is retained only as a mechanical self-inclusion
-diagnostic. Residual national totals must remain strictly positive or the workflow
-fails.
+diagnostic. Where either residual national total is nonpositive, the subtraction is
+not mathematically or compositionally valid: the leave-city-out value is missing and
+the row carries `national_focal_subtraction_valid = false` plus an endpoint-specific
+status. Rolling comparisons use the common sample on which every scored baseline is
+finite; they do not manufacture a residual for singleton, rounded-equal, or
+cross-border urban systems.
 
 This subtraction uses F21 and F01 from the same WUP 2025 revision, but direct
 component membership is assumed rather than independently crosswalk-validated.
-Outputs therefore carry national_focal_component_membership_assumed. The diagnostic
-removes arithmetic self-inclusion; it does not create causal exogeneity or make the
-revised history vintage-correct.
+Outputs therefore carry `national_focal_component_membership_assumed`. The diagnostic
+removes arithmetic self-inclusion only where `national_focal_subtraction_valid` is
+true; it does not create causal exogeneity or make the revised history vintage-correct.
 
 
 ## Temporal and geographic weighting estimands

--- a/src/urban_growth/forecast.py
+++ b/src/urban_growth/forecast.py
@@ -175,13 +175,31 @@ def attach_national_city_category_baseline(
     national_lag = national_lookup.reindex(lag_lookup).to_numpy()
     residual_origin = national_origin - result["population_start"].to_numpy()
     residual_lag = national_lag - result["population_lag"].to_numpy()
-    if (residual_origin <= 0).any() or (residual_lag <= 0).any():
-        raise SourceSchemaError(
-            "Focal city is not a strictly smaller positive component of national Cities totals"
-        )
-    result["national_city_category_recent_growth_leave_city_out"] = (
-        np.log(residual_origin) - np.log(residual_lag)
+    valid_origin = residual_origin > 0
+    valid_lag = residual_lag > 0
+    valid_subtraction = valid_origin & valid_lag
+    leave_city_out = np.full(len(result), np.nan, dtype=float)
+    leave_city_out[valid_subtraction] = (
+        np.log(residual_origin[valid_subtraction])
+        - np.log(residual_lag[valid_subtraction])
     ) / lookback_years
+    result["national_city_category_recent_growth_leave_city_out"] = leave_city_out
+    result["national_focal_subtraction_valid"] = valid_subtraction
+    result["national_focal_subtraction_status"] = np.select(
+        [
+            valid_subtraction,
+            ~valid_origin & ~valid_lag,
+            ~valid_origin,
+            ~valid_lag,
+        ],
+        [
+            "valid_positive_residuals",
+            "nonpositive_both_endpoints",
+            "nonpositive_origin_residual",
+            "nonpositive_lag_residual",
+        ],
+        default="unclassified",
+    )
     result["national_focal_share_origin"] = (
         result["population_start"].to_numpy() / national_origin
     )
@@ -190,7 +208,7 @@ def attach_national_city_category_baseline(
     )
     result["national_baseline_revision_semantics"] = "WUP_2025_revised_history"
     result["national_baseline_uses_future_value"] = False
-    result["national_baseline_focal_city_excluded"] = True
+    result["national_baseline_focal_city_excluded"] = valid_subtraction
     result["national_focal_component_membership_assumed"] = True
     result["national_focal_subtraction_semantics"] = (
         "F21_city_subtracted_from_F01_Cities_same_revision"

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -236,6 +236,11 @@ def test_national_city_category_baseline_uses_only_pre_origin_values() -> None:
     assert attached["national_focal_share_lag"].iloc[0] == pytest.approx(0.10)
     assert attached["national_focal_share_origin"].iloc[0] == pytest.approx(20 / 110)
     assert attached["national_baseline_focal_city_excluded"].iloc[0]
+    assert attached["national_focal_subtraction_valid"].iloc[0]
+    assert (
+        attached["national_focal_subtraction_status"].iloc[0]
+        == "valid_positive_residuals"
+    )
     assert attached["national_focal_component_membership_assumed"].iloc[0]
     assert not attached["national_baseline_uses_future_value"].iloc[0]
     assert attached["subregion_id"].tolist() == [10]
@@ -244,7 +249,7 @@ def test_national_city_category_baseline_uses_only_pre_origin_values() -> None:
 
 
 
-def test_national_leave_city_out_rejects_invalid_component_subtraction() -> None:
+def test_national_leave_city_out_flags_invalid_component_subtraction() -> None:
     intervals = pd.DataFrame(
         {
             "country_code": ["A"],
@@ -265,8 +270,18 @@ def test_national_leave_city_out_rejects_invalid_component_subtraction() -> None
             "region_name": ["Example region"] * 2,
         }
     )
-    with pytest.raises(SourceSchemaError, match="strictly smaller positive component"):
-        attach_national_city_category_baseline(intervals, national)
+    attached = attach_national_city_category_baseline(intervals, national)
+    assert pd.isna(
+        attached["national_city_category_recent_growth_leave_city_out"].iloc[0]
+    )
+    assert not attached["national_focal_subtraction_valid"].iloc[0]
+    assert not attached["national_baseline_focal_city_excluded"].iloc[0]
+    assert (
+        attached["national_focal_subtraction_status"].iloc[0]
+        == "nonpositive_both_endpoints"
+    )
+    assert attached["national_focal_share_lag"].iloc[0] == pytest.approx(1.0)
+    assert attached["national_focal_share_origin"].iloc[0] == pytest.approx(120 / 110)
 
 def test_baselines_include_attached_national_demographic_comparator() -> None:
     train = pd.DataFrame({"country_code": ["A"], "future_growth": [0.01]})


### PR DESCRIPTION
## Objective

Keep exact-input WUP regeneration executable without fabricating a leave-focal-city-out national total where subtraction is undefined.

Closes #39

Gate advanced: #1 exact-input regeneration.

## Changes

- compute the leave-city-out comparator only for positive lag and origin residuals
- flag subtraction validity and endpoint-specific failure status
- leave invalid diagnostics missing
- retain focal shares and the inclusive comparator for audit
- document common-sample scoring and the singleton/rounding/cross-border limitation
- replace the abort-only unit test with explicit valid/invalid-state tests

## Evidence

- all eight official downloads match the committed SHA-256 hashes
- failure reproduced on 264 city-origin rows, 55 countries, and 55 focal cities
- `uv run --locked --extra dev pytest -q` — 102 passed
- `uv run --locked --extra dev ruff check .` — passed
- `scripts/run_wup_baselines.py` completes after the change

## Manual review required

Expected result manifests intentionally remain unchanged. Regenerated WUP results differ because the prior manifest predates valid common-sample enforcement; those numerical changes require a separate review before acceptance.