### PR TITLE
Add bootstrap inference for bias-corrected dynamic estimates

### DIFF
--- a/docs/research-status.md
+++ b/docs/research-status.md
@@ -20,16 +20,18 @@ The locked hierarchy now has a machine-readable registry and one common-sample c
 It fits the pooled predictive benchmark, the Nickell-biased city fixed-effect diagnostic, and
 a split-panel-jackknife finite-T correction with country-period fixed effects. The first two
 return a country-and-period two-way sandwich covariance. The corrected estimator deliberately
-returns no analytic standard error: a panel bootstrap must be implemented and validated rather
-than pretending the uncorrected sandwich applies to a nonlinear bias correction.
+returns no analytic standard error. A separate product-exponential multiplier bootstrap
+perturbs country and period dimensions independently while preserving city time order and
+recomputing the full correction. Runs below 399 replications are marked non-production.
 
 `scripts/run_dynamic_estimator_simulation.py` spans persistence values 0.2, 0.6, and 0.9 and
 panel lengths 6, 8, and 10 under a fixed seed. It reports estimator bias and RMSE rather than
 assuming the correction improves every draw. Restricted dynamic GMM remains registered but
 unimplemented; it is not an automatic fourth model and cannot be run unless instrument-strength
 and proliferation gates are specified. Issue #27 remains open until empirical estimates use
-identical full-sample rows, bootstrap inference is available for the corrected estimator, and
-the simulation gate is evaluated at production replication counts.
+identical full-sample rows, the multiplier interval's coverage is evaluated in the declared
+simulation grid, and the simulation gate is evaluated at production replication counts. The
+presence of a bootstrap interval is not evidence that its finite-sample coverage is adequate.
 
 ## Evidence state
 

--- a/scripts/run_dynamic_estimator_bootstrap.py
+++ b/scripts/run_dynamic_estimator_bootstrap.py
@@ -1,0 +1,46 @@
+"""Fit the locked dynamic hierarchy and multiplier-bootstrap its uncertainty."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from urban_growth.dynamic_estimators import (
+    bootstrap_dynamic_hierarchy,
+    common_dynamic_sample,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--outcome", required=True)
+    parser.add_argument("--lagged-outcome", required=True)
+    parser.add_argument("--covariate", action="append", default=[])
+    parser.add_argument("--city", default="city_id")
+    parser.add_argument("--country", default="country_code")
+    parser.add_argument("--period", default="period")
+    parser.add_argument("--replications", type=int, default=999)
+    parser.add_argument("--confidence-level", type=float, default=0.95)
+    parser.add_argument("--seed", type=int, default=2718)
+    args = parser.parse_args()
+    source = pd.read_csv(args.input)
+    sample = common_dynamic_sample(
+        source, outcome=args.outcome, lagged_outcome=args.lagged_outcome,
+        covariates=args.covariate, city=args.city, country=args.country, period=args.period,
+    )
+    result = bootstrap_dynamic_hierarchy(
+        sample, outcome=args.outcome, lagged_outcome=args.lagged_outcome,
+        covariates=args.covariate, city=args.city, country=args.country, period=args.period,
+        replications=args.replications, confidence_level=args.confidence_level, seed=args.seed,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    result.to_csv(args.output, index=False)
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/urban_growth/dynamic_estimators.py
+++ b/src/urban_growth/dynamic_estimators.py
@@ -122,28 +122,39 @@ def _fit_ols(
     country: str,
     period: str,
     city_fixed_effects: bool,
+    weights: np.ndarray | None = None,
 ) -> pd.DataFrame:
     y, x, names = _design(
         sample, outcome=outcome, lagged_outcome=lagged_outcome, covariates=covariates,
         city=city, city_fixed_effects=city_fixed_effects,
     )
-    beta = np.linalg.lstsq(x, y, rcond=None)[0]
+    if weights is None:
+        fit_x, fit_y = x, y
+    else:
+        weights = np.asarray(weights, dtype=float)
+        if len(weights) != len(sample) or not np.isfinite(weights).all() or (weights <= 0).any():
+            raise SourceSchemaError("Estimator weights must be finite, positive, and row-aligned")
+        root_weight = np.sqrt(weights)
+        fit_x, fit_y = x * root_weight[:, None], y * root_weight
+    beta = np.linalg.lstsq(fit_x, fit_y, rcond=None)[0]
     residual = y - x @ beta
-    bread = np.linalg.pinv(x.T @ x)
-    country_meat = _cluster_meat(x, residual, sample[country])
-    period_meat = _cluster_meat(x, residual, sample[period])
-    intersection = sample[country].astype(str) + "::" + sample[period].astype(str)
-    covariance = bread @ (
-        country_meat + period_meat - _cluster_meat(x, residual, intersection)
-    ) @ bread
     target_count = 1 + len(covariates)
+    if weights is None:
+        bread = np.linalg.pinv(x.T @ x)
+        country_meat = _cluster_meat(x, residual, sample[country])
+        period_meat = _cluster_meat(x, residual, sample[period])
+        intersection = sample[country].astype(str) + "::" + sample[period].astype(str)
+        covariance = bread @ (
+            country_meat + period_meat - _cluster_meat(x, residual, intersection)
+        ) @ bread
+        standard_errors = np.sqrt(np.maximum(np.diag(covariance)[:target_count], 0.0))
+    else:
+        standard_errors = np.repeat(np.nan, target_count)
     return pd.DataFrame(
         {
             "term": names[:target_count],
             "estimate": beta[:target_count],
-            "std_error_country_period": np.sqrt(
-                np.maximum(np.diag(covariance)[:target_count], 0.0)
-            ),
+            "std_error_country_period": standard_errors,
             "n_rows": len(sample),
             "n_cities": sample[city].nunique(),
             "n_periods": sample[period].nunique(),
@@ -160,17 +171,18 @@ def fit_dynamic_hierarchy(
     city: str = "city_id",
     country: str = "country_code",
     period: str = "period",
+    weights: np.ndarray | None = None,
 ) -> pd.DataFrame:
     """Fit pooled, city-FE, and split-panel-jackknife estimates on one full sample."""
     required = {outcome, lagged_outcome, city, country, period, "country_period", *covariates}
     require_columns(sample, required, source_name="dynamic common sample")
     pooled = _fit_ols(
         sample, outcome=outcome, lagged_outcome=lagged_outcome, covariates=covariates,
-        city=city, country=country, period=period, city_fixed_effects=False,
+        city=city, country=country, period=period, city_fixed_effects=False, weights=weights,
     ).assign(estimator_id="pooled_dynamic")
     fixed = _fit_ols(
         sample, outcome=outcome, lagged_outcome=lagged_outcome, covariates=covariates,
-        city=city, country=country, period=period, city_fixed_effects=True,
+        city=city, country=country, period=period, city_fixed_effects=True, weights=weights,
     ).assign(estimator_id="city_fe_dynamic")
     periods = sorted(sample[period].unique())
     if len(periods) < 4:
@@ -179,7 +191,8 @@ def fit_dynamic_hierarchy(
     halves = [periods[:midpoint], periods[midpoint:]]
     half_estimates = []
     for half in halves:
-        half_sample = sample.loc[sample[period].isin(half)].copy()
+        half_mask = sample[period].isin(half).to_numpy()
+        half_sample = sample.loc[half_mask].copy()
         if half_sample.groupby(city)[city].size().min() < 2:
             raise SourceSchemaError("Each jackknife half requires two observations per city")
         half_estimates.append(
@@ -187,6 +200,7 @@ def fit_dynamic_hierarchy(
                 half_sample, outcome=outcome, lagged_outcome=lagged_outcome,
                 covariates=covariates, city=city, country=country, period=period,
                 city_fixed_effects=True,
+                weights=None if weights is None else np.asarray(weights)[half_mask],
             ).set_index("term")["estimate"]
         )
     corrected = fixed.copy()
@@ -204,6 +218,74 @@ def fit_dynamic_hierarchy(
     )
     registry = estimator_registry()[["estimator_id", "estimand", "role", "bias_correction"]]
     return result.merge(registry, on="estimator_id", validate="many_to_one")
+
+
+def bootstrap_dynamic_hierarchy(
+    sample: pd.DataFrame,
+    *,
+    outcome: str,
+    lagged_outcome: str,
+    covariates: list[str],
+    city: str = "city_id",
+    country: str = "country_code",
+    period: str = "period",
+    replications: int = 999,
+    confidence_level: float = 0.95,
+    seed: int = 2718,
+) -> pd.DataFrame:
+    """Infer uncertainty using country-by-period product multiplier weights.
+
+    Positive exponential multipliers preserve every city's ordered history and the fixed-effect
+    design while perturbing the two declared dependence dimensions independently. Runs below
+    399 replications are allowed for tests but are marked non-production.
+    """
+    if replications < 20:
+        raise SourceSchemaError("Dynamic bootstrap requires at least 20 replications")
+    if not 0.5 < confidence_level < 1:
+        raise SourceSchemaError("Bootstrap confidence_level must be between 0.5 and 1")
+    required = {outcome, lagged_outcome, city, country, period, "country_period", *covariates}
+    require_columns(sample, required, source_name="dynamic bootstrap sample")
+    countries = pd.Index(sample[country].drop_duplicates())
+    periods = pd.Index(sample[period].drop_duplicates())
+    if len(countries) < 2 or len(periods) < 4:
+        raise SourceSchemaError("Dynamic bootstrap requires two countries and four periods")
+    point = fit_dynamic_hierarchy(
+        sample, outcome=outcome, lagged_outcome=lagged_outcome, covariates=covariates,
+        city=city, country=country, period=period,
+    )[["estimator_id", "term", "estimate"]]
+    rng = np.random.default_rng(seed)
+    draws = []
+    for replication in range(replications):
+        country_weights = pd.Series(rng.exponential(size=len(countries)), index=countries)
+        period_weights = pd.Series(rng.exponential(size=len(periods)), index=periods)
+        country_weights /= country_weights.mean()
+        period_weights /= period_weights.mean()
+        row_weights = (
+            sample[country].map(country_weights).to_numpy()
+            * sample[period].map(period_weights).to_numpy()
+        )
+        estimate = fit_dynamic_hierarchy(
+            sample, outcome=outcome, lagged_outcome=lagged_outcome, covariates=covariates,
+            city=city, country=country, period=period, weights=row_weights,
+        )[["estimator_id", "term", "estimate"]]
+        estimate["replication"] = replication
+        draws.append(estimate)
+    draw_frame = pd.concat(draws, ignore_index=True)
+    alpha = (1 - confidence_level) / 2
+    summary = draw_frame.groupby(["estimator_id", "term"], as_index=False).agg(
+        bootstrap_std_error=("estimate", "std"),
+        confidence_lower=("estimate", lambda values: values.quantile(alpha)),
+        confidence_upper=("estimate", lambda values: values.quantile(1 - alpha)),
+    )
+    result = point.rename(columns={"estimate": "point_estimate"}).merge(
+        summary, on=["estimator_id", "term"], validate="one_to_one"
+    )
+    result["bootstrap_method"] = "country-period product exponential multiplier"
+    result["confidence_level"] = confidence_level
+    result["replications"] = replications
+    result["seed"] = seed
+    result["production_replications"] = replications >= 399
+    return result
 
 
 def estimator_disagreement_report(

--- a/tests/test_dynamic_estimators.py
+++ b/tests/test_dynamic_estimators.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 from urban_growth.dynamic_estimators import (
+    bootstrap_dynamic_hierarchy,
     common_dynamic_sample,
     estimator_disagreement_report,
     estimator_registry,
@@ -110,3 +111,37 @@ def test_simulation_grid_reports_bias_without_guaranteeing_correction_wins() -> 
     }
     assert result["replications"].eq(2).all()
     assert result[["mean_estimate", "bias", "rmse"]].notna().all().all()
+
+
+def test_multiplier_bootstrap_is_deterministic_and_covers_corrected_estimator() -> None:
+    sample = common_dynamic_sample(
+        simulated_panel(cities=24), outcome="growth", lagged_outcome="lagged_growth",
+        covariates=["x"],
+    )
+    first = bootstrap_dynamic_hierarchy(
+        sample, outcome="growth", lagged_outcome="lagged_growth", covariates=["x"],
+        replications=20, seed=11,
+    )
+    second = bootstrap_dynamic_hierarchy(
+        sample, outcome="growth", lagged_outcome="lagged_growth", covariates=["x"],
+        replications=20, seed=11,
+    )
+    pd.testing.assert_frame_equal(first, second)
+    assert len(first) == 6
+    corrected = first.loc[first["estimator_id"].eq("half_panel_jackknife")]
+    assert corrected["bootstrap_std_error"].gt(0).all()
+    assert corrected["confidence_lower"].lt(corrected["point_estimate"]).all()
+    assert corrected["confidence_upper"].gt(corrected["point_estimate"]).all()
+    assert not first["production_replications"].any()
+
+
+def test_multiplier_bootstrap_rejects_too_few_draws() -> None:
+    sample = common_dynamic_sample(
+        simulated_panel(cities=16), outcome="growth", lagged_outcome="lagged_growth",
+        covariates=["x"],
+    )
+    with pytest.raises(SourceSchemaError, match="at least 20"):
+        bootstrap_dynamic_hierarchy(
+            sample, outcome="growth", lagged_outcome="lagged_growth", covariates=["x"],
+            replications=19,
+        )


### PR DESCRIPTION
## Summary

- add positive weighted fitting across the dynamic-estimator hierarchy
- implement country-by-period product exponential multiplier bootstrap
- preserve city time order and recompute the full split-panel-jackknife correction per draw
- return deterministic bootstrap SEs and percentile intervals with method metadata
- mark runs below 399 replications as non-production
- add a generic command-line runner and tests
- retain interval coverage as an explicit unpassed simulation gate

Closes #49
Advances #27

## Verification

- `uv run --locked pytest` — 112 passed
- `uv run --locked ruff check .` — passed
- `git diff --check` — passed

## Limitation

This establishes a reproducible inference procedure, not that its nominal intervals attain adequate finite-sample coverage. Coverage validation remains required before empirical inference.