### PR TITLE
Predeclare and implement bootstrap coverage gate

### DIFF
--- a/docs/research-status.md
+++ b/docs/research-status.md
@@ -33,6 +33,15 @@ identical full-sample rows, the multiplier interval's coverage is evaluated in t
 simulation grid, and the simulation gate is evaluated at production replication counts. The
 presence of a bootstrap interval is not evidence that its finite-sample coverage is adequate.
 
+The coverage gate is now executable through `scripts/run_dynamic_bootstrap_coverage.py` and
+was specified before opening a production result. Each persistence-by-panel-length cell needs
+at least 200 simulated panels and 399 bootstrap draws. A nominal 95% interval passes only when
+the 95% Wilson interval around empirical coverage lies wholly within 90% to 99%; this rejects
+both material undercoverage and vacuously wide intervals. Smaller runs return a missing gate
+decision rather than a provisional pass. The command accepts repeated `--persistence` and
+`--panel-length` arguments so long runs can be split into auditable cells. No production
+coverage run has yet been accepted or recorded.
+
 ## Evidence state
 
 The source and transformation pipeline is reproducible from registered local files, but all results remain **retrospective current-revision tests**. The WUP and GHSL exercises use different city definitions and must not be pooled. WUP supplies demographic city records without a verified stable-polygon restriction. GHSL supplies a balanced panel calculated inside fixed 2025 polygons, but that definition uses future geographic information and is not vintage-correct. Neither is sufficient for a commercial forecasting claim.

--- a/scripts/run_dynamic_bootstrap_coverage.py
+++ b/scripts/run_dynamic_bootstrap_coverage.py
@@ -1,0 +1,45 @@
+"""Run the predeclared finite-sample coverage gate for dynamic estimators."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from urban_growth.dynamic_estimators import simulate_bootstrap_coverage
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output", type=Path, default=Path("outputs/dynamic_bootstrap_coverage.csv")
+    )
+    parser.add_argument("--simulation-replications", type=int, default=200)
+    parser.add_argument("--bootstrap-replications", type=int, default=399)
+    parser.add_argument("--cities", type=int, default=48)
+    parser.add_argument("--countries", type=int, default=6)
+    parser.add_argument("--seed", type=int, default=314159)
+    parser.add_argument(
+        "--persistence", action="append", type=float,
+        help="Repeat to run selected persistence cells; default: 0.2, 0.6, 0.9",
+    )
+    parser.add_argument(
+        "--panel-length", action="append", type=int,
+        help="Repeat to run selected panel-length cells; default: 6, 8, 10",
+    )
+    args = parser.parse_args()
+    result = simulate_bootstrap_coverage(
+        simulation_replications=args.simulation_replications,
+        bootstrap_replications=args.bootstrap_replications,
+        cities=args.cities,
+        countries=args.countries,
+        seed=args.seed,
+        persistence_values=tuple(args.persistence or (0.2, 0.6, 0.9)),
+        panel_lengths=tuple(args.panel_length or (6, 8, 10)),
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    result.to_csv(args.output, index=False)
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/urban_growth/dynamic_estimators.py
+++ b/src/urban_growth/dynamic_estimators.py
@@ -312,6 +312,55 @@ def estimator_disagreement_report(
     return report
 
 
+def _simulate_dynamic_panel(
+    rng: np.random.Generator,
+    *,
+    persistence: float,
+    panel_length: int,
+    cities: int,
+    countries: int,
+) -> pd.DataFrame:
+    country = np.repeat(np.arange(countries), cities // countries)
+    city_effect = rng.normal(0, 0.35, cities)
+    state = city_effect / (1 - persistence) + rng.normal(0, 0.3, cities)
+    rows = []
+    for time in range(30 + panel_length):
+        country_shock = rng.normal(0, 0.08, countries)
+        covariate = rng.normal(size=cities)
+        outcome = (
+            persistence * state + 0.3 * covariate + city_effect
+            + country_shock[country] + rng.normal(0, 0.25, cities)
+        )
+        if time >= 30:
+            for index in range(cities):
+                rows.append(
+                    {
+                        "city_id": index,
+                        "country_code": country[index],
+                        "period": time - 30,
+                        "growth": outcome[index],
+                        "lagged_growth": state[index],
+                        "x": covariate[index],
+                    }
+                )
+        state = outcome
+    return pd.DataFrame(rows)
+
+
+def _validate_simulation_design(
+    persistence_values: tuple[float, ...],
+    panel_lengths: tuple[int, ...],
+    cities: int,
+    countries: int,
+) -> None:
+    if cities % countries or cities // countries < 2:
+        raise SourceSchemaError("Simulation requires at least two equal-count cities per country")
+    if min(panel_lengths) < 4:
+        raise SourceSchemaError("Simulation requires at least four panel periods")
+    if any(not 0 <= persistence < 1 for persistence in persistence_values):
+        raise SourceSchemaError("Simulation persistence must be in [0, 1)")
+
+
 def simulate_dynamic_hierarchy(
     *,
     persistence_values: tuple[float, ...] = (0.2, 0.6, 0.9),
@@ -322,44 +371,20 @@ def simulate_dynamic_hierarchy(
     seed: int = 1729,
 ) -> pd.DataFrame:
     """Evaluate finite-T bias and RMSE over a declared persistence/length grid."""
-    if cities % countries or cities // countries < 2:
-        raise SourceSchemaError("Simulation requires at least two equal-count cities per country")
-    if replications < 2 or min(panel_lengths) < 4:
-        raise SourceSchemaError("Simulation requires two replications and four panel periods")
+    _validate_simulation_design(persistence_values, panel_lengths, cities, countries)
+    if replications < 2:
+        raise SourceSchemaError("Simulation requires at least two replications")
     rng = np.random.default_rng(seed)
     records: list[dict[str, float | int | str]] = []
-    country = np.repeat(np.arange(countries), cities // countries)
     for persistence in persistence_values:
-        if not 0 <= persistence < 1:
-            raise SourceSchemaError("Simulation persistence must be in [0, 1)")
         for panel_length in panel_lengths:
             for replication in range(replications):
-                city_effect = rng.normal(0, 0.35, cities)
-                state = city_effect / (1 - persistence) + rng.normal(0, 0.3, cities)
-                rows = []
-                # Burn-in reduces dependence on an arbitrary initial condition.
-                for time in range(30 + panel_length):
-                    country_shock = rng.normal(0, 0.08, countries)
-                    covariate = rng.normal(size=cities)
-                    outcome = (
-                        persistence * state + 0.3 * covariate + city_effect
-                        + country_shock[country] + rng.normal(0, 0.25, cities)
-                    )
-                    if time >= 30:
-                        for index in range(cities):
-                            rows.append(
-                                {
-                                    "city_id": index,
-                                    "country_code": country[index],
-                                    "period": time - 30,
-                                    "growth": outcome[index],
-                                    "lagged_growth": state[index],
-                                    "x": covariate[index],
-                                }
-                            )
-                    state = outcome
+                panel = _simulate_dynamic_panel(
+                    rng, persistence=persistence, panel_length=panel_length,
+                    cities=cities, countries=countries,
+                )
                 sample = common_dynamic_sample(
-                    pd.DataFrame(rows), outcome="growth", lagged_outcome="lagged_growth",
+                    panel, outcome="growth", lagged_outcome="lagged_growth",
                     covariates=["x"],
                 )
                 estimates = fit_dynamic_hierarchy(
@@ -384,5 +409,97 @@ def simulate_dynamic_hierarchy(
     ))
     summary["replications"] = replications
     summary["cities"] = cities
+    summary["seed"] = seed
+    return summary
+
+
+def _wilson_interval(successes: int, trials: int, z: float = 1.959963984540054) -> tuple[float, float]:
+    rate = successes / trials
+    denominator = 1 + z**2 / trials
+    center = (rate + z**2 / (2 * trials)) / denominator
+    margin = z * np.sqrt(rate * (1 - rate) / trials + z**2 / (4 * trials**2)) / denominator
+    return center - margin, center + margin
+
+
+def simulate_bootstrap_coverage(
+    *,
+    persistence_values: tuple[float, ...] = (0.2, 0.6, 0.9),
+    panel_lengths: tuple[int, ...] = (6, 8, 10),
+    simulation_replications: int = 200,
+    bootstrap_replications: int = 399,
+    cities: int = 48,
+    countries: int = 6,
+    confidence_level: float = 0.95,
+    seed: int = 314159,
+) -> pd.DataFrame:
+    """Estimate interval coverage and apply the predeclared production gate.
+
+    A design cell is production-eligible only with at least 200 simulated panels and 399
+    bootstrap draws. Its Wilson interval for empirical coverage must lie wholly inside the
+    predeclared 0.90--0.99 adequacy band. This rejects both undercoverage and vacuous intervals.
+    """
+    _validate_simulation_design(persistence_values, panel_lengths, cities, countries)
+    if simulation_replications < 2:
+        raise SourceSchemaError("Coverage simulation requires at least two panels per cell")
+    if bootstrap_replications < 20:
+        raise SourceSchemaError("Coverage simulation requires at least 20 bootstrap draws")
+    rng = np.random.default_rng(seed)
+    records = []
+    for persistence in persistence_values:
+        for panel_length in panel_lengths:
+            for replication in range(simulation_replications):
+                panel = _simulate_dynamic_panel(
+                    rng, persistence=persistence, panel_length=panel_length,
+                    cities=cities, countries=countries,
+                )
+                sample = common_dynamic_sample(
+                    panel, outcome="growth", lagged_outcome="lagged_growth", covariates=["x"]
+                )
+                bootstrap_seed = int(rng.integers(0, np.iinfo(np.int32).max))
+                intervals = bootstrap_dynamic_hierarchy(
+                    sample, outcome="growth", lagged_outcome="lagged_growth", covariates=["x"],
+                    replications=bootstrap_replications, confidence_level=confidence_level,
+                    seed=bootstrap_seed,
+                )
+                intervals = intervals.loc[intervals["term"].eq("lagged_growth")]
+                for row in intervals.itertuples():
+                    records.append(
+                        {
+                            "persistence": persistence,
+                            "panel_length": panel_length,
+                            "simulation_replication": replication,
+                            "estimator_id": row.estimator_id,
+                            "covered": row.confidence_lower <= persistence <= row.confidence_upper,
+                            "interval_width": row.confidence_upper - row.confidence_lower,
+                        }
+                    )
+    raw = pd.DataFrame(records)
+    grouped = raw.groupby(["persistence", "panel_length", "estimator_id"], as_index=False)
+    summary = grouped.agg(
+        covered_panels=("covered", "sum"),
+        evaluated_panels=("covered", "size"),
+        empirical_coverage=("covered", "mean"),
+        median_interval_width=("interval_width", "median"),
+    )
+    wilson = summary.apply(
+        lambda row: _wilson_interval(int(row["covered_panels"]), int(row["evaluated_panels"])),
+        axis=1,
+    )
+    summary[["coverage_wilson_lower", "coverage_wilson_upper"]] = pd.DataFrame(
+        wilson.tolist(), index=summary.index
+    )
+    production = simulation_replications >= 200 and bootstrap_replications >= 399
+    summary["production_design"] = production
+    adequate = summary["coverage_wilson_lower"].ge(0.90) & summary[
+        "coverage_wilson_upper"
+    ].le(0.99)
+    summary["coverage_gate_pass"] = pd.array(
+        adequate if production else [pd.NA] * len(summary), dtype="boolean"
+    )
+    summary["nominal_confidence"] = confidence_level
+    summary["simulation_replications"] = simulation_replications
+    summary["bootstrap_replications"] = bootstrap_replications
+    summary["cities"] = cities
+    summary["countries"] = countries
     summary["seed"] = seed
     return summary

--- a/tests/test_dynamic_estimators.py
+++ b/tests/test_dynamic_estimators.py
@@ -8,6 +8,7 @@ from urban_growth.dynamic_estimators import (
     estimator_disagreement_report,
     estimator_registry,
     fit_dynamic_hierarchy,
+    simulate_bootstrap_coverage,
     simulate_dynamic_hierarchy,
 )
 from urban_growth.io import SourceSchemaError
@@ -145,3 +146,15 @@ def test_multiplier_bootstrap_rejects_too_few_draws() -> None:
             sample, outcome="growth", lagged_outcome="lagged_growth", covariates=["x"],
             replications=19,
         )
+
+
+def test_coverage_smoke_run_cannot_pass_production_gate() -> None:
+    result = simulate_bootstrap_coverage(
+        persistence_values=(0.6,), panel_lengths=(6,), simulation_replications=2,
+        bootstrap_replications=20, cities=24, countries=4, seed=4,
+    )
+    assert len(result) == 3
+    assert not result["production_design"].any()
+    assert result["coverage_gate_pass"].isna().all()
+    assert result["evaluated_panels"].eq(2).all()
+    assert result["median_interval_width"].gt(0).all()


### PR DESCRIPTION
## Summary

- predeclare production replication requirements and coverage acceptance bounds
- reuse one dynamic-panel DGP for bias and coverage simulations
- measure coverage for every implemented estimator across persistence and panel-length cells
- report Wilson bounds and interval width
- make production eligibility and pass/fail machine-readable
- allow cell-specific execution for recoverable long runs
- prove undersized smoke runs cannot receive a gate decision

Closes #51
Advances #27

## Verification

- `uv run --locked pytest` — 113 passed
- `uv run --locked ruff check .` — passed
- `git diff --check` — passed
- full-grid non-production smoke run completed
- selected-cell smoke run completed

## Predeclared pass rule

A 95% interval is eligible only with at least 200 simulated panels and 399 bootstrap draws per cell. It passes only if the 95% Wilson interval around empirical coverage lies wholly within 90%–99%. No production result is included in this PR.