### PR TITLE
Add production bootstrap coverage workflow

### DIFF
--- a/.github/workflows/dynamic-bootstrap-coverage.yml
+++ b/.github/workflows/dynamic-bootstrap-coverage.yml
@@ -1,0 +1,79 @@
+name: dynamic bootstrap coverage
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  coverage-cell:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {tag: "02_06", persistence: "0.2", panel_length: "6"}
+          - {tag: "02_08", persistence: "0.2", panel_length: "8"}
+          - {tag: "02_10", persistence: "0.2", panel_length: "10"}
+          - {tag: "06_06", persistence: "0.6", panel_length: "6"}
+          - {tag: "06_08", persistence: "0.6", panel_length: "8"}
+          - {tag: "06_10", persistence: "0.6", panel_length: "10"}
+          - {tag: "09_06", persistence: "0.9", panel_length: "6"}
+          - {tag: "09_08", persistence: "0.9", panel_length: "8"}
+          - {tag: "09_10", persistence: "0.9", panel_length: "10"}
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
+        with:
+          version: "0.11.33"
+          enable-cache: true
+      - run: uv sync --locked
+      - name: Run locked coverage cell
+        run: >-
+          uv run --locked python scripts/run_dynamic_bootstrap_coverage.py
+          --simulation-replications 200 --bootstrap-replications 399
+          --cities 48 --countries 6 --seed 314159
+          --persistence ${{ matrix.persistence }} --panel-length ${{ matrix.panel_length }}
+          --output outputs/dynamic_bootstrap_coverage_${{ matrix.tag }}.csv
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dynamic-bootstrap-coverage-${{ matrix.tag }}
+          path: outputs/dynamic_bootstrap_coverage_${{ matrix.tag }}.csv
+          if-no-files-found: error
+
+  combine:
+    needs: coverage-cell
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
+        with:
+          version: "0.11.33"
+          enable-cache: true
+      - run: uv sync --locked
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: dynamic-bootstrap-coverage-*
+          path: coverage-artifacts
+      - name: Combine and validate cells
+        run: >-
+          uv run --locked python scripts/combine_dynamic_bootstrap_coverage.py
+          --input-dir coverage-artifacts
+          --output outputs/dynamic_bootstrap_coverage.csv
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dynamic-bootstrap-coverage-combined
+          path: outputs/dynamic_bootstrap_coverage.csv
+          if-no-files-found: error
+      - name: Evaluate locked coverage gate
+        run: >-
+          uv run --locked python scripts/check_dynamic_bootstrap_coverage.py
+          outputs/dynamic_bootstrap_coverage.csv

--- a/docs/research-status.md
+++ b/docs/research-status.md
@@ -42,6 +42,14 @@ decision rather than a provisional pass. The command accepts repeated `--persist
 `--panel-length` arguments so long runs can be split into auditable cells. No production
 coverage run has yet been accepted or recorded.
 
+Only the split-panel-jackknife estimator is eligible for this structural-persistence coverage
+gate. Pooled prediction has a different between-and-within estimand, so coverage of the DGP's
+within-city persistence parameter is not a coherent success criterion for it. The uncorrected
+city-FE estimator remains a known Nickell-biased diagnostic. Their simulated coverage is
+reported, but neither can receive a gate pass. The manual Actions workflow runs the nine locked
+cells independently, uploads each artifact, validates the complete 27-row grid, and uploads the
+combined result before evaluating the corrected-estimator gate.
+
 ## Evidence state
 
 The source and transformation pipeline is reproducible from registered local files, but all results remain **retrospective current-revision tests**. The WUP and GHSL exercises use different city definitions and must not be pooled. WUP supplies demographic city records without a verified stable-polygon restriction. GHSL supplies a balanced panel calculated inside fixed 2025 polygons, but that definition uses future geographic information and is not vintage-correct. Neither is sufficient for a commercial forecasting claim.

--- a/scripts/check_dynamic_bootstrap_coverage.py
+++ b/scripts/check_dynamic_bootstrap_coverage.py
@@ -1,0 +1,23 @@
+"""Fail when any eligible corrected-estimator coverage cell misses its locked gate."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from urban_growth.dynamic_estimators import check_coverage_gate
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("result", type=Path)
+    args = parser.parse_args()
+    result = pd.read_csv(args.result)
+    check_coverage_gate(result)
+    print("bootstrap coverage gate passed: 9/9 corrected-estimator cells")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/combine_dynamic_bootstrap_coverage.py
+++ b/scripts/combine_dynamic_bootstrap_coverage.py
@@ -1,0 +1,23 @@
+"""Combine and validate the nine production coverage-cell artifacts."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from urban_growth.dynamic_estimators import combine_coverage_artifacts
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-dir", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    result = combine_coverage_artifacts(args.input_dir)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    result.to_csv(args.output, index=False)
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/urban_growth/dynamic_estimators.py
+++ b/src/urban_growth/dynamic_estimators.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
 
 from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
+
+EXPECTED_COVERAGE_PERSISTENCE = {0.2, 0.6, 0.9}
+EXPECTED_COVERAGE_LENGTHS = {6, 8, 10}
+EXPECTED_COVERAGE_ESTIMATORS = {
+    "pooled_dynamic", "city_fe_dynamic", "half_panel_jackknife"
+}
 
 
 @dataclass(frozen=True)
@@ -421,6 +428,20 @@ def _wilson_interval(successes: int, trials: int, z: float = 1.959963984540054) 
     return center - margin, center + margin
 
 
+def _apply_coverage_gate(summary: pd.DataFrame, *, production: bool) -> pd.DataFrame:
+    result = summary.copy()
+    adequate = result["coverage_wilson_lower"].ge(0.90) & result[
+        "coverage_wilson_upper"
+    ].le(0.99)
+    eligible = result["estimator_id"].eq("half_panel_jackknife") & production
+    result["production_design"] = production
+    result["coverage_gate_eligible"] = eligible
+    result["coverage_gate_pass"] = pd.array(
+        adequate.where(eligible, pd.NA), dtype="boolean"
+    )
+    return result
+
+
 def simulate_bootstrap_coverage(
     *,
     persistence_values: tuple[float, ...] = (0.2, 0.6, 0.9),
@@ -489,13 +510,7 @@ def simulate_bootstrap_coverage(
         wilson.tolist(), index=summary.index
     )
     production = simulation_replications >= 200 and bootstrap_replications >= 399
-    summary["production_design"] = production
-    adequate = summary["coverage_wilson_lower"].ge(0.90) & summary[
-        "coverage_wilson_upper"
-    ].le(0.99)
-    summary["coverage_gate_pass"] = pd.array(
-        adequate if production else [pd.NA] * len(summary), dtype="boolean"
-    )
+    summary = _apply_coverage_gate(summary, production=production)
     summary["nominal_confidence"] = confidence_level
     summary["simulation_replications"] = simulation_replications
     summary["bootstrap_replications"] = bootstrap_replications
@@ -503,3 +518,56 @@ def simulate_bootstrap_coverage(
     summary["countries"] = countries
     summary["seed"] = seed
     return summary
+
+
+def combine_coverage_artifacts(input_dir: Path) -> pd.DataFrame:
+    """Return one validated production grid from nine cell files."""
+    paths = sorted(input_dir.rglob("dynamic_bootstrap_coverage_*.csv"))
+    if len(paths) != 9:
+        raise SourceSchemaError(f"Expected nine coverage artifacts, found {len(paths)}")
+    result = pd.concat([pd.read_csv(path) for path in paths], ignore_index=True)
+    required = {
+        "persistence", "panel_length", "estimator_id", "production_design",
+        "coverage_gate_eligible", "coverage_gate_pass",
+    }
+    require_columns(result, required, source_name="bootstrap coverage artifacts")
+    for column in ("production_design", "coverage_gate_eligible", "coverage_gate_pass"):
+        result[column] = result[column].map(
+            {True: True, False: False, "True": True, "False": False}
+        ).astype("boolean")
+    if set(result["persistence"]) != EXPECTED_COVERAGE_PERSISTENCE:
+        raise SourceSchemaError("Coverage artifacts do not span the locked persistence grid")
+    if set(result["panel_length"]) != EXPECTED_COVERAGE_LENGTHS:
+        raise SourceSchemaError("Coverage artifacts do not span the locked panel-length grid")
+    if set(result["estimator_id"]) != EXPECTED_COVERAGE_ESTIMATORS:
+        raise SourceSchemaError("Coverage artifacts do not span the implemented estimators")
+    keys = ["persistence", "panel_length", "estimator_id"]
+    if len(result) != 27 or result.duplicated(keys).any():
+        raise SourceSchemaError("Coverage artifacts must contain 27 unique design-estimator rows")
+    if not result["production_design"].all():
+        raise SourceSchemaError("At least one coverage artifact is not a production design")
+    eligible = result["estimator_id"].eq("half_panel_jackknife")
+    if not result.loc[eligible, "coverage_gate_eligible"].all():
+        raise SourceSchemaError("Every corrected-estimator cell must be gate eligible")
+    if result.loc[~eligible, "coverage_gate_eligible"].any():
+        raise SourceSchemaError("Diagnostic estimators cannot receive a structural coverage gate")
+    return result.sort_values(keys).reset_index(drop=True)
+
+
+def check_coverage_gate(result: pd.DataFrame) -> None:
+    """Raise unless all nine eligible corrected-estimator cells pass."""
+    require_columns(
+        result,
+        {"persistence", "panel_length", "estimator_id", "coverage_gate_eligible",
+         "coverage_gate_pass"},
+        source_name="combined bootstrap coverage",
+    )
+    eligible = result.loc[result["coverage_gate_eligible"]]
+    if len(eligible) != 9:
+        raise SourceSchemaError("Expected nine eligible corrected-estimator cells")
+    failed = eligible.loc[~eligible["coverage_gate_pass"].astype("boolean").fillna(False)]
+    if not failed.empty:
+        cells = ", ".join(
+            f"rho={row.persistence}, T={row.panel_length}" for row in failed.itertuples()
+        )
+        raise SourceSchemaError(f"Bootstrap coverage gate failed: {cells}")

--- a/tests/test_dynamic_coverage_scripts.py
+++ b/tests/test_dynamic_coverage_scripts.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from urban_growth.dynamic_estimators import check_coverage_gate, combine_coverage_artifacts
+from urban_growth.io import SourceSchemaError
+
+
+def write_coverage_cells(directory: Path, *, failing_cell: tuple[float, int] | None = None) -> None:
+    for persistence in (0.2, 0.6, 0.9):
+        for panel_length in (6, 8, 10):
+            rows = []
+            for estimator in ("pooled_dynamic", "city_fe_dynamic", "half_panel_jackknife"):
+                eligible = estimator == "half_panel_jackknife"
+                passed = eligible and (persistence, panel_length) != failing_cell
+                rows.append(
+                    {
+                        "persistence": persistence,
+                        "panel_length": panel_length,
+                        "estimator_id": estimator,
+                        "production_design": True,
+                        "coverage_gate_eligible": eligible,
+                        "coverage_gate_pass": passed if eligible else pd.NA,
+                    }
+                )
+            tag = f"{str(persistence).replace('.', '')}_{panel_length}"
+            pd.DataFrame(rows).to_csv(
+                directory / f"dynamic_bootstrap_coverage_{tag}.csv", index=False
+            )
+
+
+def test_combiner_validates_complete_grid_and_gate_pass(tmp_path: Path) -> None:
+    write_coverage_cells(tmp_path)
+    result = combine_coverage_artifacts(tmp_path)
+    assert len(result) == 27
+    check_coverage_gate(result)
+
+
+def test_gate_reports_failed_corrected_cell(tmp_path: Path) -> None:
+    write_coverage_cells(tmp_path, failing_cell=(0.9, 6))
+    result = combine_coverage_artifacts(tmp_path)
+    with pytest.raises(SourceSchemaError, match=r"rho=0.9, T=6"):
+        check_coverage_gate(result)

--- a/tests/test_dynamic_estimators.py
+++ b/tests/test_dynamic_estimators.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 
 from urban_growth.dynamic_estimators import (
+    _apply_coverage_gate,
     bootstrap_dynamic_hierarchy,
     common_dynamic_sample,
     estimator_disagreement_report,
@@ -155,6 +156,23 @@ def test_coverage_smoke_run_cannot_pass_production_gate() -> None:
     )
     assert len(result) == 3
     assert not result["production_design"].any()
+    assert not result["coverage_gate_eligible"].any()
     assert result["coverage_gate_pass"].isna().all()
     assert result["evaluated_panels"].eq(2).all()
     assert result["median_interval_width"].gt(0).all()
+
+
+def test_structural_coverage_gate_applies_only_to_corrected_estimator() -> None:
+    summary = pd.DataFrame(
+        {
+            "estimator_id": [
+                "pooled_dynamic", "city_fe_dynamic", "half_panel_jackknife",
+                "half_panel_jackknife",
+            ],
+            "coverage_wilson_lower": [0.92, 0.92, 0.92, 0.85],
+            "coverage_wilson_upper": [0.98, 0.98, 0.98, 0.98],
+        }
+    )
+    result = _apply_coverage_gate(summary, production=True)
+    assert result["coverage_gate_eligible"].tolist() == [False, False, True, True]
+    assert result["coverage_gate_pass"].tolist() == [pd.NA, pd.NA, True, False]


### PR DESCRIPTION
## Summary

- correct structural coverage eligibility to the split-panel-jackknife estimator only
- add a manual nine-cell Actions matrix for the locked production design
- preserve each cell as an independent artifact
- combine and validate the exact 27-row grid
- upload the combined result before evaluating the gate
- fail explicitly with the corrected-estimator cells that miss the predeclared criterion
- test complete-grid validation and failure reporting

Closes #53 after workflow execution and result review
Advances #27

## Verification

- `uv run --locked pytest -q` — 116 passed
- `uv run --locked ruff check .` — passed
- `git diff --check` — passed
- local non-production full-grid and selected-cell smoke runs completed

## Important correction

Pooled prediction has a different estimand and cannot be judged by coverage of structural within-city persistence. The uncorrected FE model is a known biased diagnostic. Both remain reported; only the corrected estimator is gate eligible.