### PR TITLE
Add controlled production-coverage run trigger

### DIFF
--- a/.github/workflows/dynamic-bootstrap-coverage.yml
+++ b/.github/workflows/dynamic-bootstrap-coverage.yml
@@ -2,6 +2,9 @@ name: dynamic bootstrap coverage
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - "run/dynamic-bootstrap-coverage-*"
 
 permissions:
   contents: read


### PR DESCRIPTION
Add a narrowly scoped push trigger for branches matching `run/dynamic-bootstrap-coverage-*`. This permits the production matrix to be started through the existing GitHub integration without enabling it on ordinary pushes.

Advances #53.

The workflow design, seed, grid, and thresholds are unchanged.