### PR TITLE
Implement direct national-envelope core

### DIFF
--- a/docs/national-context.md
+++ b/docs/national-context.md
@@ -1,5 +1,21 @@
 # National demographic and settlement context
 
+## Direct national envelope
+
+Module A now reads the registered WUP 2025 F01 `Cities`, `Towns`, `Rural`, and `Total`
+sheets directly. Country-category sums must reconcile to the published total within three
+persons after conversion from thousands; failure stops the build. Five-year intervals report
+total growth, category growth availability, settlement shares, share changes, and a
+zero-summing reallocation decomposition. These are revised-history national estimates, not
+vintage-real-time observations.
+
+Forecast features are built separately. They contain origin settlement shares and growth or
+share change from the interval completed at the origin. Realized origin-to-endpoint envelope
+growth and share change are outcomes and are prohibited as forecast-origin features. Global
+and regional summaries report country-equal and population-at-origin weighting separately.
+The direct envelope supersedes any attempt to treat recovered Module B country-period fixed
+effects as primary national demographic data; recovered effects remain diagnostic only.
+
 ## Purpose
 
 National population and the distribution of population across cities, towns and

--- a/docs/research-status.md
+++ b/docs/research-status.md
@@ -52,6 +52,14 @@ combined result before evaluating the corrected-estimator gate.
 
 ## Evidence state
 
+The direct Module A national-envelope pipeline is executable from the registered WUP F01
+workbook. It reconciles Cities, Towns, and Rural country totals to the publisher's Total sheet,
+constructs five-year reallocation intervals, separates retrospective outcomes from
+origin-available forecast features, and produces country-equal and population-weighted
+regional/global summaries. This is an implementation result, not evidence that a national
+envelope improves city forecasts. Numerical interpretation and provenance-bound result
+registration remain open under issue #29.
+
 The source and transformation pipeline is reproducible from registered local files, but all results remain **retrospective current-revision tests**. The WUP and GHSL exercises use different city definitions and must not be pooled. WUP supplies demographic city records without a verified stable-polygon restriction. GHSL supplies a balanced panel calculated inside fixed 2025 polygons, but that definition uses future geographic information and is not vintage-correct. Neither is sufficient for a commercial forecasting claim.
 
 ## Fixed-2025-boundary sensitivity

--- a/scripts/run_national_envelope.py
+++ b/scripts/run_national_envelope.py
@@ -1,0 +1,41 @@
+"""Build direct WUP national settlement-envelope tables."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from urban_growth.adapters.wup import read_f01_country_degurb_population
+from urban_growth.national_envelope import (
+    national_envelope_feature_registry,
+    national_envelope_forecast_features,
+    national_envelope_intervals,
+    national_envelope_summaries,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--raw-dir", type=Path, default=Path("data/raw"))
+    parser.add_argument("--output-dir", type=Path, default=Path("outputs"))
+    args = parser.parse_args()
+    panel = read_f01_country_degurb_population(
+        args.raw_dir / "WUP2025-F01-Degree-of-Urbanization_Pop_by_category.xlsx"
+    )
+    intervals = national_envelope_intervals(panel)
+    outputs = {
+        "national_envelope_panel.csv": panel,
+        "national_envelope_intervals.csv": intervals,
+        "national_envelope_forecast_features.csv": national_envelope_forecast_features(intervals),
+        "national_envelope_summaries.csv": national_envelope_summaries(intervals),
+        "national_envelope_feature_registry.csv": national_envelope_feature_registry(),
+    }
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    for filename, frame in outputs.items():
+        path = args.output_dir / filename
+        frame.to_csv(path, index=False)
+        print(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/urban_growth/adapters/wup.py
+++ b/src/urban_growth/adapters/wup.py
@@ -234,6 +234,90 @@ def read_f01_country_city_population(path: str) -> pd.DataFrame:
     return panel.sort_values(["country_code", "year"]).reset_index(drop=True)
 
 
+def read_f01_country_degurb_population(path: str) -> pd.DataFrame:
+    """Read reconciled country Cities, Towns, and Rural populations from WUP F01."""
+    from urban_growth.io import read_table, require_columns
+
+    city = read_f01_country_city_population(path)
+    hierarchy_columns = [
+        "location_id", "country_code", "country_name", "ParentID", "subregion_id",
+        "subregion_name", "region_id", "region_name", "year", "observation_type",
+        "revision_semantics",
+    ]
+    hierarchy = city[hierarchy_columns].copy()
+    category_frames = [
+        city.rename(columns={"national_city_category_population": "population"}).assign(
+            category="city"
+        )
+    ]
+    required = {
+        "LocID", "ISO3_Code", "Location", "LocType", "LocTypeName",
+        "ParentID", "1950", "2025", "2050",
+    }
+    for sheet_name, category in (("Towns", "town_and_semi_dense"), ("Rural", "rural")):
+        frame = read_table(path, sheet_name=sheet_name)
+        require_columns(frame, required, source_name=f"WUP 2025 F01 {sheet_name}")
+        countries = frame.loc[frame["LocType"].eq(4)].copy()
+        if countries.empty or countries["LocTypeName"].ne("Country/Area").any():
+            raise SourceSchemaError(f"WUP F01 {sheet_name} has no valid Country/Area rows")
+        countries["category"] = category
+        panel = degree_of_urbanization_panel(
+            countries,
+            location_id_column="LocID",
+            category_column="category",
+            metadata_columns=["ISO3_Code", "Location"],
+        ).rename(
+            columns={"ISO3_Code": "country_code", "Location": "country_name"}
+        )
+        panel["observation_type"] = panel["year"].le(2025).map(
+            {True: "estimate", False: "projection"}
+        )
+        panel["revision_semantics"] = "WUP_2025_revised_history"
+        category_frames.append(
+            panel.merge(
+                hierarchy.drop(columns=["country_name", "observation_type", "revision_semantics"]),
+                on=["location_id", "country_code", "year"],
+                how="left",
+                validate="one_to_one",
+            )
+        )
+    result = pd.concat(category_frames, ignore_index=True)
+    result = result[
+        [
+            "location_id", "country_code", "country_name", "ParentID", "subregion_id",
+            "subregion_name", "region_id", "region_name", "year", "category", "population",
+            "observation_type", "revision_semantics",
+        ]
+    ]
+    if result[["country_code", "subregion_id", "region_id"]].isna().any().any():
+        raise SourceSchemaError("WUP F01 category sheets do not match the Cities hierarchy")
+    reject_duplicate_keys(
+        result, ["country_code", "year", "category"], source_name="WUP F01 DEGURBA"
+    )
+
+    total_frame = read_table(path, sheet_name="Total")
+    require_columns(total_frame, required, source_name="WUP 2025 F01 Total")
+    total_countries = total_frame.loc[total_frame["LocType"].eq(4)].copy()
+    total = wide_years_to_long(
+        total_countries,
+        id_columns=["LocID", "ISO3_Code"],
+        value_pattern=r"(?P<year>\d{4})",
+        value_name="reported_total",
+    ).rename(columns={"LocID": "location_id", "ISO3_Code": "country_code"})
+    total = _scale_population(total.rename(columns={"reported_total": "population"}), "thousands")
+    total = total.rename(columns={"population": "reported_total"})
+    computed = result.groupby(["location_id", "country_code", "year"], as_index=False)[
+        "population"
+    ].sum().rename(columns={"population": "computed_total"})
+    reconciliation = computed.merge(
+        total, on=["location_id", "country_code", "year"], validate="one_to_one"
+    )
+    difference = (reconciliation["computed_total"] - reconciliation["reported_total"]).abs()
+    if difference.gt(3).any():
+        raise SourceSchemaError("WUP F01 category populations do not reconcile to Total")
+    return result.sort_values(["country_code", "year", "category"]).reset_index(drop=True)
+
+
 def city_area_panel(
     frame: pd.DataFrame,
     *,

--- a/src/urban_growth/national_envelope.py
+++ b/src/urban_growth/national_envelope.py
@@ -1,0 +1,219 @@
+"""Direct national settlement-envelope decomposition from country DEGURBA totals."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
+
+DEGURBA_CATEGORIES = ("city", "town_and_semi_dense", "rural")
+
+
+def national_envelope_intervals(
+    panel: pd.DataFrame, *, interval_years: int = 5, estimate_end_year: int = 2025
+) -> pd.DataFrame:
+    """Decompose national population change and settlement-class reallocation."""
+    required = {
+        "country_code", "year", "category", "population", "observation_type",
+        "revision_semantics", "subregion_name", "region_name",
+    }
+    require_columns(panel, required, source_name="national settlement panel")
+    reject_duplicate_keys(
+        panel, ["country_code", "year", "category"], source_name="national settlement panel"
+    )
+    if interval_years <= 0:
+        raise SourceSchemaError("National-envelope interval must be positive")
+    unknown = set(panel["category"].dropna()) - set(DEGURBA_CATEGORIES)
+    if unknown:
+        raise SourceSchemaError(f"Unknown national settlement categories: {sorted(unknown)}")
+    population = pd.to_numeric(panel["population"], errors="coerce")
+    if population.isna().any() or not np.isfinite(population).all() or (population < 0).any():
+        raise SourceSchemaError("National settlement population must be finite and nonnegative")
+    source = panel.assign(population=population)
+    metadata = source[
+        ["country_code", "year", "subregion_name", "region_name", "observation_type",
+         "revision_semantics"]
+    ].drop_duplicates()
+    reject_duplicate_keys(metadata, ["country_code", "year"], source_name="national metadata")
+    wide = source.pivot(
+        index=["country_code", "year"], columns="category", values="population"
+    ).reset_index()
+    if any(category not in wide for category in DEGURBA_CATEGORIES):
+        raise SourceSchemaError("National settlement panel lacks a required category")
+    if wide[list(DEGURBA_CATEGORIES)].isna().any().any():
+        raise SourceSchemaError("National settlement panel has incomplete country-year composition")
+    start = wide.rename(columns={
+        category: f"{category}_population_start" for category in DEGURBA_CATEGORIES
+    })
+    end = wide.rename(columns={
+        "year": "period_end",
+        **{category: f"{category}_population_end" for category in DEGURBA_CATEGORIES},
+    })
+    start["period_end"] = start["year"] + interval_years
+    result = start.merge(end, on=["country_code", "period_end"], validate="one_to_one")
+    result = result.rename(columns={"year": "period_start"})
+    result = result.loc[result["period_end"].le(estimate_end_year)].copy()
+    result = result.merge(
+        metadata.rename(columns={"year": "period_start", "observation_type": "start_status"}),
+        on=["country_code", "period_start"], validate="many_to_one",
+    ).merge(
+        metadata[["country_code", "year", "observation_type"]].rename(
+            columns={"year": "period_end", "observation_type": "end_status"}
+        ),
+        on=["country_code", "period_end"], validate="many_to_one",
+    )
+    start_columns = [f"{category}_population_start" for category in DEGURBA_CATEGORIES]
+    end_columns = [f"{category}_population_end" for category in DEGURBA_CATEGORIES]
+    result["total_population_start"] = result[start_columns].sum(axis=1)
+    result["total_population_end"] = result[end_columns].sum(axis=1)
+    if (result[["total_population_start", "total_population_end"]] <= 0).any().any():
+        raise SourceSchemaError("National total population must be positive at both endpoints")
+    result["total_population_change"] = (
+        result["total_population_end"] - result["total_population_start"]
+    )
+    result["total_annualized_log_growth"] = (
+        np.log(result["total_population_end"]) - np.log(result["total_population_start"])
+    ) / interval_years
+    for category in DEGURBA_CATEGORIES:
+        start_population = result[f"{category}_population_start"]
+        end_population = result[f"{category}_population_end"]
+        start_share = start_population / result["total_population_start"]
+        end_share = end_population / result["total_population_end"]
+        result[f"{category}_population_change"] = end_population - start_population
+        result[f"{category}_share_start"] = start_share
+        result[f"{category}_share_end"] = end_share
+        result[f"{category}_share_change"] = end_share - start_share
+        result[f"{category}_reallocation_change"] = (
+            end_population - start_population - start_share * result["total_population_change"]
+        )
+        positive = (start_population > 0) & (end_population > 0)
+        result[f"{category}_log_growth_available"] = positive
+        log_growth = pd.Series(np.nan, index=result.index, dtype=float)
+        log_growth.loc[positive] = (
+            np.log(end_population.loc[positive]) - np.log(start_population.loc[positive])
+        ) / interval_years
+        result[f"{category}_annualized_log_growth"] = log_growth
+    share_change_columns = [f"{category}_share_change" for category in DEGURBA_CATEGORIES]
+    reallocation_columns = [f"{category}_reallocation_change" for category in DEGURBA_CATEGORIES]
+    if not np.allclose(result[share_change_columns].sum(axis=1), 0, atol=1e-10):
+        raise SourceSchemaError("National settlement share changes do not sum to zero")
+    if not np.allclose(result[reallocation_columns].sum(axis=1), 0, atol=1e-6):
+        raise SourceSchemaError("National settlement reallocations do not sum to zero")
+    result["interval_observation_status"] = np.where(
+        result["start_status"].eq("estimate") & result["end_status"].eq("estimate"),
+        "retrospective_revised_estimate", "contains_projection",
+    )
+    return result.sort_values(["country_code", "period_start"]).reset_index(drop=True)
+
+
+def national_envelope_feature_registry() -> pd.DataFrame:
+    """Separate explanatory outcomes from features available at a forecast origin."""
+    return pd.DataFrame(
+        [
+            {
+                "feature_family": "realized_envelope_growth",
+                "timing": "period_start_to_period_end",
+                "retrospective_role": "Module A outcome",
+                "future_usable_at_origin": False,
+            },
+            {
+                "feature_family": "lagged_envelope_growth",
+                "timing": "period_start_minus_interval_to_period_start",
+                "retrospective_role": "forecast covariate",
+                "future_usable_at_origin": True,
+            },
+            {
+                "feature_family": "origin_settlement_shares",
+                "timing": "period_start",
+                "retrospective_role": "forecast covariate",
+                "future_usable_at_origin": True,
+            },
+            {
+                "feature_family": "realized_share_change",
+                "timing": "period_start_to_period_end",
+                "retrospective_role": "Module A outcome",
+                "future_usable_at_origin": False,
+            },
+        ]
+    )
+
+
+def national_envelope_forecast_features(intervals: pd.DataFrame) -> pd.DataFrame:
+    """Build origin-available features without copying realized outcome-period values."""
+    required = {
+        "country_code", "period_start", "period_end", "total_annualized_log_growth",
+        *{f"{category}_share_start" for category in DEGURBA_CATEGORIES},
+        *{f"{category}_share_change" for category in DEGURBA_CATEGORIES},
+    }
+    require_columns(intervals, required, source_name="national envelope intervals")
+    reject_duplicate_keys(
+        intervals, ["country_code", "period_start"], source_name="national envelope intervals"
+    )
+    lag_columns = [
+        "country_code", "period_end", "total_annualized_log_growth",
+        *[f"{category}_share_change" for category in DEGURBA_CATEGORIES],
+    ]
+    lagged = intervals[lag_columns].rename(
+        columns={
+            "period_end": "period_start",
+            "total_annualized_log_growth": "lagged_total_annualized_log_growth",
+            **{
+                f"{category}_share_change": f"lagged_{category}_share_change"
+                for category in DEGURBA_CATEGORIES
+            },
+        }
+    )
+    origin_columns = [
+        "country_code", "period_start", "period_end",
+        *[f"{category}_share_start" for category in DEGURBA_CATEGORIES],
+    ]
+    result = intervals[origin_columns].merge(
+        lagged, on=["country_code", "period_start"], how="left", validate="one_to_one"
+    )
+    result["lagged_envelope_available"] = result["lagged_total_annualized_log_growth"].notna()
+    result["uses_outcome_period_value"] = False
+    return result.sort_values(["country_code", "period_start"]).reset_index(drop=True)
+
+
+def national_envelope_summaries(intervals: pd.DataFrame) -> pd.DataFrame:
+    """Summarize direct national envelopes with country-equal and population weights."""
+    metrics = [
+        "total_annualized_log_growth",
+        *[f"{category}_share_change" for category in DEGURBA_CATEGORIES],
+    ]
+    required = {
+        "country_code", "period_start", "period_end", "region_name",
+        "total_population_start", *metrics,
+    }
+    require_columns(intervals, required, source_name="national envelope intervals")
+    records = []
+    group_designs = [
+        ("global", pd.Series("Global", index=intervals.index)),
+        ("region", intervals["region_name"]),
+    ]
+    for aggregation_level, labels in group_designs:
+        working = intervals.assign(_group=labels)
+        for (period_start, period_end, group_name), group in working.groupby(
+            ["period_start", "period_end", "_group"], sort=True
+        ):
+            weights = group["total_population_start"].to_numpy(dtype=float)
+            for weighting in ("country_equal", "population_start"):
+                row: dict[str, int | float | str] = {
+                    "aggregation_level": aggregation_level,
+                    "group_name": str(group_name),
+                    "period_start": int(period_start),
+                    "period_end": int(period_end),
+                    "weighting": weighting,
+                    "country_count": group["country_code"].nunique(),
+                }
+                for metric in metrics:
+                    values = group[metric].to_numpy(dtype=float)
+                    row[metric] = (
+                        float(values.mean()) if weighting == "country_equal"
+                        else float(np.average(values, weights=weights))
+                    )
+                records.append(row)
+    return pd.DataFrame(records).sort_values(
+        ["aggregation_level", "group_name", "period_start", "weighting"]
+    ).reset_index(drop=True)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -13,6 +13,7 @@ from urban_growth.adapters.wup import (
     city_population_panel,
     degree_of_urbanization_panel,
     read_f01_country_city_population,
+    read_f01_country_degurb_population,
     validate_density_identity,
 )
 from urban_growth.io import SourceSchemaError
@@ -217,6 +218,31 @@ def test_wup_f01_repairs_only_omitted_northern_america_parent(tmp_path) -> None:
             "region_name": "NORTHERN AMERICA",
         }
     ]
+
+
+def test_wup_f01_reads_and_reconciles_all_country_categories(tmp_path) -> None:
+    metadata = {
+        "LocID": [905, 840], "ISO3_Code": [None, "USA"],
+        "Location": ["NORTHERN AMERICA", "United States"], "LocType": [2, 4],
+        "LocTypeName": ["Geographic region", "Country/Area"], "ParentID": [5505, 918],
+    }
+    values = {
+        "Cities": ([6.0, 5.0], [12.0, 10.0], [18.0, 15.0]),
+        "Towns": ([3.0, 2.0], [5.0, 4.0], [7.0, 6.0]),
+        "Rural": ([2.0, 1.0], [3.0, 2.0], [4.0, 3.0]),
+        "Total": ([11.0, 8.0], [20.0, 16.0], [29.0, 24.0]),
+    }
+    path = tmp_path / "f01.xlsx"
+    with pd.ExcelWriter(path) as writer:
+        for sheet, years in values.items():
+            frame = pd.DataFrame(metadata).assign(**{"1950": years[0], "2025": years[1], "2050": years[2]})
+            frame.to_excel(writer, sheet_name=sheet, index=False)
+    result = read_f01_country_degurb_population(path)
+    usa_2025 = result.loc[result["country_code"].eq("USA") & result["year"].eq(2025)]
+    assert usa_2025.set_index("category")["population"].to_dict() == {
+        "city": 10_000.0, "rural": 2_000.0, "town_and_semi_dense": 4_000.0,
+    }
+    assert usa_2025["region_name"].eq("NORTHERN AMERICA").all()
 
 
 def test_wup_city_panel_preserves_prethreshold_history_and_marks_projections() -> None:

--- a/tests/test_national_envelope.py
+++ b/tests/test_national_envelope.py
@@ -1,0 +1,91 @@
+import pandas as pd
+import pytest
+
+from urban_growth.io import SourceSchemaError
+from urban_growth.national_envelope import (
+    national_envelope_feature_registry,
+    national_envelope_forecast_features,
+    national_envelope_intervals,
+    national_envelope_summaries,
+)
+
+
+def envelope_panel() -> pd.DataFrame:
+    values = {
+        2000: {"city": 400.0, "town_and_semi_dense": 300.0, "rural": 300.0},
+        2005: {"city": 500.0, "town_and_semi_dense": 320.0, "rural": 280.0},
+        2010: {"city": 600.0, "town_and_semi_dense": 330.0, "rural": 270.0},
+        2030: {"city": 900.0, "town_and_semi_dense": 350.0, "rural": 250.0},
+    }
+    rows = []
+    for year, categories in values.items():
+        for category, population in categories.items():
+            rows.append(
+                {
+                    "country_code": "X", "year": year, "category": category,
+                    "population": population, "subregion_name": "Example subregion",
+                    "region_name": "Example region",
+                    "observation_type": "estimate" if year <= 2025 else "projection",
+                    "revision_semantics": "WUP_2025_revised_history",
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def test_national_envelope_decomposes_growth_and_reallocation() -> None:
+    result = national_envelope_intervals(envelope_panel())
+    assert result["period_start"].tolist() == [2000, 2005]
+    first = result.iloc[0]
+    assert first["total_population_start"] == 1000.0
+    assert first["total_population_end"] == 1100.0
+    assert first["city_population_change"] == 100.0
+    assert first["city_reallocation_change"] == pytest.approx(60.0)
+    assert sum(first[f"{category}_share_change"] for category in (
+        "city", "town_and_semi_dense", "rural"
+    )) == pytest.approx(0.0)
+    assert sum(first[f"{category}_reallocation_change"] for category in (
+        "city", "town_and_semi_dense", "rural"
+    )) == pytest.approx(0.0)
+    assert result["interval_observation_status"].eq("retrospective_revised_estimate").all()
+
+
+def test_national_envelope_rejects_incomplete_composition() -> None:
+    source = envelope_panel()
+    source = source.loc[~(source["category"].eq("rural") & source["year"].eq(2005))]
+    with pytest.raises(SourceSchemaError, match="incomplete"):
+        national_envelope_intervals(source)
+
+
+def test_feature_registry_forbids_realized_future_values() -> None:
+    registry = national_envelope_feature_registry().set_index("feature_family")
+    assert not registry.loc["realized_envelope_growth", "future_usable_at_origin"]
+    assert not registry.loc["realized_share_change", "future_usable_at_origin"]
+    assert registry.loc["lagged_envelope_growth", "future_usable_at_origin"]
+    assert registry.loc["origin_settlement_shares", "future_usable_at_origin"]
+
+
+def test_forecast_features_use_only_completed_prior_interval() -> None:
+    intervals = national_envelope_intervals(envelope_panel())
+    features = national_envelope_forecast_features(intervals)
+    first, second = features.iloc[0], features.iloc[1]
+    assert not first["lagged_envelope_available"]
+    assert second["lagged_total_annualized_log_growth"] == pytest.approx(
+        intervals.iloc[0]["total_annualized_log_growth"]
+    )
+    assert not features["uses_outcome_period_value"].any()
+
+
+def test_summaries_separate_country_equal_and_population_weights() -> None:
+    intervals = national_envelope_intervals(envelope_panel())
+    second_country = intervals.assign(
+        country_code="Y", total_population_start=intervals["total_population_start"] * 10,
+        total_annualized_log_growth=intervals["total_annualized_log_growth"] * 2,
+    )
+    summaries = national_envelope_summaries(pd.concat([intervals, second_country]))
+    global_first = summaries.loc[
+        summaries["aggregation_level"].eq("global") & summaries["period_start"].eq(2000)
+    ].set_index("weighting")
+    assert global_first.loc["population_start", "total_annualized_log_growth"] > global_first.loc[
+        "country_equal", "total_annualized_log_growth"
+    ]
+    assert global_first["country_count"].eq(2).all()


### PR DESCRIPTION
## Summary

- read and normalize WUP F01 Cities, Towns, Rural, and Total country sheets
- reconcile category sums to published totals
- construct five-year total-growth, share-change, and zero-summing reallocation intervals
- preserve estimate/projection and revised-history semantics
- separate realized outcomes from origin-available lagged forecast features
- add country-equal and population-weighted global/region summaries
- add a reproducible runner and documentation

Closes #56
Advances #29

## Verification

- `uv run --locked pytest -q` — 122 passed
- `uv run --locked ruff check .` — passed
- `git diff --check` — passed
- real registered F01 workbook reconciled successfully
- real run produced 71,811 panel rows and 16,827 retrospective five-year intervals across 237 countries/areas

## Limitation

These counts establish executable coverage, not predictive value. Forecast comparison and result registration remain open under #29.