### PR TITLE
Correct national-envelope origin grid and audit discontinuities

### DIFF
--- a/docs/national-context.md
+++ b/docs/national-context.md
@@ -6,13 +6,24 @@ Module A now reads the registered WUP 2025 F01 `Cities`, `Towns`, `Rural`, and `
 sheets directly. Country-category sums must reconcile to the published total within three
 persons after conversion from thousands; failure stops the build. Five-year intervals report
 total growth, category growth availability, settlement shares, share changes, and a
-zero-summing reallocation decomposition. These are revised-history national estimates, not
-vintage-real-time observations.
+zero-summing reallocation decomposition. Origins are restricted to a five-year grid anchored
+at 1950, matching the city forecast cadence and preventing overlapping annual windows from
+being treated as independent time information. These are revised-history national estimates,
+not vintage-real-time observations.
+
+An interval receives `composition_discontinuity_flag` when any settlement category appears or
+disappears at an endpoint, or when any category share changes by at least 0.25 within five
+years. The threshold is a prespecified audit rule, not an estimate of demographic plausibility.
+All intervals remain in the `all` summaries; `stable_composition` summaries exclude flagged
+intervals as a sensitivity analysis. A flag can reflect real rapid change, classification
+change, or source revision and must not be interpreted as a data error without country-level
+source review.
 
 Forecast features are built separately. They contain origin settlement shares and growth or
 share change from the interval completed at the origin. Realized origin-to-endpoint envelope
 growth and share change are outcomes and are prohibited as forecast-origin features. Global
 and regional summaries report country-equal and population-at-origin weighting separately.
+They also identify whether they use all intervals or the stable-composition sensitivity sample.
 The direct envelope supersedes any attempt to treat recovered Module B country-period fixed
 effects as primary national demographic data; recovered effects remain diagnostic only.
 

--- a/docs/research-status.md
+++ b/docs/research-status.md
@@ -54,11 +54,15 @@ combined result before evaluating the corrected-estimator gate.
 
 The direct Module A national-envelope pipeline is executable from the registered WUP F01
 workbook. It reconciles Cities, Towns, and Rural country totals to the publisher's Total sheet,
-constructs five-year reallocation intervals, separates retrospective outcomes from
-origin-available forecast features, and produces country-equal and population-weighted
-regional/global summaries. This is an implementation result, not evidence that a national
-envelope improves city forecasts. Numerical interpretation and provenance-bound result
-registration remain open under issue #29.
+constructs 3,555 non-overlapping five-year reallocation intervals on the forecast-origin grid,
+separates retrospective outcomes from origin-available forecast features, and produces
+country-equal and population-weighted regional/global summaries. The audit flags 85 intervals
+(2.39%) for category appearance/disappearance or an absolute category-share change of at least
+0.25; summaries retain the complete sample and report a stable-composition sensitivity that
+excludes those intervals. A flag is not proof of source error or demographic impossibility.
+This is an implementation and numerical-audit result, not evidence that a national envelope
+improves city forecasts or a causal interpretation of settlement reallocation. Provenance-bound
+result registration remains open under issue #29.
 
 The source and transformation pipeline is reproducible from registered local files, but all results remain **retrospective current-revision tests**. The WUP and GHSL exercises use different city definitions and must not be pooled. WUP supplies demographic city records without a verified stable-polygon restriction. GHSL supplies a balanced panel calculated inside fixed 2025 polygons, but that definition uses future geographic information and is not vintage-correct. Neither is sufficient for a commercial forecasting claim.
 

--- a/src/urban_growth/national_envelope.py
+++ b/src/urban_growth/national_envelope.py
@@ -11,7 +11,13 @@ DEGURBA_CATEGORIES = ("city", "town_and_semi_dense", "rural")
 
 
 def national_envelope_intervals(
-    panel: pd.DataFrame, *, interval_years: int = 5, estimate_end_year: int = 2025
+    panel: pd.DataFrame,
+    *,
+    interval_years: int = 5,
+    origin_step_years: int = 5,
+    origin_anchor_year: int = 1950,
+    estimate_end_year: int = 2025,
+    large_share_change_threshold: float = 0.25,
 ) -> pd.DataFrame:
     """Decompose national population change and settlement-class reallocation."""
     required = {
@@ -22,8 +28,10 @@ def national_envelope_intervals(
     reject_duplicate_keys(
         panel, ["country_code", "year", "category"], source_name="national settlement panel"
     )
-    if interval_years <= 0:
-        raise SourceSchemaError("National-envelope interval must be positive")
+    if interval_years <= 0 or origin_step_years <= 0:
+        raise SourceSchemaError("National-envelope interval and origin step must be positive")
+    if not 0 < large_share_change_threshold <= 1:
+        raise SourceSchemaError("Large-share-change threshold must be in (0, 1]")
     unknown = set(panel["category"].dropna()) - set(DEGURBA_CATEGORIES)
     if unknown:
         raise SourceSchemaError(f"Unknown national settlement categories: {sorted(unknown)}")
@@ -53,7 +61,10 @@ def national_envelope_intervals(
     start["period_end"] = start["year"] + interval_years
     result = start.merge(end, on=["country_code", "period_end"], validate="one_to_one")
     result = result.rename(columns={"year": "period_start"})
-    result = result.loc[result["period_end"].le(estimate_end_year)].copy()
+    result = result.loc[
+        result["period_end"].le(estimate_end_year)
+        & result["period_start"].sub(origin_anchor_year).mod(origin_step_years).eq(0)
+    ].copy()
     result = result.merge(
         metadata.rename(columns={"year": "period_start", "observation_type": "start_status"}),
         on=["country_code", "period_start"], validate="many_to_one",
@@ -100,6 +111,19 @@ def national_envelope_intervals(
         raise SourceSchemaError("National settlement share changes do not sum to zero")
     if not np.allclose(result[reallocation_columns].sum(axis=1), 0, atol=1e-6):
         raise SourceSchemaError("National settlement reallocations do not sum to zero")
+    presence_transitions = []
+    for category in DEGURBA_CATEGORIES:
+        start_positive = result[f"{category}_population_start"].gt(0)
+        end_positive = result[f"{category}_population_end"].gt(0)
+        presence_transitions.append(start_positive.ne(end_positive))
+    result["category_presence_transition"] = pd.concat(presence_transitions, axis=1).any(axis=1)
+    result["large_share_change_threshold"] = large_share_change_threshold
+    result["large_share_change_flag"] = result[share_change_columns].abs().max(axis=1).ge(
+        large_share_change_threshold
+    )
+    result["composition_discontinuity_flag"] = (
+        result["category_presence_transition"] | result["large_share_change_flag"]
+    )
     result["interval_observation_status"] = np.where(
         result["start_status"].eq("estimate") & result["end_status"].eq("estimate"),
         "retrospective_revised_estimate", "contains_projection",
@@ -184,7 +208,7 @@ def national_envelope_summaries(intervals: pd.DataFrame) -> pd.DataFrame:
     ]
     required = {
         "country_code", "period_start", "period_end", "region_name",
-        "total_population_start", *metrics,
+        "total_population_start", "composition_discontinuity_flag", *metrics,
     }
     require_columns(intervals, required, source_name="national envelope intervals")
     records = []
@@ -192,28 +216,33 @@ def national_envelope_summaries(intervals: pd.DataFrame) -> pd.DataFrame:
         ("global", pd.Series("Global", index=intervals.index)),
         ("region", intervals["region_name"]),
     ]
-    for aggregation_level, labels in group_designs:
-        working = intervals.assign(_group=labels)
-        for (period_start, period_end, group_name), group in working.groupby(
-            ["period_start", "period_end", "_group"], sort=True
-        ):
-            weights = group["total_population_start"].to_numpy(dtype=float)
-            for weighting in ("country_equal", "population_start"):
-                row: dict[str, int | float | str] = {
-                    "aggregation_level": aggregation_level,
-                    "group_name": str(group_name),
-                    "period_start": int(period_start),
-                    "period_end": int(period_end),
-                    "weighting": weighting,
-                    "country_count": group["country_code"].nunique(),
-                }
-                for metric in metrics:
-                    values = group[metric].to_numpy(dtype=float)
-                    row[metric] = (
-                        float(values.mean()) if weighting == "country_equal"
-                        else float(np.average(values, weights=weights))
-                    )
-                records.append(row)
+    for sample_name, sample in (
+        ("all", intervals),
+        ("stable_composition", intervals.loc[~intervals["composition_discontinuity_flag"]]),
+    ):
+        for aggregation_level, labels in group_designs:
+            working = sample.assign(_group=labels.reindex(sample.index))
+            for (period_start, period_end, group_name), group in working.groupby(
+                ["period_start", "period_end", "_group"], sort=True
+            ):
+                weights = group["total_population_start"].to_numpy(dtype=float)
+                for weighting in ("country_equal", "population_start"):
+                    row: dict[str, int | float | str] = {
+                        "sample": sample_name,
+                        "aggregation_level": aggregation_level,
+                        "group_name": str(group_name),
+                        "period_start": int(period_start),
+                        "period_end": int(period_end),
+                        "weighting": weighting,
+                        "country_count": group["country_code"].nunique(),
+                    }
+                    for metric in metrics:
+                        values = group[metric].to_numpy(dtype=float)
+                        row[metric] = (
+                            float(values.mean()) if weighting == "country_equal"
+                            else float(np.average(values, weights=weights))
+                        )
+                    records.append(row)
     return pd.DataFrame(records).sort_values(
-        ["aggregation_level", "group_name", "period_start", "weighting"]
+        ["sample", "aggregation_level", "group_name", "period_start", "weighting"]
     ).reset_index(drop=True)

--- a/tests/test_national_envelope.py
+++ b/tests/test_national_envelope.py
@@ -47,6 +47,7 @@ def test_national_envelope_decomposes_growth_and_reallocation() -> None:
         "city", "town_and_semi_dense", "rural"
     )) == pytest.approx(0.0)
     assert result["interval_observation_status"].eq("retrospective_revised_estimate").all()
+    assert not result["composition_discontinuity_flag"].any()
 
 
 def test_national_envelope_rejects_incomplete_composition() -> None:
@@ -83,9 +84,26 @@ def test_summaries_separate_country_equal_and_population_weights() -> None:
     )
     summaries = national_envelope_summaries(pd.concat([intervals, second_country]))
     global_first = summaries.loc[
-        summaries["aggregation_level"].eq("global") & summaries["period_start"].eq(2000)
+        summaries["sample"].eq("all") & summaries["aggregation_level"].eq("global")
+        & summaries["period_start"].eq(2000)
     ].set_index("weighting")
     assert global_first.loc["population_start", "total_annualized_log_growth"] > global_first.loc[
         "country_equal", "total_annualized_log_growth"
     ]
     assert global_first["country_count"].eq(2).all()
+
+
+def test_origin_grid_is_nonoverlapping_and_discontinuities_are_flagged() -> None:
+    source = envelope_panel()
+    extra_start = source.loc[source["year"].eq(2005)].assign(year=2001)
+    extra_end = source.loc[source["year"].eq(2010)].assign(year=2006)
+    result = national_envelope_intervals(pd.concat([source, extra_start, extra_end]))
+    assert 2001 not in result["period_start"].tolist()
+    source.loc[source["year"].eq(2005) & source["category"].eq("city"), "population"] = 1000
+    source.loc[
+        source["year"].eq(2005) & source["category"].eq("town_and_semi_dense"), "population"
+    ] = 0
+    flagged = national_envelope_intervals(source).iloc[0]
+    assert flagged["category_presence_transition"]
+    assert flagged["large_share_change_flag"]
+    assert flagged["composition_discontinuity_flag"]


### PR DESCRIPTION
Closes #58. Advances #29.

## What changed
- restrict Module A to non-overlapping five-year origins anchored at 1950;
- surface category-presence transitions and absolute share changes of at least 0.25;
- retain the full sample while adding a `stable_composition` sensitivity summary;
- document the 3,555-interval production audit and its 85 flagged intervals without treating flags as source errors or causal evidence.

## Validation
- `uv run --locked pytest` — 123 passed
- `uv run --locked ruff check .` — passed
- `git diff --check` — passed

## Result registration
No result manifest is added here. A follow-up must regenerate the outputs after this PR merges and bind the manifest to the exact producing merge commit.