### PR TITLE
Make the dynamic hierarchy executable on WUP

### DIFF
--- a/docs/research-status.md
+++ b/docs/research-status.md
@@ -64,6 +64,15 @@ result, not a workflow failure to retry. Thresholds were not changed and no clai
 the jackknife multiplier interval as validated uncertainty pending a separately specified
 estimator or interval redesign.
 
+The empirical hierarchy runner now absorbs country-period and city fixed effects by weighted
+alternating projections rather than materializing a global city-dummy matrix. Small-panel tests
+require absorbed coefficients to match the prior dense weighted and unweighted fits. The WUP
+runner also enforces at least two observations per city in each jackknife half and reports the
+resulting row and city retention. This makes the common-sample point-estimate comparison
+executable, but it increases survivorship selection. Numerical outputs remain unregistered
+until regeneration from the merged producing commit; no interim coefficient should be treated
+as a validated inferential result.
+
 ## Evidence state
 
 The direct Module A national-envelope pipeline is executable from the registered WUP F01

--- a/scripts/run_wup_dynamic_hierarchy.py
+++ b/scripts/run_wup_dynamic_hierarchy.py
@@ -1,0 +1,106 @@
+"""Run the point-estimate dynamic hierarchy on one empirical WUP sample."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from urban_growth.adapters.wup import (
+    read_f21_city_population,
+    read_f25_city_land_area,
+    read_f30_built_up_area_per_capita,
+    read_f34_population_density,
+)
+from urban_growth.dynamic_estimators import (
+    common_dynamic_sample,
+    estimator_disagreement_report,
+    fit_dynamic_hierarchy,
+)
+from urban_growth.forecast import build_forecast_intervals
+from urban_growth.wup_panel import build_wup_city_year_panel
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--raw-dir", type=Path, default=Path("data/raw"))
+    parser.add_argument(
+        "--estimates-output", type=Path,
+        default=Path("outputs/wup_dynamic_hierarchy_estimates.csv"),
+    )
+    parser.add_argument(
+        "--disagreement-output", type=Path,
+        default=Path("outputs/wup_dynamic_hierarchy_disagreement.csv"),
+    )
+    parser.add_argument(
+        "--sample-audit-output", type=Path,
+        default=Path("outputs/wup_dynamic_hierarchy_sample_audit.csv"),
+    )
+    args = parser.parse_args()
+    raw = args.raw_dir
+    population = read_f21_city_population(raw / "WUP2025-F21-DEGURBA-Cities_Pop.xlsx")
+    area = read_f25_city_land_area(raw / "WUP2025-F25-DEGURBA-Cities_AREA_km2.xlsx")
+    built = read_f30_built_up_area_per_capita(
+        raw / "WUP2025-F30-DEGURBA-Cities_BU_m2_per_capita.xlsx"
+    )
+    density = read_f34_population_density(
+        raw / "WUP2025-F34-DEGURBA-Cities_Pop_density.xlsx"
+    )
+    panel = build_wup_city_year_panel(population, area, built, density)
+    intervals = build_forecast_intervals(panel, list(range(1980, 2025, 5)))
+    intervals["log_population_start"] = np.log(intervals["population_start"])
+    covariates = ["log_population_start", "country_rank_percentile_origin"]
+    sample = common_dynamic_sample(
+        intervals, outcome="future_growth", lagged_outcome="recent_growth",
+        covariates=covariates, period="period_start",
+    )
+    estimates = fit_dynamic_hierarchy(
+        sample, outcome="future_growth", lagged_outcome="recent_growth",
+        covariates=covariates, period="period_start",
+    )
+    estimates["data_revision"] = "WUP_2025_revised_history"
+    estimates["boundary_semantics"] = "WUP changing city definitions"
+    estimates["causal_interpretation_permitted"] = False
+    estimates["validated_inference"] = False
+    estimates["uncertainty_status"] = (
+        "point estimates only; corrected-estimator production coverage gate failed"
+    )
+    disagreement = estimator_disagreement_report(estimates)
+    by_period = sample.groupby("period_start", as_index=False).agg(
+        rows=("city_id", "size"), cities=("city_id", "nunique"),
+        countries=("country_code", "nunique"),
+    )
+    by_period.insert(0, "scope", "period")
+    overall = pd.DataFrame(
+        [{
+            "scope": "overall", "period_start": pd.NA, "rows": len(sample),
+            "cities": sample["city_id"].nunique(),
+            "countries": sample["country_code"].nunique(),
+        }]
+    )
+    audit = pd.concat([overall, by_period], ignore_index=True)
+    audit["candidate_rows"] = len(intervals)
+    audit["candidate_cities"] = intervals["city_id"].nunique()
+    audit["candidate_countries"] = intervals["country_code"].nunique()
+    audit["row_retention_rate"] = len(sample) / len(intervals)
+    audit["city_retention_rate"] = sample["city_id"].nunique() / intervals["city_id"].nunique()
+    audit["minimum_periods_per_city"] = sample.groupby("city_id").size().min()
+    audit["maximum_periods_per_city"] = sample.groupby("city_id").size().max()
+    audit["common_sample_across_estimators"] = True
+    audit["selection_semantics"] = (
+        "requires at least two observations in each forecast-origin half"
+    )
+    for path, frame in (
+        (args.estimates_output, estimates),
+        (args.disagreement_output, disagreement),
+        (args.sample_audit_output, audit),
+    ):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        frame.to_csv(path, index=False)
+        print(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/urban_growth/dynamic_estimators.py
+++ b/src/urban_growth/dynamic_estimators.py
@@ -83,6 +83,15 @@ def common_dynamic_sample(
         sample = sample.loc[
             sample.groupby(city)[city].transform("size").ge(min_city_periods)
         ]
+        periods = sorted(sample[period].unique())
+        if len(periods) < 4:
+            raise SourceSchemaError("Dynamic common sample needs at least four periods")
+        midpoint = len(periods) // 2
+        eligible_cities = set(sample[city].unique())
+        for half in (periods[:midpoint], periods[midpoint:]):
+            half_counts = sample.loc[sample[period].isin(half)].groupby(city).size()
+            eligible_cities &= set(half_counts.loc[half_counts.ge(2)].index)
+        sample = sample.loc[sample[city].isin(eligible_cities)]
         # A singleton country-period cell is absorbed perfectly and carries no allocation signal.
         sample = sample.loc[
             sample.groupby("country_period")["country_period"].transform("size").ge(2)
@@ -92,7 +101,7 @@ def common_dynamic_sample(
     return sample.sort_values([city, period]).reset_index(drop=True)
 
 
-def _design(
+def _dense_design_reference(
     sample: pd.DataFrame,
     *,
     outcome: str,
@@ -113,6 +122,48 @@ def _design(
     return sample[outcome].to_numpy(dtype=float), design.to_numpy(), list(design.columns)
 
 
+def _group_codes(groups: pd.Series) -> tuple[np.ndarray, int]:
+    codes, uniques = pd.factorize(groups, sort=False)
+    if (codes < 0).any():
+        raise SourceSchemaError("Fixed-effect groups cannot be missing")
+    return codes, len(uniques)
+
+
+def _weighted_group_demean(
+    values: np.ndarray, *, codes: np.ndarray, group_count: int, weights: np.ndarray
+) -> np.ndarray:
+    weighted_sums = np.zeros((group_count, values.shape[1]), dtype=float)
+    np.add.at(weighted_sums, codes, values * weights[:, None])
+    weight_sums = np.bincount(codes, weights=weights, minlength=group_count)
+    if (weight_sums <= 0).any():
+        raise SourceSchemaError("Every absorbed fixed-effect group needs positive weight")
+    return values - weighted_sums[codes] / weight_sums[codes, None]
+
+
+def _absorb_fixed_effects(
+    values: np.ndarray,
+    *,
+    groups: list[pd.Series],
+    weights: np.ndarray,
+    tolerance: float = 1e-10,
+    max_iterations: int = 10_000,
+) -> np.ndarray:
+    """Residualize columns by one or more fixed effects without dummy matrices."""
+    encoded = [_group_codes(group) for group in groups]
+    result = values.astype(float, copy=True)
+    for _ in range(max_iterations):
+        previous = result.copy()
+        for codes, group_count in encoded:
+            result = _weighted_group_demean(
+                result, codes=codes, group_count=group_count, weights=weights
+            )
+        change = float(np.max(np.abs(result - previous)))
+        scale = max(1.0, float(np.max(np.abs(previous))))
+        if change <= tolerance * scale:
+            return result
+    raise SourceSchemaError("Fixed-effect absorption did not converge")
+
+
 def _cluster_meat(x: np.ndarray, residual: np.ndarray, groups: pd.Series) -> np.ndarray:
     scores = x * residual[:, None]
     grouped = pd.DataFrame(scores).groupby(groups.astype(str).to_numpy(), sort=False).sum()
@@ -131,21 +182,27 @@ def _fit_ols(
     city_fixed_effects: bool,
     weights: np.ndarray | None = None,
 ) -> pd.DataFrame:
-    y, x, names = _design(
-        sample, outcome=outcome, lagged_outcome=lagged_outcome, covariates=covariates,
-        city=city, city_fixed_effects=city_fixed_effects,
-    )
+    names = [lagged_outcome, *covariates]
+    values = sample[[outcome, *names]].to_numpy(dtype=float)
     if weights is None:
-        fit_x, fit_y = x, y
+        row_weights = np.ones(len(sample), dtype=float)
     else:
-        weights = np.asarray(weights, dtype=float)
-        if len(weights) != len(sample) or not np.isfinite(weights).all() or (weights <= 0).any():
+        row_weights = np.asarray(weights, dtype=float)
+        if (
+            len(row_weights) != len(sample)
+            or not np.isfinite(row_weights).all()
+            or (row_weights <= 0).any()
+        ):
             raise SourceSchemaError("Estimator weights must be finite, positive, and row-aligned")
-        root_weight = np.sqrt(weights)
-        fit_x, fit_y = x * root_weight[:, None], y * root_weight
+    fixed_effects = [sample["country_period"]]
+    if city_fixed_effects:
+        fixed_effects.append(sample[city])
+    absorbed = _absorb_fixed_effects(values, groups=fixed_effects, weights=row_weights)
+    y, x = absorbed[:, 0], absorbed[:, 1:]
+    root_weight = np.sqrt(row_weights)
+    fit_x, fit_y = x * root_weight[:, None], y * root_weight
     beta = np.linalg.lstsq(fit_x, fit_y, rcond=None)[0]
     residual = y - x @ beta
-    target_count = 1 + len(covariates)
     if weights is None:
         bread = np.linalg.pinv(x.T @ x)
         country_meat = _cluster_meat(x, residual, sample[country])
@@ -154,13 +211,13 @@ def _fit_ols(
         covariance = bread @ (
             country_meat + period_meat - _cluster_meat(x, residual, intersection)
         ) @ bread
-        standard_errors = np.sqrt(np.maximum(np.diag(covariance)[:target_count], 0.0))
+        standard_errors = np.sqrt(np.maximum(np.diag(covariance), 0.0))
     else:
-        standard_errors = np.repeat(np.nan, target_count)
+        standard_errors = np.repeat(np.nan, len(names))
     return pd.DataFrame(
         {
-            "term": names[:target_count],
-            "estimate": beta[:target_count],
+            "term": names,
+            "estimate": beta,
             "std_error_country_period": standard_errors,
             "n_rows": len(sample),
             "n_cities": sample[city].nunique(),

--- a/tests/test_dynamic_estimators.py
+++ b/tests/test_dynamic_estimators.py
@@ -4,6 +4,7 @@ import pytest
 
 from urban_growth.dynamic_estimators import (
     _apply_coverage_gate,
+    _dense_design_reference,
     bootstrap_dynamic_hierarchy,
     common_dynamic_sample,
     estimator_disagreement_report,
@@ -69,6 +70,21 @@ def test_common_sample_rejects_duplicate_city_periods() -> None:
         )
 
 
+def test_common_sample_requires_support_in_both_jackknife_halves() -> None:
+    source = simulated_panel(cities=16, periods=8)
+    source = source.loc[
+        ~(source["city_id"].eq(0) & source["period"].isin([0, 1, 2]))
+    ]
+    sample = common_dynamic_sample(
+        source, outcome="growth", lagged_outcome="lagged_growth", covariates=["x"]
+    )
+    assert 0 not in sample["city_id"].unique()
+    periods = sorted(sample["period"].unique())
+    midpoint = len(periods) // 2
+    for half in (periods[:midpoint], periods[midpoint:]):
+        assert sample.loc[sample["period"].isin(half)].groupby("city_id").size().min() >= 2
+
+
 def test_hierarchy_recovers_parameters_within_declared_single_panel_tolerances() -> None:
     sample = common_dynamic_sample(
         simulated_panel(), outcome="growth", lagged_outcome="lagged_growth", covariates=["x"]
@@ -84,6 +100,50 @@ def test_hierarchy_recovers_parameters_within_declared_single_panel_tolerances()
     assert abs(covariate.loc["half_panel_jackknife", "estimate"] - 0.3) < 0.08
     assert abs(persistence.loc["half_panel_jackknife", "estimate"] - 0.55) < 0.08
     assert persistence.loc["half_panel_jackknife", "n_rows"] == len(sample)
+
+
+@pytest.mark.parametrize("weighted", [False, True])
+@pytest.mark.parametrize("city_fixed_effects", [False, True])
+def test_absorbed_coefficients_match_dense_reference(
+    weighted: bool, city_fixed_effects: bool
+) -> None:
+    sample = common_dynamic_sample(
+        simulated_panel(cities=16, periods=6), outcome="growth",
+        lagged_outcome="lagged_growth", covariates=["x"],
+    )
+    weights = np.linspace(0.5, 1.5, len(sample)) if weighted else None
+    dense_y, dense_x, _ = _dense_design_reference(
+        sample, outcome="growth", lagged_outcome="lagged_growth", covariates=["x"],
+        city="city_id", city_fixed_effects=city_fixed_effects,
+    )
+    if weights is None:
+        dense_beta = np.linalg.lstsq(dense_x, dense_y, rcond=None)[0][:2]
+    else:
+        root = np.sqrt(weights)
+        dense_beta = np.linalg.lstsq(
+            dense_x * root[:, None], dense_y * root, rcond=None
+        )[0][:2]
+    estimator = "city_fe_dynamic" if city_fixed_effects else "pooled_dynamic"
+    absorbed = fit_dynamic_hierarchy(
+        sample, outcome="growth", lagged_outcome="lagged_growth", covariates=["x"],
+        weights=weights,
+    )
+    actual = absorbed.loc[absorbed["estimator_id"].eq(estimator), "estimate"].to_numpy()
+    np.testing.assert_allclose(actual, dense_beta, rtol=1e-8, atol=1e-9)
+
+
+def test_production_fit_does_not_construct_dummy_matrix(monkeypatch: pytest.MonkeyPatch) -> None:
+    sample = common_dynamic_sample(
+        simulated_panel(cities=16, periods=6), outcome="growth",
+        lagged_outcome="lagged_growth", covariates=["x"],
+    )
+    monkeypatch.setattr(
+        pd, "get_dummies", lambda *args, **kwargs: pytest.fail("dense dummies constructed")
+    )
+    result = fit_dynamic_hierarchy(
+        sample, outcome="growth", lagged_outcome="lagged_growth", covariates=["x"]
+    )
+    assert len(result) == 6
 
 
 def test_disagreement_report_flags_sign_and_magnitude() -> None:


### PR DESCRIPTION
Closes #64. Advances #27.

## What changed
- replaces dense country-period/city dummy matrices with weighted alternating-projection absorption;
- enforces two observations per city in each jackknife half on the common sample;
- proves absorbed coefficients equal the prior dense weighted and unweighted fits on small panels;
- adds a WUP point-estimate runner using recent growth, origin log population, and origin country-rank percentile;
- emits estimator results, disagreement, and explicit retention audit;
- labels every empirical output as current-revision, changing-boundary, non-causal, and without validated inference.

## Provisional numerical audit
The runner completes on 55,793 common-sample rows, 6,450 cities, 142 countries, and nine origins. All three terms trigger mandatory estimator-disagreement reporting. These outputs are not registered in this PR and must be regenerated after merge before entering research status as results.

## Explicit non-scope
- no replacement confidence interval;
- no relaxation of the failed coverage gate;
- no causal interpretation of size, hierarchy, or persistence coefficients.

## Validation
- `uv run --locked pytest` — 129 passed
- `uv run --locked ruff check .` — passed
- absorbed/dense equivalence tested for pooled/city-FE and weighted/unweighted fits
- production path test prohibits dense dummy construction
- `git diff --check` — passed