### PR TITLE
Correct interval-policy provenance and sparse-cell reporting

### DIFF
--- a/docs/interval-policy-audit-2026-08-30.md
+++ b/docs/interval-policy-audit-2026-08-30.md
@@ -1,0 +1,68 @@
+# Pass 3 audit — sequential interval policy and sparse cells
+
+Date: 30 August 2026
+
+## Verdicts
+
+### Q1 — sequential leakage: PASS
+
+`sequential_interval_calibration` constructs each calibration set with
+`origin < test origin`. A recent-window policy then truncates that already eligible
+set to its latest three origins. Both production scripts call only
+`registered_sequential_interval_calibration` with literal policy identifiers. There
+is no script pre-pass that pools future residuals to choose a policy, parameter or
+reported stratum.
+
+This pass applies to the mechanics of each reported row. It does not establish that
+the policy menu itself was selected prospectively.
+
+### Q2 — policy-selection timing: UNRESOLVED-PROCESS
+
+Git history establishes the following sequence:
+
+1. Sequential calibration implementation: `8c4e2fa6fb1e48b530cc85089f74452a6872f013`.
+2. Base policy registry: `2e9d7784dfd623877a4ef6d9b25b515918f3fcf7`.
+3. Recent-three-origin policies: `bd2be2e5aaf5e809bfbcddaed0c38b9826650cac`.
+4. Equal-country policies: `5fd82b646cdb46c70369184dfab757b81b9592ac`.
+5. Locked specification: `9f1c8cb76da4655493e16797eacb7f96c268e61c`.
+
+The source tree cannot establish when the first real-data calibration output was
+computed because generated outputs were not committed. No earlier timestamped design
+artifact names all six policies and their exact parameters. The repository therefore
+has no basis for `stratification_prespecified=True` or for a prospective-registration
+claim.
+
+Resolution would require a timestamped external artifact predating the first real
+run, containing the exact six identifiers and values for miscoverage, minimum rows,
+minimum origins, recent-window length, weighting and grouping. Without that evidence,
+the policies remain retrospective sensitivity analyses.
+
+### Q3 — sparse-cell handling: FAIL, remediated
+
+Before this change, cells below `minimum_calibration_rows` or
+`minimum_calibration_origins` hit `continue` and vanished. The output therefore
+contained only eligible cells and could not disclose the share or identity of
+candidate cells omitted for sparse calibration history.
+
+Registered runs now retain every origin/model/stratum candidate with:
+
+- `calibration_eligible`;
+- `calibration_exclusion_reason`;
+- available row, origin and country counts;
+- policy timing and lock-commit metadata.
+
+Ineligible rows carry no realized coverage statistic. Coverage summaries must report
+their eligibility denominator separately; they may not silently drop these rows.
+
+The registered production rerun gives the following eligibility audit:
+
+| Source and table | Candidate cells | Eligible | Ineligible | Eligible share |
+|---|---:|---:|---:|---:|
+| WUP overall | 288 | 216 | 72 | 75% |
+| WUP by size | 1,728 | 1,296 | 432 | 75% |
+| GHSL fixed overall | 120 | 90 | 30 | 75% |
+| GHSL fixed by size | 840 | 630 | 210 | 75% |
+
+All ineligible cells occur before enough prior origins are available. Some also fail
+the 100-row minimum. They are calibration-availability exclusions, not empirical
+coverage failures.

--- a/docs/research-design.md
+++ b/docs/research-design.md
@@ -66,8 +66,10 @@ Forecasting does not require causal exogeneity, but interpretation of coefficien
 Point-error rankings do not establish usable uncertainty. The WUP and fixed-GHSL
 workflows now construct symmetric 90% empirical error bands for each model and
 forecast origin using absolute errors from strictly earlier origins only. The radius is the exact
-order statistic at rank \(\lceil(n+1)(1-\alpha)\rceil\); origins with too few
-calibration rows to realize that rank are not reported. Outputs report the chosen
+order statistic at rank \(\lceil(n+1)(1-\alpha)\rceil\). Origins with too few
+calibration rows or prior origins are retained as ineligible ledger rows with an
+explicit exclusion reason; they carry no coverage statistic and must remain in
+denominators used to report calibration availability. Eligible rows report the chosen
 rank, interval radius and width, city-
 weighted realized coverage, equal-country realized coverage, coverage error, and the
 latest calibration origin. They also report lower-tail misses (actual growth below
@@ -78,8 +80,14 @@ such a band can meet its nominal rate while systematically understating decline 
 or upside growth. The executable workflows report four versioned policies. `overall_90_v1`
 and `size_bin_90_v1` use all prior origins; `overall_90_recent3_v1` and
 `size_bin_90_recent3_v1` retain only the three most recent eligible origins.
-Each fixes nominal coverage, minimum calibration rows, minimum prior origins,
-maximum prior origins and grouping before outputs are opened. The recent-window
+Each now fixes nominal coverage, minimum calibration rows, minimum prior origins,
+maximum prior origins and grouping for reproducible reruns. This is a retrospective
+lock, not preregistration: calibration-capable code preceded the policy registry,
+and no committed timestamped artifact establishes that the six policies preceded
+the first real-data calibration run. The recent-window and equal-country variants
+were committed after the base registry.
+Accordingly, registered outputs mark `stratification_prespecified` and
+`policy_locked_before_first_results` false and identify the policy-lock commit. The recent-window
 variants are sensitivity tests for residual-distribution drift, not alternatives to
 select after comparing coverage. Material disagreement means the expanding
 exchangeability assumption is not credible. Two additional registered sensitivities,
@@ -89,7 +97,7 @@ whether countries with many reported cities determine the radius. These weighted
 empirical quantiles do not receive the ordinary finite-sample conformal rank guarantee
 and are labeled accordingly; they must be compared with, not substituted for, the
 city-weighted policies.
-Registered outputs carry the policy identifier and a prespecification flag. Arbitrary
+Registered outputs carry the policy identifier and honest timing metadata. Arbitrary
 groupings produced by the lower-level function are labeled `ad_hoc_unregistered`
 and cannot be presented as confirmatory conditional-coverage tests.
 

--- a/docs/research-status.md
+++ b/docs/research-status.md
@@ -518,6 +518,30 @@ Single-city influence is negligible at the pooled level. The largest deletion ch
 
 This diagnostic addresses dependence on one observed cluster; it does not repair unequal country representation, threshold selection or common WUP revision error. Balanced-country weighting and balanced-entry cohorts remain separate required tests.
 
+## Interval-policy audit
+
+The sequential mechanics pass the leakage check: every evaluated origin uses only
+strictly earlier residuals, and recent-window policies retain only the latest three
+eligible prior origins. The policy-selection provenance does not pass a prospective
+registration claim. Git history shows sequential calibration was implemented before
+the base registry; recent-window and equal-country variants were added later, and the
+locked specification followed all of them. Source history cannot date the first
+uncommitted real-data run, and no contemporaneous preregistration artifact is present.
+The six policies must therefore be treated as retrospectively frozen sensitivity
+analyses unless external timestamped evidence resolves the process question. They are
+reproducible, but none currently qualifies as a clean holdout-confirmatory policy.
+
+Registered calibration outputs now retain every origin/model/stratum candidate.
+Cells below the minimum row or prior-origin thresholds are marked ineligible with an
+explicit reason and have no coverage statistic. This prevents calibration summaries
+from silently describing only well-powered cells. Any aggregate must report both the
+eligible-cell coverage result and the fraction of candidate cells eligible.
+On the registered rerun, each table is 75% eligible: WUP retains coverage statistics
+for 216 of 288 overall candidate cells and 1,296 of 1,728 size-stratified cells;
+fixed-boundary GHSL retains 90 of 120 and 630 of 840, respectively. The omitted
+quarter consists of early cells lacking the two required prior origins, sometimes
+also lacking 100 prior rows. These are availability exclusions, not observed misses.
+
 ## Reproduction
 
 With the registered raw files under `data/raw/`, run:

--- a/src/urban_growth/forecast.py
+++ b/src/urban_growth/forecast.py
@@ -30,6 +30,7 @@ REGISTERED_INTERVAL_CALIBRATION_POLICIES = {
         "minimum_calibration_origins": 2,
         "maximum_calibration_origins": None,
         "group_columns": [],
+        "policy_lock_commit": "2e9d7784dfd623877a4ef6d9b25b515918f3fcf7",
     },
     "overall_90_recent3_v1": {
         "miscoverage": 0.10,
@@ -38,6 +39,7 @@ REGISTERED_INTERVAL_CALIBRATION_POLICIES = {
         "minimum_calibration_origins": 2,
         "maximum_calibration_origins": 3,
         "group_columns": [],
+        "policy_lock_commit": "bd2be2e5aaf5e809bfbcddaed0c38b9826650cac",
     },
     "size_bin_90_v1": {
         "miscoverage": 0.10,
@@ -46,6 +48,7 @@ REGISTERED_INTERVAL_CALIBRATION_POLICIES = {
         "minimum_calibration_origins": 2,
         "maximum_calibration_origins": None,
         "group_columns": ["size_bin"],
+        "policy_lock_commit": "2e9d7784dfd623877a4ef6d9b25b515918f3fcf7",
     },
     "size_bin_90_recent3_v1": {
         "miscoverage": 0.10,
@@ -54,6 +57,7 @@ REGISTERED_INTERVAL_CALIBRATION_POLICIES = {
         "minimum_calibration_origins": 2,
         "maximum_calibration_origins": 3,
         "group_columns": ["size_bin"],
+        "policy_lock_commit": "bd2be2e5aaf5e809bfbcddaed0c38b9826650cac",
     },
     "overall_90_equal_country_v1": {
         "miscoverage": 0.10,
@@ -62,6 +66,7 @@ REGISTERED_INTERVAL_CALIBRATION_POLICIES = {
         "minimum_calibration_origins": 2,
         "maximum_calibration_origins": None,
         "group_columns": [],
+        "policy_lock_commit": "5fd82b646cdb46c70369184dfab757b81b9592ac",
     },
     "size_bin_90_equal_country_v1": {
         "miscoverage": 0.10,
@@ -70,6 +75,7 @@ REGISTERED_INTERVAL_CALIBRATION_POLICIES = {
         "minimum_calibration_origins": 2,
         "maximum_calibration_origins": None,
         "group_columns": ["size_bin"],
+        "policy_lock_commit": "5fd82b646cdb46c70369184dfab757b81b9592ac",
     },
 }
 
@@ -945,6 +951,9 @@ def sequential_interval_calibration(
     group_columns: list[str] | None = None,
     policy_id: str = "ad_hoc_unregistered",
     stratification_prespecified: bool = False,
+    policy_locked_before_first_results: bool = False,
+    policy_lock_commit: str = "",
+    include_ineligible: bool = False,
 ) -> pd.DataFrame:
     """Audit symmetric empirical error bands using strictly earlier origins.
 
@@ -970,7 +979,7 @@ def sequential_interval_calibration(
     if not np.isfinite(working[["error", "absolute_error"]]).all().all():
         raise SourceSchemaError("Interval calibration requires finite errors")
     keys = [*groups, "model"]
-    rows: list[dict[str, float | int | str]] = []
+    rows: list[dict[str, object]] = []
     grouper: str | list[str] = keys[0] if len(keys) == 1 else keys
     for key, model_group in working.groupby(grouper, observed=True, sort=True):
         key_values = (key,) if len(keys) == 1 else key
@@ -984,12 +993,51 @@ def sequential_interval_calibration(
                     calibration["origin"].isin(retained_origins)
                 ]
             calibration_origin_count = calibration["origin"].nunique()
+            test = model_group.loc[model_group["origin"].eq(origin)]
+            base_row: dict[str, float | int | str | bool | None] = dict(labels)
+            base_row.update(
+                {
+                    "origin": int(origin),
+                    "nominal_coverage": 1 - miscoverage,
+                    "test_rows": len(test),
+                    "test_countries": int(test["country_code"].nunique()),
+                    "calibration_rows": len(calibration),
+                    "calibration_weighting": calibration_weighting,
+                    "calibration_countries": int(
+                        calibration["country_code"].nunique()
+                    ),
+                    "calibration_origins": int(calibration_origin_count),
+                    "maximum_calibration_origins": maximum_calibration_origins,
+                    "calibration_uses_current_or_future_origin": False,
+                    "interval_semantics": (
+                        "symmetric_pre_origin_empirical_absolute_error_band"
+                    ),
+                    "calibration_policy_id": policy_id,
+                    "stratification_prespecified": stratification_prespecified,
+                    "policy_locked_before_first_results": (
+                        policy_locked_before_first_results
+                    ),
+                    "policy_lock_commit": policy_lock_commit,
+                }
+            )
             if (
                 len(calibration) < minimum_calibration_rows
                 or calibration_origin_count < minimum_calibration_origins
             ):
+                if include_ineligible:
+                    reasons = []
+                    if len(calibration) < minimum_calibration_rows:
+                        reasons.append("insufficient_calibration_rows")
+                    if calibration_origin_count < minimum_calibration_origins:
+                        reasons.append("insufficient_calibration_origins")
+                    base_row.update(
+                        {
+                            "calibration_eligible": False,
+                            "calibration_exclusion_reason": ";".join(reasons),
+                        }
+                    )
+                    rows.append(base_row)
                 continue
-            test = model_group.loc[model_group["origin"].eq(origin)]
             if test.empty:
                 continue
             conformal_rank: int | None = None
@@ -998,6 +1046,17 @@ def sequential_interval_calibration(
                     np.ceil((len(calibration) + 1) * (1 - miscoverage))
                 )
                 if conformal_rank > len(calibration):
+                    if include_ineligible:
+                        base_row.update(
+                            {
+                                "calibration_eligible": False,
+                                "calibration_exclusion_reason": (
+                                    "unrealizable_conformal_rank"
+                                ),
+                                "calibration_order_statistic_rank": conformal_rank,
+                            }
+                        )
+                        rows.append(base_row)
                     continue
                 ordered_errors = np.sort(calibration["absolute_error"].to_numpy())
                 radius = float(ordered_errors[conformal_rank - 1])
@@ -1020,11 +1079,11 @@ def sequential_interval_calibration(
             country_coverage = covered.groupby(test["country_code"]).mean()
             country_lower_tail = lower_tail_miss.groupby(test["country_code"]).mean()
             country_upper_tail = upper_tail_miss.groupby(test["country_code"]).mean()
-            row: dict[str, float | int | str] = dict(labels)
+            row = dict(base_row)
             row.update(
                 {
-                    "origin": int(origin),
-                    "nominal_coverage": 1 - miscoverage,
+                    "calibration_eligible": True,
+                    "calibration_exclusion_reason": "",
                     "empirical_city_coverage": float(covered.mean()),
                     "equal_country_coverage": float(country_coverage.mean()),
                     "coverage_gap": float(covered.mean() - (1 - miscoverage)),
@@ -1041,27 +1100,12 @@ def sequential_interval_calibration(
                     ),
                     "interval_radius": radius,
                     "interval_width": 2 * radius,
-                    "test_rows": len(test),
-                    "test_countries": int(test["country_code"].nunique()),
-                    "calibration_rows": len(calibration),
                     "calibration_order_statistic_rank": conformal_rank,
-                    "calibration_weighting": calibration_weighting,
-                    "calibration_countries": int(
-                        calibration["country_code"].nunique()
-                    ),
                     "finite_sample_conformal_rank_applied": (
                         calibration_weighting == "city"
                     ),
-                    "calibration_origins": int(calibration_origin_count),
                     "calibration_origin_start": int(calibration["origin"].min()),
                     "calibration_origin_end": int(calibration["origin"].max()),
-                    "maximum_calibration_origins": maximum_calibration_origins,
-                    "calibration_uses_current_or_future_origin": False,
-                    "interval_semantics": (
-                        "symmetric_pre_origin_empirical_absolute_error_band"
-                    ),
-                    "calibration_policy_id": policy_id,
-                    "stratification_prespecified": stratification_prespecified,
                 }
             )
             rows.append(row)
@@ -1091,7 +1135,10 @@ def registered_sequential_interval_calibration(
         calibration_weighting=str(policy["calibration_weighting"]),
         group_columns=list(policy["group_columns"]),
         policy_id=policy_id,
-        stratification_prespecified=True,
+        stratification_prespecified=False,
+        policy_locked_before_first_results=False,
+        policy_lock_commit=str(policy["policy_lock_commit"]),
+        include_ineligible=True,
     )
 
 

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -688,9 +688,43 @@ def test_registered_interval_policy_freezes_strata_and_parameters() -> None:
         pd.DataFrame(rows), policy_id="size_bin_90_v1"
     )
     assert result["calibration_policy_id"].eq("size_bin_90_v1").all()
-    assert result["stratification_prespecified"].all()
+    assert not result["stratification_prespecified"].any()
+    assert not result["policy_locked_before_first_results"].any()
+    assert result["policy_lock_commit"].eq(
+        "2e9d7784dfd623877a4ef6d9b25b515918f3fcf7"
+    ).all()
     assert result["nominal_coverage"].eq(0.90).all()
     assert result["size_bin"].eq("50–150k").all()
+
+
+def test_registered_interval_policy_retains_sparse_cells_as_ineligible() -> None:
+    rows = []
+    for origin, count in [(2000, 40), (2005, 40), (2010, 30), (2015, 5)]:
+        for city_id in range(count):
+            rows.append(
+                {
+                    "origin": origin,
+                    "model": "m",
+                    "country_code": f"C{city_id % 5}",
+                    "error": 0.10,
+                    "absolute_error": 0.10,
+                }
+            )
+
+    result = registered_sequential_interval_calibration(
+        pd.DataFrame(rows), policy_id="overall_90_v1"
+    )
+
+    assert result["origin"].tolist() == [2000, 2005, 2010, 2015]
+    assert not result.loc[result["origin"].eq(2000), "calibration_eligible"].iloc[0]
+    assert (
+        result.loc[result["origin"].eq(2010), "calibration_exclusion_reason"].iloc[0]
+        == "insufficient_calibration_rows"
+    )
+    eligible = result.loc[result["origin"].eq(2015)].iloc[0]
+    assert eligible["calibration_eligible"]
+    assert eligible["calibration_rows"] == 110
+    assert eligible["calibration_origins"] == 3
 
 
 def test_registered_interval_policy_rejects_analyst_defined_name() -> None:


### PR DESCRIPTION
Closes #73.

## Verdicts

- **Q1 PASS:** every interval row uses only strictly earlier calibration origins; no production call site performs a future-aware policy-selection pre-pass.
- **Q2 UNRESOLVED-PROCESS:** Git establishes that calibration-capable code preceded the registry, but cannot date the first uncommitted real-data run. No timestamped artifact in the repository preregisters all six exact policies. The code therefore stops claiming prospective timing.
- **Q3 FAIL, remediated:** threshold-ineligible cells previously disappeared through `continue`; registered runs now retain them as explicit ledger rows.

## Changes

- Adds exact policy-lock commits and marks all six policies as not known to have been locked before first results.
- Changes registered calibration output to retain every candidate cell with `calibration_eligible` and `calibration_exclusion_reason`.
- Leaves coverage fields absent for ineligible rows.
- Adds a sparse-cell regression test and dated Pass 3 audit.
- Corrects research design/status language from prespecification to retrospective lock.

## Production impact

| Output | Candidate | Eligible | Newly visible ineligible |
|---|---:|---:|---:|
| WUP overall | 288 | 216 | 72 |
| WUP by size | 1,728 | 1,296 | 432 |
| GHSL overall | 120 | 90 | 30 |
| GHSL by size | 840 | 630 | 210 |

Eligible coverage calculations are unchanged. The output schemas and row counts change, so WUP and GHSL manifests require a producing-commit follow-up after merge.

## Verification

- 132 tests passed.
- Ruff passed.
- Both affected production workflows completed against registered raw inputs.