### PR TITLE
Document and expose pooled-bootstrap dependence assumptions

### DIFF
--- a/docs/bootstrap-dependence-audit-2026-08-30.md
+++ b/docs/bootstrap-dependence-audit-2026-08-30.md
@@ -1,0 +1,60 @@
+# Pass 4 audit — bootstrap dependence across overlapping origins
+
+Date: 30 August 2026
+
+## Verdicts
+
+### Q1 — country and origin resampling: PASS WITH LIMITATION
+
+The two-way bootstrap resamples whole countries. Each country draw carries the
+country's complete city-by-origin matrix, preserving arbitrary dependence among its
+cities and across their origins. Because every city is nested in a country, the
+shared-boundary mechanism does not require an additional city cluster to preserve
+same-city adjacent-origin correlation.
+
+Origins are independently weighted as exchangeable clusters. That dimension captures
+common shocks shared across countries at an origin, but it does not preserve temporal
+adjacency as a block characteristic. This is an explicit limitation, not evidence
+that the registered interval is too narrow.
+
+### Q2 — absence of city resampling: PASS
+
+No CI-producing bootstrap separately resamples cities. That is appropriate under the
+registered country-cluster estimand: country is a broader cluster containing every
+city trajectory. Adding a nested city draw would require an additional assumption
+that observed cities are exchangeable within country and would not automatically
+produce more conservative inference.
+
+### Q3 — temporal reversal diagnostics: NOT RESPONSIVE
+
+`temporal_reversal_diagnostics` computes period-specific correlations, persistence
+slopes and reversal rates. It neither pools origins nor estimates cross-origin
+covariance. It provides no bootstrap-dependence correction.
+
+### Q4 — shared-endpoint documentation: FAIL, remediated
+
+The prior shared-endpoint section examined predictor/outcome arithmetic and model
+performance under a five-year gap. It did not address uncertainty dependence across
+origins. Research status now separates the model-bias question from the bootstrap
+dependence question.
+
+## Magnitude diagnostic
+
+Using registered WUP row-level errors for persistence minus the leave-city-out country
+mean, 20,000 draws produced:
+
+| Resampling design | 95% interval | Half-width |
+|---|---:|---:|
+| Registered country x exchangeable-origin | [-0.416, +0.204] pp | 0.310 pp |
+| Country x circular origin blocks, length 2 | [-0.359, +0.128] pp | 0.243 pp |
+| Country x circular origin blocks, length 3 | [-0.352, +0.111] pp | 0.231 pp |
+
+All three intervals cross zero. The moving-block alternatives narrow the interval by
+roughly 22% to 25%; they do not reveal understated uncertainty. Same-city adjacent-
+origin correlations in paired absolute-error differences have a city-pair-weighted
+mean of 0.038 and range from -0.289 to +0.259 across adjacent periods.
+
+The disjoint-window errors do not remove all serial dependence and have only six
+origins. Their registered half-width is 0.240 pp versus 0.230 pp for two-origin blocks;
+the conclusion again does not change. These diagnostics are too sensitive to block
+length and too short in time to justify replacing the registered estimator.

--- a/docs/research-design.md
+++ b/docs/research-design.md
@@ -58,7 +58,11 @@ Forecasting does not require causal exogeneity, but interpretation of coefficien
 - Report MAE, RMSE, median absolute error, bias, and directional accuracy.
 - Report results overall and by prespecified size, region, data-quality, and urbanization-stage strata.
 - Compare errors on identical observations; coverage gains are reported separately.
-- Use paired block bootstrap intervals clustered at minimum by country; add time blocks when periods overlap.
+- Cluster at minimum by country so each sampled cluster retains complete nested-city
+  trajectories across origins. For pooled inference, also resample origins to reflect
+  common period shocks. Because only eight WUP origins are available, treat contiguous
+  moving-origin blocks as a sensitivity analysis rather than a replacement estimator;
+  report the block length and whether conclusions change.
 - Use leave-one-country-out and influential-city diagnostics.
 
 ### Sequential prediction-interval calibration

--- a/docs/research-status.md
+++ b/docs/research-status.md
@@ -327,6 +327,15 @@ their city-origin weighting rather than as generic global performance.
 
 The two-way pigeonhole bootstrap independently resamples countries and forecast origins, applying the product of their resampling weights to each country-origin cell. It retains all city errors within a cell and uses the same 2,000 repetitions and seed. This targets sensitivity to both geographic composition and which historical periods were realized.
 
+The country draw retains each selected country's entire city-by-origin matrix. Since
+cities are nested within countries, this preserves arbitrary within-city serial
+dependence, including dependence induced by adjacent intervals sharing a boundary-year
+population. A separate city resampling dimension is therefore not required for that
+dependence channel and would impose additional within-country exchangeability. The
+origin draw is different: it treats the eight origins as exchangeable clusters and
+does not preserve adjacency as a block feature. Output rows now state both assumptions
+explicitly.
+
 | Size bin | Difference | Two-way 95% interval |
 |---|---:|---:|
 | 50–150k | −0.151 pp | [−0.426, +0.165] pp |
@@ -339,6 +348,16 @@ The two-way pigeonhole bootstrap independently resamples countries and forecast 
 Every size-bin interval crosses zero. The overall persistence-minus-leave-city-out-country difference is −0.129 pp with interval [−0.406, +0.206] pp. In the balanced cohort it is −0.223 pp with interval [−0.466, +0.060] pp. The data therefore do not support a stable pooled persistence advantage across periods, overall or by size.
 
 This does not overturn the 2020 finding. A single-origin comparison has no across-time sampling dimension; its country-clustered intervals remain the relevant uncertainty calculation and remain adverse to persistence in every size bin. With only eight evaluated origins, the two-way intervals are necessarily coarse and should be treated as a warning against pooled generalization rather than precise time-series inference.
+
+A 20,000-draw diagnostic compared the registered WUP pooled interval with circular
+moving-origin blocks. The existing half-width is 0.310 pp, versus 0.243 pp for
+two-origin blocks and 0.231 pp for three-origin blocks. All intervals cross zero.
+Adjacent-origin correlations in the same-city paired error difference average 0.038,
+range from -0.289 to +0.259, and change sign across periods. The omitted adjacency
+structure therefore does not explain an artificially narrow registered interval in
+this sample; the block alternatives are narrower. With only eight origins, their
+width is highly block-length-dependent, so they remain diagnostics rather than a new
+primary estimator.
 
 ## National demographic comparator
 

--- a/src/urban_growth/forecast.py
+++ b/src/urban_growth/forecast.py
@@ -1340,7 +1340,13 @@ def two_way_cluster_bootstrap_paired_difference(
     seed: int = 20260827,
     confidence: float = 0.95,
 ) -> pd.DataFrame:
-    """Bootstrap paired MAE differences by independently resampling countries and origins."""
+    """Bootstrap paired MAE differences by independently resampling countries and origins.
+
+    Country draws retain each sampled country's complete city-by-origin matrix, so
+    arbitrary serial dependence for cities nested within a country is preserved.
+    Origin draws are exchangeable clusters rather than contiguous temporal blocks;
+    the output records that limitation explicitly.
+    """
     groups = group_columns or []
     required = {
         "city_id", "model", "absolute_error", country_column, time_column, *groups,
@@ -1395,6 +1401,9 @@ def two_way_cluster_bootstrap_paired_difference(
                 "n": len(group),
                 "countries": len(countries),
                 "time_clusters": len(times),
+                "country_cluster_preserves_nested_city_trajectories": True,
+                "time_resampling_scheme": "exchangeable_origin_clusters",
+                "adjacent_origin_blocks_preserved": False,
                 "observed_mean_difference": float(group["difference"].mean()),
                 "ci_lower": float(np.quantile(estimates, alpha)),
                 "ci_upper": float(np.quantile(estimates, 1 - alpha)),

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -535,6 +535,9 @@ def test_two_way_cluster_bootstrap_resamples_country_and_time() -> None:
     pd.testing.assert_frame_equal(first, second)
     assert first.loc[0, "countries"] == 3
     assert first.loc[0, "time_clusters"] == 3
+    assert first.loc[0, "country_cluster_preserves_nested_city_trajectories"]
+    assert first.loc[0, "time_resampling_scheme"] == "exchangeable_origin_clusters"
+    assert not first.loc[0, "adjacent_origin_blocks_preserved"]
 
 
 def test_temporal_diagnostics_detect_reversal() -> None:


### PR DESCRIPTION
Closes #77.

## Verdicts

- **Q1 PASS WITH LIMITATION:** country draws preserve complete nested city trajectories across origins. Exchangeable origin draws do not preserve temporal adjacency as blocks.
- **Q2 PASS:** the country cluster already contains same-city serial dependence; a separate city draw is not automatically more conservative.
- **Q3 NOT RESPONSIVE:** temporal reversal diagnostics do not estimate cross-origin covariance.
- **Q4 FAIL, remediated:** prior shared-endpoint documentation covered model arithmetic but not uncertainty dependence.

## Magnitude diagnostic

At 20,000 draws, the registered-design half-width is 0.310 pp. Circular origin blocks give 0.243 pp at length 2 and 0.231 pp at length 3. All intervals cross zero. Adjacent-origin paired-error correlations average 0.038 and change sign across periods. The evidence does not support the claim that the current interval is artificially narrow.

## Changes

- Adds explicit output metadata stating that country clustering preserves nested city trajectories, origins are exchangeable clusters, and adjacent blocks are not preserved.
- Adds regression assertions for those fields.
- Corrects research-design language that previously implied a contiguous block bootstrap was already primary.
- Adds a dated Pass 4 audit and separates model-bias from dependence claims.

## Verification

- 132 tests passed.
- Ruff passed.
- `git diff --check` passed.

The added output columns require a WUP manifest refresh after this producing code commit is merged.