### PR TITLE
Add U.S. Census threshold validation pilot

### DIFF
--- a/docs/locked-specification.md
+++ b/docs/locked-specification.md
@@ -147,6 +147,7 @@ receives a machine-readable reason.
 | O8 | Modern accessibility window | Accessibility protocol |
 | O9 | Forecastable national envelope | Separate forecast-module specification |
 | O10 | India census scope | Test 2001–2011 as historical-only; defer modern validation until Census 2027 locality outputs and crosswave concordances exist |
+| O11 | U.S. Census place pipeline | Validate code on direct 2010/2020 enumerations and official one-to-one boundary relationships; does not close O1–O3 |
 
 No shrinkage model can manufacture missing within-country information. The recovered
 country-period effect diagnostic excludes cells with fewer than three eligible cities and

--- a/docs/research-status.md
+++ b/docs/research-status.md
@@ -14,6 +14,20 @@ census pilots, the independent-lineage morphology matrix, modern accessibility r
 and national-envelope forecast module also remain open gates in
 `docs/locked-specification.md`. No new causal claim follows from merging contract code.
 
+## U.S. Census threshold-pipeline validation
+
+The first national-census implementation uses official 2010 and 2020 U.S. decennial
+place counts and the Census Bureau's 2020-place to 2010-place relationship file. The
+cohort is fixed at 25,000–100,000 residents in 2010. It retains only one-to-one place
+relationships with at least 99.5% land overlap against both endpoint places, records
+direct-enumeration status, and interval-censors threshold crossings in `(2010, 2020)`.
+Synthetic contract tests pass, but the empirical acquisition is awaiting a local
+`CENSUS_API_KEY`; no U.S. result is currently registered.
+
+This is an implementation-validation pilot in a comparatively strong identifier and
+boundary-data environment. It does not satisfy the Global South country-pilot gate or
+close the Mexico/Brazil feasibility work. See `docs/us-census-threshold-pilot.md`.
+
 ## Dynamic-estimator implementation gate
 
 The locked hierarchy now has a machine-readable registry and one common-sample constructor.

--- a/docs/source-library.md
+++ b/docs/source-library.md
@@ -14,6 +14,23 @@ The machine-readable catalog is `data/sources.json`. It records analytical role,
 | OECD FUA | Mechanism | Urban core versus commuting zone | Restricted country/sample comparability |
 | WorldPop Global 2 | Robustness | Fine-grid population allocation | 2015-2030 is too short for the primary historical design |
 | Natural Earth Admin 0 | Spatial control | Borders and island geometry | Geometry does not measure migration-policy restrictiveness |
+| U.S. Decennial Census places | Threshold validation | Direct 2010/2020 place counts and official relationship file | Favorable single-country pipeline test; not Global South feasibility evidence |
+
+## U.S. Decennial Census place pilot
+
+The initial threshold-pipeline validation uses the 2010 Decennial Census SF1 total
+population field `P001001`, the 2020 Decennial Census PL 94-171 total population field
+`P1_001N`, and the official national 2020-place to 2010-place relationship file. The
+population calls cover the 50 states and District of Columbia. The raw API responses
+are retained rather than replacing them with derived estimates.
+
+The relationship file supplies both place GEOIDs, both endpoint land areas, and the
+intersection land area. Analysis is restricted to one-to-one mappings with at least
+99.5% land overlap against each endpoint. This is an auditable screen for boundary
+comparability, not a claim that land overlap alone harmonizes population definitions.
+Exact files enter `data/manifest.csv` only after credentialed acquisition and hashing.
+The U.S. source validates pipeline behavior but cannot satisfy the separate Global
+South census-feasibility requirement.
 
 ## Verified WUP F01 national control
 

--- a/docs/us-census-threshold-pilot.md
+++ b/docs/us-census-threshold-pilot.md
@@ -1,0 +1,69 @@
+# U.S. Census place threshold pilot
+
+## Purpose and scope
+
+This pilot validates the census-threshold pipeline with official U.S. decennial place
+counts. It does **not** satisfy the specification's Global South feasibility gate and
+does not replace the Mexico, Brazil, South Africa, or Ghana pilots. U.S. place
+identifiers and Census relationship files make this a comparatively favorable test of
+the implementation rather than a demanding test of international harmonization.
+
+The first registered interval is 2010–2020. The origin cohort contains places with
+25,000–100,000 residents in 2010. A place crosses the WUP observation threshold when
+its directly enumerated population is below 50,000 in 2010 and at least 50,000 in
+2020. Crossing is interval-censored in the open interval `(2010, 2020)`; the code does
+not invent a point crossing year.
+
+## Official inputs
+
+| Input | Official field | Role |
+|---|---|---|
+| 2010 Decennial Census SF1 place population | `P001001` | Origin population |
+| 2020 Decennial Census PL 94-171 place population | `P1_001N` | Endpoint population |
+| 2020-place to 2010-place national relationship file | Place GEOIDs, endpoint land areas, intersection land area | Comparable-geography screen |
+
+Population is retrieved for the 50 states and District of Columbia. Puerto Rico is
+outside this initial U.S. pilot. The relationship file is the official pipe-delimited
+national file at
+`https://www2.census.gov/geo/docs/maps-data/data/rel2020/place/tab20_place20_place10_natl.txt`.
+
+## Comparable-geography rule
+
+A repeated GEOID alone is not treated as proof of stable geography. The registered
+cohort keeps only relationships that are one-to-one in both directions and whose
+intersection land area is at least 99.5% of both the 2010 and 2020 place land areas.
+A changed GEOID can enter as an `official_crosswalk` when it passes those same rules.
+All other relationships are excluded rather than interpreted as demographic change.
+
+This land-overlap rule is a conservative feasibility screen. It is not proof that
+population was enumerated on perfectly identical geography, and the retained overlap
+ratios remain in the output for sensitivity analysis.
+
+## Acquisition and execution
+
+Request a Census API key and export it in the local shell without writing it to the
+repository:
+
+```bash
+export CENSUS_API_KEY
+uv run --locked python scripts/fetch_us_census_place_pilot.py
+uv run --locked python scripts/run_us_census_threshold_pilot.py
+```
+
+The acquisition script saves untouched API responses and the official relationship
+file under `data/raw/`. Those inputs must be inventoried in `data/manifest.csv` with
+their retrieval date, exact URL, and SHA-256 hash before an empirical result is
+registered. The cohort and summary are written under `outputs/` and remain outside
+Git.
+
+## Current status and decision rule
+
+The adapter, acquisition script, cohort builder, and synthetic contract tests are
+implemented. The empirical run is blocked until a Census API key is available; no
+modeled or intercensal estimate will be substituted for the two decennial counts.
+
+The summary deliberately writes `gate_g2_satisfied = false`. Successful execution
+shows that the common threshold-audit code works against an official, well-documented
+national system. It does not establish that comparable multiwave locality data are
+available in the countries central to the global claim. The next feasibility decision
+therefore remains a Mexico or Brazil pilot.

--- a/scripts/fetch_us_census_place_pilot.py
+++ b/scripts/fetch_us_census_place_pilot.py
@@ -1,0 +1,111 @@
+"""Acquire official U.S. Census place inputs for the 2010-2020 pilot."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from urllib.parse import urlencode
+from urllib.request import urlopen
+
+STATE_FIPS = [
+    "01",
+    "02",
+    "04",
+    "05",
+    "06",
+    "08",
+    "09",
+    "10",
+    "11",
+    "12",
+    "13",
+    "15",
+    "16",
+    "17",
+    "18",
+    "19",
+    "20",
+    "21",
+    "22",
+    "23",
+    "24",
+    "25",
+    "26",
+    "27",
+    "28",
+    "29",
+    "30",
+    "31",
+    "32",
+    "33",
+    "34",
+    "35",
+    "36",
+    "37",
+    "38",
+    "39",
+    "40",
+    "41",
+    "42",
+    "44",
+    "45",
+    "46",
+    "47",
+    "48",
+    "49",
+    "50",
+    "51",
+    "53",
+    "54",
+    "55",
+    "56",
+]
+QUERIES = {
+    2010: ("https://api.census.gov/data/2010/dec/sf1", "P001001"),
+    2020: ("https://api.census.gov/data/2020/dec/pl", "P1_001N"),
+}
+RELATIONSHIP_URL = (
+    "https://www2.census.gov/geo/docs/maps-data/data/rel2020/place/tab20_place20_place10_natl.txt"
+)
+
+
+def fetch_json(url: str) -> list[list[str]]:
+    with urlopen(url, timeout=60) as response:
+        return json.load(response)
+
+
+def main() -> None:
+    key = os.environ.get("CENSUS_API_KEY")
+    if not key:
+        raise SystemExit("CENSUS_API_KEY is required; do not commit it")
+    raw = Path("data/raw")
+    raw.mkdir(parents=True, exist_ok=True)
+    for year, (endpoint, variable) in QUERIES.items():
+        combined: list[list[str]] = []
+        for state in STATE_FIPS:
+            query = urlencode(
+                {
+                    "get": f"NAME,{variable}",
+                    "for": "place:*",
+                    "in": f"state:{state}",
+                    "key": key,
+                }
+            )
+            payload = fetch_json(f"{endpoint}?{query}")
+            if not combined:
+                combined.append(payload[0])
+            if payload[0] != combined[0]:
+                raise RuntimeError("Census API schema changed across states")
+            combined.extend(payload[1:])
+        output = raw / f"us_census_{year}_place_population.json"
+        output.write_text(json.dumps(combined), encoding="utf-8")
+        print(output)
+    relationship = raw / "tab20_place20_place10_natl.txt"
+    with urlopen(RELATIONSHIP_URL, timeout=60) as response:
+        relationship.write_bytes(response.read())
+    print(relationship)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_us_census_threshold_pilot.py
+++ b/scripts/run_us_census_threshold_pilot.py
@@ -1,0 +1,67 @@
+"""Build the strict 2010-2020 U.S. Census place threshold cohort."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from urban_growth.adapters.us_census import (
+    build_us_place_boundary_cohort,
+    read_2020_place_relationship,
+    read_place_population_snapshot,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--raw-dir", type=Path, default=Path("data/raw"))
+    parser.add_argument(
+        "--cohort-output",
+        type=Path,
+        default=Path("outputs/us_census_threshold_cohort.csv"),
+    )
+    parser.add_argument(
+        "--summary-output",
+        type=Path,
+        default=Path("outputs/us_census_threshold_summary.csv"),
+    )
+    args = parser.parse_args()
+    population_2010 = read_place_population_snapshot(
+        args.raw_dir / "us_census_2010_place_population.json", year=2010
+    )
+    population_2020 = read_place_population_snapshot(
+        args.raw_dir / "us_census_2020_place_population.json", year=2020
+    )
+    relationship = read_2020_place_relationship(args.raw_dir / "tab20_place20_place10_natl.txt")
+    cohort = build_us_place_boundary_cohort(population_2010, population_2020, relationship)
+    summary = pd.DataFrame(
+        [
+            {
+                "country_code": "USA",
+                "origin_year": 2010,
+                "endpoint_year": 2020,
+                "cohort_rows": len(cohort),
+                "stable_geography_rows": int(cohort["geography_status"].eq("stable").sum()),
+                "official_crosswalk_rows": int(
+                    cohort["geography_status"].eq("official_crosswalk").sum()
+                ),
+                "crossed_50000_rows": int(cohort["crossed_50000"].sum()),
+                "origin_threshold_uncertain_rows": int(
+                    cohort["origin_threshold_band"].eq("threshold_uncertain").sum()
+                ),
+                "minimum_land_overlap": 0.995,
+                "gate_g2_satisfied": False,
+                "gate_note": "US pipeline validation does not satisfy Global South pilot gate",
+            }
+        ]
+    )
+    for path, frame in [(args.cohort_output, cohort), (args.summary_output, summary)]:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        frame.to_csv(path, index=False)
+        print(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/urban_growth/adapters/us_census.py
+++ b/src/urban_growth/adapters/us_census.py
@@ -1,0 +1,184 @@
+"""Adapters for the U.S. decennial place threshold-validation pilot."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from urban_growth.census_threshold import (
+    classify_threshold_measurement_band,
+    validate_boundary_cohort,
+)
+from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
+
+PLACE_POPULATION_VARIABLES = {2010: "P001001", 2020: "P1_001N"}
+
+
+def read_place_population_snapshot(path: Path, *, year: int) -> pd.DataFrame:
+    """Read one saved Census API place response without making a network call."""
+    if year not in PLACE_POPULATION_VARIABLES:
+        raise SourceSchemaError("U.S. place pilot supports only 2010 and 2020")
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, list) or len(payload) < 2:
+        raise SourceSchemaError("Census API snapshot must contain a header and data rows")
+    header = payload[0]
+    variable = PLACE_POPULATION_VARIABLES[year]
+    required = {"NAME", variable, "state", "place"}
+    if not required.issubset(header):
+        raise SourceSchemaError("Census API snapshot has an unexpected schema")
+    frame = pd.DataFrame(payload[1:], columns=header)
+    frame["state"] = frame["state"].astype(str).str.zfill(2)
+    frame["place"] = frame["place"].astype(str).str.zfill(5)
+    frame["geoid"] = frame["state"] + frame["place"]
+    frame["population"] = pd.to_numeric(frame[variable], errors="coerce")
+    if frame["population"].isna().any() or frame["population"].lt(0).any():
+        raise SourceSchemaError("Census place population must be non-negative and complete")
+    reject_duplicate_keys(frame, ["geoid"], source_name=f"{year} Census places")
+    return frame[["geoid", "NAME", "population"]].rename(columns={"NAME": "place_name"})
+
+
+def read_2020_place_relationship(path: Path) -> pd.DataFrame:
+    """Read the official national 2020-place to 2010-place relationship file."""
+    frame = pd.read_csv(path, sep="|", dtype=str, encoding="utf-8-sig")
+    required = {
+        "GEOID_PLACE_20",
+        "GEOID_PLACE_10",
+        "NAMELSAD_PLACE_20",
+        "NAMELSAD_PLACE_10",
+        "AREALAND_PLACE_20",
+        "AREALAND_PLACE_10",
+        "AREALAND_PART",
+    }
+    require_columns(frame, required, source_name="2020-to-2010 Census place relationship")
+    for column in ["GEOID_PLACE_20", "GEOID_PLACE_10"]:
+        frame[column] = frame[column].str.strip().replace("", pd.NA)
+    for column in ["AREALAND_PLACE_20", "AREALAND_PLACE_10", "AREALAND_PART"]:
+        frame[column] = pd.to_numeric(frame[column], errors="coerce")
+    return frame
+
+
+def build_us_place_boundary_cohort(
+    population_2010: pd.DataFrame,
+    population_2020: pd.DataFrame,
+    relationship: pd.DataFrame,
+    *,
+    minimum_origin_population: int = 25_000,
+    maximum_origin_population: int = 100_000,
+    minimum_land_overlap: float = 0.995,
+) -> pd.DataFrame:
+    """Build a strict one-to-one, near-identical-land U.S. place cohort.
+
+    Land overlap is a feasibility screen, not proof of population comparability.
+    Places failing it remain excluded rather than being treated as demographic change.
+    """
+    if not 0 < minimum_land_overlap <= 1:
+        raise SourceSchemaError("Minimum land overlap must be in (0, 1]")
+    if minimum_origin_population <= 0 or maximum_origin_population < minimum_origin_population:
+        raise SourceSchemaError("Origin population bounds are invalid")
+    for frame, label in [
+        (population_2010, "2010 Census places"),
+        (population_2020, "2020 Census places"),
+    ]:
+        require_columns(frame, {"geoid", "place_name", "population"}, source_name=label)
+        reject_duplicate_keys(frame, ["geoid"], source_name=label)
+        if frame["population"].isna().any() or frame["population"].le(0).any():
+            raise SourceSchemaError(f"{label} population must be positive and complete")
+
+    require_columns(
+        relationship,
+        {
+            "GEOID_PLACE_10",
+            "GEOID_PLACE_20",
+            "AREALAND_PLACE_10",
+            "AREALAND_PLACE_20",
+            "AREALAND_PART",
+        },
+        source_name="2020-to-2010 Census place relationship",
+    )
+
+    related = relationship.dropna(subset=["GEOID_PLACE_10", "GEOID_PLACE_20"]).copy()
+    count_10 = related.groupby("GEOID_PLACE_10")["GEOID_PLACE_20"].transform("size")
+    count_20 = related.groupby("GEOID_PLACE_20")["GEOID_PLACE_10"].transform("size")
+    related["one_to_one_relationship"] = count_10.eq(1) & count_20.eq(1)
+    related["origin_land_overlap"] = related["AREALAND_PART"] / related["AREALAND_PLACE_10"]
+    related["endpoint_land_overlap"] = related["AREALAND_PART"] / related["AREALAND_PLACE_20"]
+    comparable = related.loc[
+        related["one_to_one_relationship"]
+        & related["origin_land_overlap"].ge(minimum_land_overlap)
+        & related["endpoint_land_overlap"].ge(minimum_land_overlap)
+    ].copy()
+    cohort = comparable.merge(
+        population_2010.add_suffix("_2010"),
+        left_on="GEOID_PLACE_10",
+        right_on="geoid_2010",
+        validate="one_to_one",
+    ).merge(
+        population_2020.add_suffix("_2020"),
+        left_on="GEOID_PLACE_20",
+        right_on="geoid_2020",
+        validate="one_to_one",
+    )
+    cohort = cohort.loc[
+        cohort["population_2010"].between(
+            minimum_origin_population, maximum_origin_population, inclusive="both"
+        )
+    ].copy()
+    if cohort.empty:
+        raise SourceSchemaError("No U.S. places satisfy the threshold-pilot cohort rules")
+    cohort["settlement_id"] = "US_PLACE_2010_" + cohort["GEOID_PLACE_10"]
+    cohort["country_code"] = "USA"
+    cohort["origin_year"] = 2010
+    cohort["endpoint_year"] = 2020
+    cohort["population_origin"] = cohort["population_2010"]
+    cohort["population_endpoint"] = cohort["population_2020"]
+    cohort["geography_status"] = np.where(
+        cohort["GEOID_PLACE_10"].eq(cohort["GEOID_PLACE_20"]),
+        "stable",
+        "official_crosswalk",
+    )
+    cohort["origin_population_status"] = "direct_decennial_enumeration"
+    cohort["endpoint_population_status"] = "direct_decennial_enumeration"
+    cohort["origin_threshold_band"] = classify_threshold_measurement_band(
+        cohort["population_origin"]
+    ).astype(str)
+    cohort["endpoint_threshold_band"] = classify_threshold_measurement_band(
+        cohort["population_endpoint"]
+    ).astype(str)
+    cohort["crossed_50000"] = cohort["population_origin"].lt(50_000) & cohort[
+        "population_endpoint"
+    ].ge(50_000)
+    cohort["crossing_interval_lower"] = np.where(cohort["crossed_50000"], 2010, np.nan)
+    cohort["crossing_interval_upper"] = np.where(cohort["crossed_50000"], 2020, np.nan)
+    cohort["annualized_log_growth"] = (
+        np.log(cohort["population_endpoint"]) - np.log(cohort["population_origin"])
+    ) / 10
+    output_columns = [
+        "settlement_id",
+        "country_code",
+        "GEOID_PLACE_10",
+        "GEOID_PLACE_20",
+        "place_name_2010",
+        "place_name_2020",
+        "origin_year",
+        "endpoint_year",
+        "population_origin",
+        "population_endpoint",
+        "origin_population_status",
+        "endpoint_population_status",
+        "geography_status",
+        "origin_land_overlap",
+        "endpoint_land_overlap",
+        "origin_threshold_band",
+        "endpoint_threshold_band",
+        "crossed_50000",
+        "crossing_interval_lower",
+        "crossing_interval_upper",
+        "annualized_log_growth",
+    ]
+    result = cohort[output_columns].sort_values("settlement_id").reset_index(drop=True)
+    validate_boundary_cohort(result)
+    return result

--- a/tests/test_us_census.py
+++ b/tests/test_us_census.py
@@ -1,0 +1,76 @@
+import json
+
+import pandas as pd
+import pytest
+
+from urban_growth.adapters.us_census import (
+    build_us_place_boundary_cohort,
+    read_place_population_snapshot,
+)
+from urban_growth.io import SourceSchemaError
+
+
+def test_read_place_population_snapshot_builds_geoid(tmp_path) -> None:
+    path = tmp_path / "places.json"
+    path.write_text(
+        json.dumps([["NAME", "P001001", "state", "place"], ["Test city", "40000", "1", "123"]]),
+        encoding="utf-8",
+    )
+    result = read_place_population_snapshot(path, year=2010)
+    assert result.loc[0, "geoid"] == "0100123"
+    assert result.loc[0, "population"] == 40_000
+
+
+def test_us_place_cohort_requires_one_to_one_near_identical_land() -> None:
+    population_2010 = pd.DataFrame(
+        {
+            "geoid": ["0100001", "0100002", "0100003"],
+            "place_name": ["A", "B", "C"],
+            "population": [40_000, 60_000, 30_000],
+        }
+    )
+    population_2020 = pd.DataFrame(
+        {
+            "geoid": ["0100001", "0100002", "0100004"],
+            "place_name": ["A", "B", "C successor"],
+            "population": [55_000, 70_000, 45_000],
+        }
+    )
+    relationship = pd.DataFrame(
+        {
+            "GEOID_PLACE_10": ["0100001", "0100002", "0100003"],
+            "GEOID_PLACE_20": ["0100001", "0100002", "0100004"],
+            "AREALAND_PLACE_10": [100, 100, 100],
+            "AREALAND_PLACE_20": [100, 150, 100],
+            "AREALAND_PART": [100, 100, 100],
+        }
+    )
+    result = build_us_place_boundary_cohort(population_2010, population_2020, relationship)
+    assert result["settlement_id"].tolist() == ["US_PLACE_2010_0100001", "US_PLACE_2010_0100003"]
+    assert result["crossed_50000"].tolist() == [True, False]
+    assert result["geography_status"].tolist() == ["stable", "official_crosswalk"]
+
+
+def test_us_place_cohort_rejects_invalid_overlap_threshold() -> None:
+    with pytest.raises(SourceSchemaError, match="land overlap"):
+        build_us_place_boundary_cohort(
+            pd.DataFrame(), pd.DataFrame(), pd.DataFrame(), minimum_land_overlap=0
+        )
+
+
+def test_us_place_cohort_rejects_nonpositive_endpoint_population() -> None:
+    population_2010 = pd.DataFrame(
+        {"geoid": ["0100001"], "place_name": ["A"], "population": [40_000]}
+    )
+    population_2020 = pd.DataFrame({"geoid": ["0100001"], "place_name": ["A"], "population": [0]})
+    relationship = pd.DataFrame(
+        {
+            "GEOID_PLACE_10": ["0100001"],
+            "GEOID_PLACE_20": ["0100001"],
+            "AREALAND_PLACE_10": [100],
+            "AREALAND_PLACE_20": [100],
+            "AREALAND_PART": [100],
+        }
+    )
+    with pytest.raises(SourceSchemaError, match="positive and complete"):
+        build_us_place_boundary_cohort(population_2010, population_2020, relationship)


### PR DESCRIPTION
## Summary

- add official 2010 SF1 and 2020 PL place-population acquisition
- build a strict one-to-one 2010–2020 place cohort with at least 99.5% land overlap against both endpoints
- preserve direct-enumeration and interval-censored threshold-crossing semantics
- document that the U.S. pilot validates the pipeline but does not satisfy the Global South feasibility gate

## Validation

- `uv run --locked --extra dev ruff check src tests scripts`
- `uv run --locked --extra dev pytest -q` — 136 passed
- `git diff --check`

## Manual block

The empirical run still requires a locally exported `CENSUS_API_KEY`. No modeled or intercensal estimate is substituted.
