### PR TITLE
Implement City Data Fitness Standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# Urban Growth Research Instructions
+
+This repository is governed by a falsification-first research design for explaining and forecasting city population growth.
+
+## Core rules
+
+1. Separate predictive relationships from causal claims.
+2. Preserve geographic identity before estimation. Changing polygons, annexations, mergers, splits, renamed jurisdictions, or reclassification must not masquerade as growth.
+3. Treat the 50,000 population threshold as a selection problem. Test truncation, survivorship, entry, exit, and threshold sensitivity using earlier-period population where possible.
+4. Make persistence the forecasting benchmark. New variables must earn their complexity through genuine out-of-sample improvement over simple baselines.
+5. Separate absolute population size from national city rank.
+6. Model expected growth, conditional variance, and downside risk separately.
+7. Account for shared dependence across countries, regions, sources/origins, and overlapping spatial structures. Document bootstrap dependence assumptions.
+8. Classify results explicitly as descriptive, predictive, quasi-causal, or causal.
+9. Prefer geographically validated stable samples for headline results. Less certain concordances belong in robustness analyses only.
+10. Preserve a complete evidence chain from raw source through validation, model, robustness test, and claim.
+
+## Immediate empirical order
+
+Do not broaden the project with expensive or weakly observed variables until the following sequence is completed:
+
+1. geographic and temporal validation;
+2. City Data Fitness Standard;
+3. persistence-only out-of-sample benchmarks;
+4. size and rank conditional on persistence and survivorship correction;
+5. conditional growth volatility by size/rank;
+6. spatial exposure;
+7. network accessibility and incremental predictive value.
+
+## City Data Fitness Standard
+
+The executable standard is defined in `src/urban_growth/data_fitness.py` and documented in `docs/city-data-fitness-standard.md`.
+
+Never create a single composite quality score. Fitness is analysis-specific. At minimum preserve separate eligibility for:
+
+- population-level analysis;
+- growth-rate analysis;
+- spatial/network analysis;
+- headline analysis.
+
+Questionable records must remain auditable. Preserve raw values, transformations, exclusions, and machine-readable reasons. Never silently repair a questionable observation.
+
+## Governing principle
+
+Prefer a simple model that survives geographic validation, selection correction, dependence-aware inference, and out-of-sample testing over a sophisticated model whose apparent explanatory power comes from unstable boundaries, leakage, endogenous controls, or in-sample fit.

--- a/docs/city-data-fitness-standard.md
+++ b/docs/city-data-fitness-standard.md
@@ -1,0 +1,89 @@
+# City Data Fitness Standard
+
+## Purpose
+
+Fitness is defined for a particular analytical use, not as a generic source score. A record can be fit for within-boundary growth estimation while being unfit for level comparisons or spatial analysis.
+
+The standard is implemented in `urban_growth.data_fitness`. It produces explicit eligibility flags and machine-readable failure reasons without altering source values.
+
+## Required evidence fields
+
+The evaluator accepts the following evidence where available:
+
+| Field | Meaning |
+|---|---|
+| `source_id` | Source/provenance identifier |
+| `population_concept` | Administrative city, locality, municipality, agglomeration, built-up footprint, metro, etc. |
+| `geographic_unit` | Declared geographic unit |
+| `reference_date` | Observation reference date |
+| `observation_type` | Census, estimate, projection, administrative register, etc. |
+| `temporal_comparable` | Same measurement concept/method across the compared interval |
+| `geographic_comparable` | Same or defensibly harmonized geography across observations |
+| `boundary_temporally_fixed` | Boundary fixed over the analytical interval |
+| `boundary_change_status` | None, harmonized, unresolved, annexation, merger, split, etc. |
+| `administrative_reclassification` | Whether classification changed |
+| `methodology_change` | Whether source methodology changed materially |
+| `minimum_reporting_threshold` | Known reporting threshold, if any |
+| `truncation_exposure` | none / low / material / unknown |
+| `survivorship_exposure` | none / low / material / unknown |
+| `concordance_method` | How geographic identity was linked through time/sources |
+| `concordance_status` | stable / official_crosswalk / harmonized_common_geography / uncertain / unresolved |
+| `known_inconsistency` | Known unresolved inconsistency |
+| `validation_status` | passed / partial / failed / not_reviewed |
+| `coordinates_validated` | Coordinates/geometries validated for spatial use |
+| `network_geography_validated` | Geography suitable for network/accessibility use |
+
+The evaluator also preserves any supplied `raw_value`, `transformation`, and `exclusion_reason` fields. It does not repair observations.
+
+## Eligibility outputs
+
+Each record receives four independent flags:
+
+- `level_eligible`: suitable for population-level comparisons;
+- `growth_eligible`: suitable for within-entity growth-rate analysis;
+- `spatial_eligible`: suitable for spatial/network analysis;
+- `headline_eligible`: suitable for headline analyses.
+
+Each flag has a corresponding semicolon-delimited reason field. A `fitness_reasons` field contains the union of all reasons.
+
+## Headline gate
+
+Headline eligibility is intentionally strict. A record must be growth-eligible and must also have:
+
+- validation status `passed`;
+- a stable or accepted harmonized concordance;
+- no unresolved geographic change;
+- no material or unknown survivorship/truncation exposure for threshold-sensitive analyses;
+- no known unresolved inconsistency.
+
+The exact analysis can impose additional requirements. The standard is a minimum gate, not permission to ignore estimator-specific assumptions.
+
+## Geographic rules
+
+Accepted concordance states for stable growth analysis are:
+
+- `stable`;
+- `official_crosswalk`;
+- `harmonized_common_geography`.
+
+`uncertain` and `unresolved` matches are excluded from headline analyses. They may be retained for robustness tests if explicitly requested.
+
+A changing administrative boundary can still support growth analysis only when the observations have been harmonized to a common geography and the concordance status records that fact. A simple name match is not sufficient.
+
+## Threshold-selection rules
+
+For analyses near a population threshold, `truncation_exposure` and `survivorship_exposure` must not be `material` or `unknown` for headline use. These fields do not mechanically remove observations from unrelated analyses; they are analysis-specific warnings and gates.
+
+Sample construction should use earlier-period population wherever possible. Entry, exit, threshold crossing, and lower-tail coverage should be reported separately.
+
+## No composite score
+
+Do not average these dimensions into a percentage or ordinal data-quality score. Doing so destroys the distinction between errors that invalidate levels, errors that invalidate growth, and errors that matter only for spatial analysis.
+
+## Evidence-chain requirement
+
+Any downstream result using the fitness flags should preserve enough identifiers to trace:
+
+`raw source -> ingestion -> geographic concordance -> fitness evaluation -> analytical sample -> model -> robustness -> claim`.
+
+The `headline_eligible` flag must never be manually overwritten in an analytical dataset. Change the underlying evidence and rerun the evaluator instead.

--- a/src/urban_growth/data_fitness.py
+++ b/src/urban_growth/data_fitness.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pandas as pd
+
+
+ACCEPTED_CONCORDANCE = {
+    "stable",
+    "official_crosswalk",
+    "harmonized_common_geography",
+}
+
+PASS_VALIDATION = {"passed"}
+BAD_EXPOSURE = {"material", "unknown"}
+UNRESOLVED_BOUNDARY = {
+    "annexation",
+    "merger",
+    "split",
+    "reclassification",
+    "unresolved",
+    "unknown",
+}
+
+
+def _norm(value: object) -> str:
+    if value is None or pd.isna(value):
+        return ""
+    return str(value).strip().lower()
+
+
+def _truthy(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    return _norm(value) in {"1", "true", "yes", "y", "passed", "valid"}
+
+
+def _join_reasons(reasons: Iterable[str]) -> str:
+    return ";".join(sorted(set(reasons)))
+
+
+def _evaluate_row(row: pd.Series) -> dict[str, object]:
+    level_reasons: list[str] = []
+    growth_reasons: list[str] = []
+    spatial_reasons: list[str] = []
+    headline_reasons: list[str] = []
+
+    source_id = _norm(row.get("source_id"))
+    population_concept = _norm(row.get("population_concept"))
+    geographic_unit = _norm(row.get("geographic_unit"))
+    validation_status = _norm(row.get("validation_status"))
+    concordance_status = _norm(row.get("concordance_status"))
+    boundary_change_status = _norm(row.get("boundary_change_status"))
+    truncation_exposure = _norm(row.get("truncation_exposure"))
+    survivorship_exposure = _norm(row.get("survivorship_exposure"))
+
+    if not source_id:
+        level_reasons.append("missing_source_id")
+        growth_reasons.append("missing_source_id")
+        spatial_reasons.append("missing_source_id")
+
+    if not population_concept:
+        level_reasons.append("missing_population_concept")
+        growth_reasons.append("missing_population_concept")
+
+    if not geographic_unit:
+        level_reasons.append("missing_geographic_unit")
+        growth_reasons.append("missing_geographic_unit")
+        spatial_reasons.append("missing_geographic_unit")
+
+    if validation_status not in PASS_VALIDATION:
+        level_reasons.append("validation_not_passed")
+        growth_reasons.append("validation_not_passed")
+        spatial_reasons.append("validation_not_passed")
+
+    geographic_comparable = _truthy(row.get("geographic_comparable"))
+    temporal_comparable = _truthy(row.get("temporal_comparable"))
+    boundary_fixed = _truthy(row.get("boundary_temporally_fixed"))
+    harmonized = concordance_status == "harmonized_common_geography"
+
+    if not geographic_comparable:
+        level_reasons.append("geography_not_comparable")
+
+    if not temporal_comparable:
+        growth_reasons.append("time_not_comparable")
+
+    if concordance_status not in ACCEPTED_CONCORDANCE:
+        growth_reasons.append("concordance_not_accepted")
+        spatial_reasons.append("concordance_not_accepted")
+
+    if not boundary_fixed and not harmonized:
+        growth_reasons.append("boundary_not_stable_or_harmonized")
+
+    if boundary_change_status in UNRESOLVED_BOUNDARY and not harmonized:
+        growth_reasons.append("unresolved_boundary_change")
+
+    if _truthy(row.get("administrative_reclassification")) and not harmonized:
+        growth_reasons.append("administrative_reclassification")
+
+    if _truthy(row.get("methodology_change")):
+        growth_reasons.append("methodology_change")
+
+    if _truthy(row.get("known_inconsistency")):
+        level_reasons.append("known_inconsistency")
+        growth_reasons.append("known_inconsistency")
+        spatial_reasons.append("known_inconsistency")
+
+    if not _truthy(row.get("coordinates_validated")):
+        spatial_reasons.append("coordinates_not_validated")
+
+    if not _truthy(row.get("network_geography_validated")):
+        spatial_reasons.append("network_geography_not_validated")
+
+    level_eligible = not level_reasons
+    growth_eligible = not growth_reasons
+    spatial_eligible = not spatial_reasons
+
+    if not growth_eligible:
+        headline_reasons.append("not_growth_eligible")
+    if validation_status not in PASS_VALIDATION:
+        headline_reasons.append("validation_not_passed")
+    if concordance_status not in ACCEPTED_CONCORDANCE:
+        headline_reasons.append("concordance_not_accepted")
+    if boundary_change_status in UNRESOLVED_BOUNDARY and not harmonized:
+        headline_reasons.append("unresolved_boundary_change")
+    if truncation_exposure in BAD_EXPOSURE:
+        headline_reasons.append("truncation_exposure")
+    if survivorship_exposure in BAD_EXPOSURE:
+        headline_reasons.append("survivorship_exposure")
+    if _truthy(row.get("known_inconsistency")):
+        headline_reasons.append("known_inconsistency")
+
+    headline_eligible = not headline_reasons
+
+    all_reasons = (
+        level_reasons + growth_reasons + spatial_reasons + headline_reasons
+    )
+
+    return {
+        "level_eligible": level_eligible,
+        "level_exclusion_reasons": _join_reasons(level_reasons),
+        "growth_eligible": growth_eligible,
+        "growth_exclusion_reasons": _join_reasons(growth_reasons),
+        "spatial_eligible": spatial_eligible,
+        "spatial_exclusion_reasons": _join_reasons(spatial_reasons),
+        "headline_eligible": headline_eligible,
+        "headline_exclusion_reasons": _join_reasons(headline_reasons),
+        "fitness_reasons": _join_reasons(all_reasons),
+    }
+
+
+def evaluate_city_data_fitness(frame: pd.DataFrame) -> pd.DataFrame:
+    """Return *frame* with deterministic analysis-specific fitness flags appended.
+
+    The function never edits source values and never computes a composite quality score.
+    Missing evidence fails only the analytical dimensions that require that evidence.
+    """
+    out = frame.copy()
+    if out.empty:
+        for column in (
+            "level_eligible",
+            "level_exclusion_reasons",
+            "growth_eligible",
+            "growth_exclusion_reasons",
+            "spatial_eligible",
+            "spatial_exclusion_reasons",
+            "headline_eligible",
+            "headline_exclusion_reasons",
+            "fitness_reasons",
+        ):
+            out[column] = pd.Series(dtype="bool" if column.endswith("eligible") else "object")
+        return out
+
+    evaluated = pd.DataFrame((_evaluate_row(row) for _, row in out.iterrows()), index=out.index)
+    return pd.concat([out, evaluated], axis=1)
+
+
+def headline_sample(frame: pd.DataFrame) -> pd.DataFrame:
+    """Evaluate fitness and return only records permitted in headline analyses."""
+    evaluated = evaluate_city_data_fitness(frame)
+    return evaluated.loc[evaluated["headline_eligible"]].copy()

--- a/src/urban_growth/data_fitness.py
+++ b/src/urban_growth/data_fitness.py
@@ -4,7 +4,6 @@ from collections.abc import Iterable
 
 import pandas as pd
 
-
 ACCEPTED_CONCORDANCE = {
     "stable",
     "official_crosswalk",
@@ -132,9 +131,7 @@ def _evaluate_row(row: pd.Series) -> dict[str, object]:
 
     headline_eligible = not headline_reasons
 
-    all_reasons = (
-        level_reasons + growth_reasons + spatial_reasons + headline_reasons
-    )
+    all_reasons = level_reasons + growth_reasons + spatial_reasons + headline_reasons
 
     return {
         "level_eligible": level_eligible,

--- a/tests/test_data_fitness.py
+++ b/tests/test_data_fitness.py
@@ -1,0 +1,125 @@
+import pandas as pd
+
+from urban_growth.data_fitness import evaluate_city_data_fitness, headline_sample
+
+
+def stable_row(**overrides):
+    row = {
+        "city_id": "example:1",
+        "source_id": "source-a",
+        "population_concept": "locality",
+        "geographic_unit": "locality",
+        "validation_status": "passed",
+        "concordance_status": "stable",
+        "boundary_change_status": "none",
+        "boundary_temporally_fixed": True,
+        "geographic_comparable": True,
+        "temporal_comparable": True,
+        "administrative_reclassification": False,
+        "methodology_change": False,
+        "known_inconsistency": False,
+        "truncation_exposure": "none",
+        "survivorship_exposure": "none",
+        "coordinates_validated": True,
+        "network_geography_validated": True,
+        "raw_value": 52_000,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_stable_validated_row_is_eligible_for_all_uses():
+    result = evaluate_city_data_fitness(pd.DataFrame([stable_row()])).iloc[0]
+
+    assert bool(result["level_eligible"])
+    assert bool(result["growth_eligible"])
+    assert bool(result["spatial_eligible"])
+    assert bool(result["headline_eligible"])
+    assert result["fitness_reasons"] == ""
+
+
+def test_changing_boundary_blocks_growth_and_headline_but_not_valid_level_record():
+    result = evaluate_city_data_fitness(
+        pd.DataFrame(
+            [
+                stable_row(
+                    boundary_temporally_fixed=False,
+                    boundary_change_status="annexation",
+                    concordance_status="uncertain",
+                )
+            ]
+        )
+    ).iloc[0]
+
+    assert bool(result["level_eligible"])
+    assert not bool(result["growth_eligible"])
+    assert not bool(result["headline_eligible"])
+    assert "unresolved_boundary_change" in result["growth_exclusion_reasons"]
+
+
+def test_harmonized_common_geography_can_restore_growth_eligibility():
+    result = evaluate_city_data_fitness(
+        pd.DataFrame(
+            [
+                stable_row(
+                    boundary_temporally_fixed=False,
+                    boundary_change_status="annexation",
+                    concordance_status="harmonized_common_geography",
+                )
+            ]
+        )
+    ).iloc[0]
+
+    assert bool(result["growth_eligible"])
+    assert bool(result["headline_eligible"])
+
+
+def test_methodology_change_blocks_growth_without_rewriting_raw_value():
+    frame = pd.DataFrame([stable_row(methodology_change=True, raw_value=49_999)])
+    result = evaluate_city_data_fitness(frame).iloc[0]
+
+    assert result["raw_value"] == 49_999
+    assert not bool(result["growth_eligible"])
+    assert "methodology_change" in result["growth_exclusion_reasons"]
+
+
+def test_threshold_selection_exposure_blocks_headline_only():
+    result = evaluate_city_data_fitness(
+        pd.DataFrame([stable_row(truncation_exposure="material")])
+    ).iloc[0]
+
+    assert bool(result["growth_eligible"])
+    assert not bool(result["headline_eligible"])
+    assert "truncation_exposure" in result["headline_exclusion_reasons"]
+
+
+def test_spatial_use_requires_validated_coordinates_and_network_geography():
+    result = evaluate_city_data_fitness(
+        pd.DataFrame(
+            [stable_row(coordinates_validated=False, network_geography_validated=False)]
+        )
+    ).iloc[0]
+
+    assert not bool(result["spatial_eligible"])
+    assert "coordinates_not_validated" in result["spatial_exclusion_reasons"]
+    assert "network_geography_not_validated" in result["spatial_exclusion_reasons"]
+    assert bool(result["growth_eligible"])
+
+
+def test_headline_sample_filters_ineligible_rows_and_preserves_reasons():
+    frame = pd.DataFrame(
+        [
+            stable_row(city_id="keep"),
+            stable_row(
+                city_id="drop",
+                concordance_status="unresolved",
+                boundary_temporally_fixed=False,
+                boundary_change_status="unresolved",
+            ),
+        ]
+    )
+
+    result = headline_sample(frame)
+
+    assert result["city_id"].tolist() == ["keep"]
+    assert "headline_eligible" in result.columns


### PR DESCRIPTION
Closes #84.

Implements the City Data Fitness Standard as an executable analytical gate rather than a generic quality score.

### Changes
- adds repository-level `AGENTS.md` governing the falsification-first research sequence;
- documents analysis-specific data fitness requirements;
- adds `urban_growth.data_fitness` with independent level, growth, spatial, and headline eligibility flags plus machine-readable reasons;
- preserves raw input fields unchanged;
- adds a strict `headline_sample` helper;
- adds tests for stable geography, unresolved boundary changes, harmonized common geography, methodology changes, threshold-selection exposure, and spatial validation.

### Design choice
No composite data-quality score is created. Eligibility is estimator/use specific, because a record can be fit for within-boundary growth while being unfit for level or network analysis.

### Next step after merge
Apply the gate to the geographically validated census cohort, then build persistence-only out-of-sample benchmarks before adding further covariates.