### PR TITLE
Apply City Data Fitness gate to U.S. Census pilot

### DIFF
--- a/docs/us-census-threshold-pilot.md
+++ b/docs/us-census-threshold-pilot.md
@@ -39,6 +39,29 @@ This land-overlap rule is a conservative feasibility screen. It is not proof tha
 population was enumerated on perfectly identical geography, and the retained overlap
 ratios remain in the output for sensitivity analysis.
 
+## City Data Fitness gate
+
+The registered cohort is passed through `urban_growth.census_fitness` before any
+headline analysis. The adapter translates the existing boundary evidence into the
+common City Data Fitness vocabulary and then calls the repository-wide evaluator.
+
+For this pilot:
+
+- direct 2010 and 2020 decennial counts are temporally comparable for the registered
+  total-population growth use;
+- `stable` and `official_crosswalk` geography states are accepted because both have
+  already passed the one-to-one and 99.5% land-overlap screen;
+- truncation and survivorship exposure are labeled `low`, not `none`, because the
+  registered analysis is conditional on the explicit 25,000–100,000 origin cohort;
+- the cohort is not spatial/network eligible because coordinates and network geography
+  are not validated by this pilot;
+- the headline sample is written separately and can only be produced through the
+  common `headline_eligible` gate.
+
+This fitness decision is specific to the registered 50,000-threshold analysis. It must
+not be generalized to arbitrary U.S. place level comparisons, spatial models, or
+samples outside the 25,000–100,000 origin range.
+
 ## Acquisition and execution
 
 Request a Census API key and export it in the local shell without writing it to the
@@ -53,17 +76,18 @@ uv run --locked python scripts/run_us_census_threshold_pilot.py
 The acquisition script saves untouched API responses and the official relationship
 file under `data/raw/`. Those inputs must be inventoried in `data/manifest.csv` with
 their retrieval date, exact URL, and SHA-256 hash before an empirical result is
-registered. The cohort and summary are written under `outputs/` and remain outside
-Git.
+registered. The fitness-annotated cohort, strict headline sample, and summary are
+written under `outputs/` and remain outside Git.
 
 ## Current status and decision rule
 
-The adapter, acquisition script, cohort builder, and synthetic contract tests are
-implemented. The empirical run is blocked until a Census API key is available; no
-modeled or intercensal estimate will be substituted for the two decennial counts.
+The adapter, acquisition script, cohort builder, City Data Fitness application, and
+synthetic contract tests are implemented. The empirical run is blocked until a Census
+API key is available; no modeled or intercensal estimate will be substituted for the
+two decennial counts.
 
 The summary deliberately writes `gate_g2_satisfied = false`. Successful execution
-shows that the common threshold-audit code works against an official, well-documented
-national system. It does not establish that comparable multiwave locality data are
-available in the countries central to the global claim. The next feasibility decision
-therefore remains a Mexico or Brazil pilot.
+shows that the common threshold-audit and fitness-gating code works against an
+official, well-documented national system. It does not establish that comparable
+multiwave locality data are available in the countries central to the global claim.
+The next feasibility decision therefore remains a Mexico or Brazil pilot.

--- a/scripts/run_us_census_threshold_pilot.py
+++ b/scripts/run_us_census_threshold_pilot.py
@@ -1,4 +1,4 @@
-"""Build the strict 2010-2020 U.S. Census place threshold cohort."""
+"""Build and fitness-gate the strict 2010-2020 U.S. Census place threshold cohort."""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ from urban_growth.adapters.us_census import (
     read_2020_place_relationship,
     read_place_population_snapshot,
 )
+from urban_growth.census_fitness import apply_us_census_place_fitness, us_census_headline_sample
 
 
 def main() -> None:
@@ -21,6 +22,11 @@ def main() -> None:
         "--cohort-output",
         type=Path,
         default=Path("outputs/us_census_threshold_cohort.csv"),
+    )
+    parser.add_argument(
+        "--headline-output",
+        type=Path,
+        default=Path("outputs/us_census_threshold_headline_sample.csv"),
     )
     parser.add_argument(
         "--summary-output",
@@ -35,7 +41,9 @@ def main() -> None:
         args.raw_dir / "us_census_2020_place_population.json", year=2020
     )
     relationship = read_2020_place_relationship(args.raw_dir / "tab20_place20_place10_natl.txt")
-    cohort = build_us_place_boundary_cohort(population_2010, population_2020, relationship)
+    raw_cohort = build_us_place_boundary_cohort(population_2010, population_2020, relationship)
+    cohort = apply_us_census_place_fitness(raw_cohort)
+    headline = us_census_headline_sample(raw_cohort)
     summary = pd.DataFrame(
         [
             {
@@ -43,21 +51,30 @@ def main() -> None:
                 "origin_year": 2010,
                 "endpoint_year": 2020,
                 "cohort_rows": len(cohort),
+                "headline_eligible_rows": int(cohort["headline_eligible"].sum()),
+                "growth_eligible_rows": int(cohort["growth_eligible"].sum()),
+                "spatial_eligible_rows": int(cohort["spatial_eligible"].sum()),
                 "stable_geography_rows": int(cohort["geography_status"].eq("stable").sum()),
                 "official_crosswalk_rows": int(
                     cohort["geography_status"].eq("official_crosswalk").sum()
                 ),
                 "crossed_50000_rows": int(cohort["crossed_50000"].sum()),
+                "headline_crossed_50000_rows": int(headline["crossed_50000"].sum()),
                 "origin_threshold_uncertain_rows": int(
                     cohort["origin_threshold_band"].eq("threshold_uncertain").sum()
                 ),
                 "minimum_land_overlap": 0.995,
+                "fitness_scope": "us_census_place_2010_2020_threshold_pilot",
                 "gate_g2_satisfied": False,
                 "gate_note": "US pipeline validation does not satisfy Global South pilot gate",
             }
         ]
     )
-    for path, frame in [(args.cohort_output, cohort), (args.summary_output, summary)]:
+    for path, frame in [
+        (args.cohort_output, cohort),
+        (args.headline_output, headline),
+        (args.summary_output, summary),
+    ]:
         path.parent.mkdir(parents=True, exist_ok=True)
         frame.to_csv(path, index=False)
         print(path)

--- a/src/urban_growth/census_fitness.py
+++ b/src/urban_growth/census_fitness.py
@@ -1,0 +1,76 @@
+"""Analysis-specific fitness evidence for validated census cohorts."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from urban_growth.data_fitness import evaluate_city_data_fitness, headline_sample
+from urban_growth.io import require_columns
+
+US_CENSUS_FITNESS_SCOPE = "us_census_place_2010_2020_threshold_pilot"
+
+
+def apply_us_census_place_fitness(cohort: pd.DataFrame) -> pd.DataFrame:
+    """Attach City Data Fitness evidence to the validated U.S. place cohort.
+
+    The upstream cohort has already enforced one-to-one place relationships and
+    >=99.5% land overlap. This function translates that evidence into the common
+    fitness vocabulary without modifying the original cohort fields.
+
+    The cohort is suitable for level/growth headline work inside the registered
+    25k-100k origin-population design. It is not spatial/network eligible because
+    the pilot does not validate coordinates or network geography.
+    """
+    require_columns(
+        cohort,
+        {
+            "settlement_id",
+            "geography_status",
+            "origin_land_overlap",
+            "endpoint_land_overlap",
+            "origin_population_status",
+            "endpoint_population_status",
+        },
+        source_name="U.S. Census threshold cohort",
+    )
+    out = cohort.copy()
+    accepted = out["geography_status"].isin({"stable", "official_crosswalk"})
+    direct_counts = out["origin_population_status"].eq("direct_decennial_enumeration") & out[
+        "endpoint_population_status"
+    ].eq("direct_decennial_enumeration")
+    overlap_valid = out["origin_land_overlap"].ge(0.995) & out["endpoint_land_overlap"].ge(0.995)
+
+    out["fitness_scope"] = US_CENSUS_FITNESS_SCOPE
+    out["source_id"] = "us_census_decennial_place_2010_2020"
+    out["population_concept"] = "census_place_total_population"
+    out["geographic_unit"] = "census_place"
+    out["reference_date"] = "2010-04-01/2020-04-01"
+    out["observation_type"] = "direct_decennial_enumeration"
+    out["temporal_comparable"] = direct_counts
+    out["geographic_comparable"] = accepted & overlap_valid
+    out["boundary_temporally_fixed"] = out["geography_status"].eq("stable")
+    out["boundary_change_status"] = np.where(
+        out["geography_status"].eq("stable"), "none", "official_crosswalk"
+    )
+    out["administrative_reclassification"] = False
+    out["methodology_change"] = False
+    out["minimum_reporting_threshold"] = 0
+    out["truncation_exposure"] = "low"
+    out["survivorship_exposure"] = "low"
+    out["concordance_method"] = "census_place_relationship_one_to_one_land_overlap_0.995"
+    out["concordance_status"] = out["geography_status"]
+    out["known_inconsistency"] = False
+    out["validation_status"] = np.where(accepted & direct_counts & overlap_valid, "passed", "failed")
+    out["coordinates_validated"] = False
+    out["network_geography_validated"] = False
+    out["fitness_note"] = (
+        "Eligibility applies only to the registered 25k-100k 2010 origin cohort; "
+        "spatial/network use requires separate geometry validation."
+    )
+    return evaluate_city_data_fitness(out)
+
+
+def us_census_headline_sample(cohort: pd.DataFrame) -> pd.DataFrame:
+    """Return the registered U.S. threshold cohort after the common headline gate."""
+    return headline_sample(apply_us_census_place_fitness(cohort))

--- a/src/urban_growth/data_fitness.py
+++ b/src/urban_growth/data_fitness.py
@@ -20,6 +20,17 @@ UNRESOLVED_BOUNDARY = {
     "unresolved",
     "unknown",
 }
+FITNESS_OUTPUT_COLUMNS = (
+    "level_eligible",
+    "level_exclusion_reasons",
+    "growth_eligible",
+    "growth_exclusion_reasons",
+    "spatial_eligible",
+    "spatial_exclusion_reasons",
+    "headline_eligible",
+    "headline_exclusion_reasons",
+    "fitness_reasons",
+)
 
 
 def _norm(value: object) -> str:
@@ -76,6 +87,8 @@ def _evaluate_row(row: pd.Series) -> dict[str, object]:
     temporal_comparable = _truthy(row.get("temporal_comparable"))
     boundary_fixed = _truthy(row.get("boundary_temporally_fixed"))
     harmonized = concordance_status == "harmonized_common_geography"
+    officially_crosswalked = concordance_status == "official_crosswalk"
+    boundary_resolved = boundary_fixed or harmonized or officially_crosswalked
 
     if not geographic_comparable:
         level_reasons.append("geography_not_comparable")
@@ -87,7 +100,7 @@ def _evaluate_row(row: pd.Series) -> dict[str, object]:
         growth_reasons.append("concordance_not_accepted")
         spatial_reasons.append("concordance_not_accepted")
 
-    if not boundary_fixed and not harmonized:
+    if not boundary_resolved:
         growth_reasons.append("boundary_not_stable_or_harmonized")
 
     if boundary_change_status in UNRESOLVED_BOUNDARY and not harmonized:
@@ -151,20 +164,12 @@ def evaluate_city_data_fitness(frame: pd.DataFrame) -> pd.DataFrame:
 
     The function never edits source values and never computes a composite quality score.
     Missing evidence fails only the analytical dimensions that require that evidence.
+    Existing fitness outputs are replaced so repeated evaluation is idempotent rather
+    than creating duplicate columns.
     """
-    out = frame.copy()
+    out = frame.drop(columns=list(FITNESS_OUTPUT_COLUMNS), errors="ignore").copy()
     if out.empty:
-        for column in (
-            "level_eligible",
-            "level_exclusion_reasons",
-            "growth_eligible",
-            "growth_exclusion_reasons",
-            "spatial_eligible",
-            "spatial_exclusion_reasons",
-            "headline_eligible",
-            "headline_exclusion_reasons",
-            "fitness_reasons",
-        ):
+        for column in FITNESS_OUTPUT_COLUMNS:
             out[column] = pd.Series(dtype="bool" if column.endswith("eligible") else "object")
         return out
 

--- a/tests/test_census_fitness.py
+++ b/tests/test_census_fitness.py
@@ -1,0 +1,66 @@
+import pandas as pd
+
+from urban_growth.census_fitness import apply_us_census_place_fitness, us_census_headline_sample
+
+
+def cohort_row(**overrides) -> dict[str, object]:
+    row = {
+        "settlement_id": "US_PLACE_2010_0100001",
+        "geography_status": "stable",
+        "origin_land_overlap": 1.0,
+        "endpoint_land_overlap": 1.0,
+        "origin_population_status": "direct_decennial_enumeration",
+        "endpoint_population_status": "direct_decennial_enumeration",
+        "crossed_50000": True,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_us_census_fitness_accepts_registered_stable_growth_row() -> None:
+    result = apply_us_census_place_fitness(pd.DataFrame([cohort_row()]))
+    assert result.loc[0, "level_eligible"]
+    assert result.loc[0, "growth_eligible"]
+    assert result.loc[0, "headline_eligible"]
+    assert not result.loc[0, "spatial_eligible"]
+    assert "coordinates_not_validated" in result.loc[0, "spatial_exclusion_reasons"]
+
+
+def test_us_census_fitness_accepts_official_crosswalk_for_growth() -> None:
+    result = apply_us_census_place_fitness(
+        pd.DataFrame([cohort_row(geography_status="official_crosswalk")])
+    )
+    assert result.loc[0, "growth_eligible"]
+    assert result.loc[0, "headline_eligible"]
+    assert not result.loc[0, "boundary_temporally_fixed"]
+    assert result.loc[0, "concordance_status"] == "official_crosswalk"
+
+
+def test_us_census_fitness_fails_bad_overlap_if_upstream_contract_is_bypassed() -> None:
+    result = apply_us_census_place_fitness(
+        pd.DataFrame([cohort_row(origin_land_overlap=0.90)])
+    )
+    assert not result.loc[0, "growth_eligible"]
+    assert not result.loc[0, "headline_eligible"]
+    assert result.loc[0, "validation_status"] == "failed"
+
+
+def test_us_census_headline_sample_cannot_bypass_gate() -> None:
+    cohort = pd.DataFrame(
+        [
+            cohort_row(),
+            cohort_row(
+                settlement_id="US_PLACE_2010_0100002",
+                origin_population_status="modeled_estimate",
+            ),
+        ]
+    )
+    result = us_census_headline_sample(cohort)
+    assert result["settlement_id"].tolist() == ["US_PLACE_2010_0100001"]
+
+
+def test_us_census_fitness_preserves_original_fields() -> None:
+    original = pd.DataFrame([cohort_row(custom_raw_field="raw-audit-value")])
+    result = apply_us_census_place_fitness(original)
+    assert result.loc[0, "custom_raw_field"] == "raw-audit-value"
+    assert original.columns.tolist() == list(cohort_row(custom_raw_field="x").keys())


### PR DESCRIPTION
Applies the newly merged City Data Fitness Standard to the first geographically validated census cohort.

### Changes
- adds `urban_growth.census_fitness` to translate the U.S. 2010–2020 place-cohort evidence into the common fitness vocabulary;
- preserves the upstream one-to-one / 99.5% land-overlap geography contract;
- marks the registered cohort eligible for level/growth headline use when those checks pass;
- explicitly marks the pilot ineligible for spatial/network analysis because coordinates/network geography are not validated;
- labels truncation and survivorship exposure `low`, not `none`, because inference is conditional on the registered 25k–100k origin cohort;
- writes a separate strict headline sample from the common gate;
- extends the summary with eligibility counts;
- adds tests preventing upstream geography/population-evidence bypass.

This does not create an empirical result in Git: the raw Census inputs and generated outputs remain local/outside Git, and the empirical run still requires the registered official inputs.