### PR TITLE
Enforce fitness-gated persistence-only OOS benchmarks

### DIFF
--- a/docs/persistence-oos-fitness-gate.md
+++ b/docs/persistence-oos-fitness-gate.md
@@ -1,0 +1,54 @@
+# Fitness-gated persistence-only out-of-sample benchmark
+
+## Purpose
+
+This stage tests whether a city's recent growth contains genuine forecasting information after geographic and temporal fitness screening. It is deliberately simple: persistence must earn its place before size, rank, spatial exposure, or network variables are added.
+
+## Eligibility gate
+
+Forecast rows are not implicitly accepted. The forecasting layer requires an explicit boolean eligibility field produced by a source-specific application of the City Data Fitness Standard. The default is `growth_eligible`; headline analyses may instead require `headline_eligible`.
+
+Missing eligibility is an error. Rows marked false are removed before any training/test split, baseline estimation, or scoring. The gate name and enforcement status are written into benchmark outputs.
+
+## Rolling-origin requirement
+
+A persistence benchmark is genuinely out of sample only when earlier completed outcomes can train the benchmark and later origins can be tested chronologically. The implementation therefore requires at least two usable rolling origins after fitness screening.
+
+The U.S. Census 2010–2020 threshold pilot has only one registered interval. It can validate source ingestion, geographic concordance, threshold selection, and the fitness gate, but it cannot by itself identify persistence out-of-sample performance. The code must raise rather than relabel that single interval as OOS evidence.
+
+## Locked simple baseline ladder
+
+The persistence stage retains only simple baselines already implemented in `urban_growth.forecast`:
+
+- zero growth;
+- recent city growth (`persistence`);
+- leave-city-out country mean when available;
+- leave-city-out region and subregion means when available;
+- leave-city-out national Cities-category recent growth when available.
+
+No size, rank, density, built-form, spatial, accessibility, or socioeconomic covariates belong in this stage.
+
+## Leakage rule
+
+For origin `t`, training rows must have `period_end <= t`, while test rows must start at `t`. Ineligible rows are removed before those chronological splits. The implementation uses the existing rolling-origin and leave-city-out baseline primitives rather than creating a second forecast engine.
+
+## Metrics
+
+The benchmark inherits the common matched-row metrics:
+
+- MAE;
+- RMSE;
+- median absolute error;
+- bias;
+- directional accuracy.
+
+Row-level errors are retained for later size/rank, downside, country, and region decompositions, but those decompositions must not change the persistence-stage model specification.
+
+## Next empirical execution
+
+The next dataset used for a registered persistence result must satisfy both conditions:
+
+1. source-specific City Data Fitness evidence has been mapped into the common eligibility fields; and
+2. at least two chronological forecast origins remain after the gate.
+
+Until then, this stage is implemented and testable but no new persistence result should be claimed from the U.S. single-interval census pilot.

--- a/src/urban_growth/forecast_fitness.py
+++ b/src/urban_growth/forecast_fitness.py
@@ -1,0 +1,121 @@
+"""Fitness-gated persistence-only out-of-sample forecast evaluation."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from urban_growth.forecast import evaluate_rolling_baselines, rolling_baseline_errors
+from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
+
+PERSISTENCE_BASELINE_MODELS = {
+    "zero_growth",
+    "persistence",
+    "country_mean_leave_city_out",
+    "region_mean_leave_city_out",
+    "subregion_mean_leave_city_out",
+    "national_city_category_persistence_leave_city_out",
+}
+
+
+def fitness_gated_forecast_panel(
+    panel: pd.DataFrame,
+    *,
+    eligibility_column: str = "growth_eligible",
+) -> pd.DataFrame:
+    """Return only explicitly eligible forecast rows.
+
+    Eligibility must already have been produced by a source-specific application of
+    the City Data Fitness Standard. Missing eligibility is an error rather than an
+    implicit pass.
+    """
+    require_columns(
+        panel,
+        {
+            "city_id",
+            "period_start",
+            "period_end",
+            "country_code",
+            "recent_growth",
+            "future_growth",
+            eligibility_column,
+        },
+        source_name="fitness-gated forecast panel",
+    )
+    reject_duplicate_keys(
+        panel,
+        ["city_id", "period_start", "period_end"],
+        source_name="fitness-gated forecast panel",
+    )
+    eligibility = panel[eligibility_column]
+    if not pd.api.types.is_bool_dtype(eligibility.dtype):
+        raise SourceSchemaError(f"{eligibility_column} must be boolean")
+    result = panel.loc[eligibility].copy()
+    if result.empty:
+        raise SourceSchemaError("No forecast rows pass the declared data-fitness gate")
+    result["forecast_fitness_gate"] = eligibility_column
+    result["forecast_fitness_gate_passed"] = True
+    return result.reset_index(drop=True)
+
+
+def _validate_multi_origin_oos(panel: pd.DataFrame, origins: list[int]) -> list[int]:
+    if not origins or len(set(origins)) != len(origins):
+        raise SourceSchemaError("Forecast origins must be unique and non-empty")
+    declared = sorted(origins)
+    available = set(panel["period_start"].unique())
+    missing = [origin for origin in declared if origin not in available]
+    if missing:
+        raise SourceSchemaError(f"Fitness-eligible panel lacks declared origins: {missing}")
+    usable = []
+    for origin in declared:
+        has_train = panel["period_end"].le(origin).any()
+        has_test = panel["period_start"].eq(origin).any()
+        if has_train and has_test:
+            usable.append(origin)
+    if len(usable) < 2:
+        raise SourceSchemaError(
+            "Persistence OOS benchmark requires at least two rolling origins with "
+            "fitness-eligible training and test rows"
+        )
+    return usable
+
+
+def evaluate_fitness_gated_persistence_baselines(
+    panel: pd.DataFrame,
+    origins: list[int],
+    *,
+    eligibility_column: str = "growth_eligible",
+    outcome_column: str = "future_growth",
+) -> pd.DataFrame:
+    """Evaluate the locked simple-baseline ladder on eligible rows only."""
+    gated = fitness_gated_forecast_panel(panel, eligibility_column=eligibility_column)
+    usable_origins = _validate_multi_origin_oos(gated, origins)
+    result = evaluate_rolling_baselines(gated, usable_origins, outcome_column=outcome_column)
+    result = result.loc[result["model"].isin(PERSISTENCE_BASELINE_MODELS)].copy()
+    if "persistence" not in set(result["model"]):
+        raise SourceSchemaError("Persistence baseline was not produced")
+    if "zero_growth" not in set(result["model"]):
+        raise SourceSchemaError("Zero-growth baseline was not produced")
+    result["fitness_gate"] = eligibility_column
+    result["fitness_gate_enforced"] = True
+    result["benchmark_stage"] = "persistence_only"
+    return result.sort_values(["origin", "model"]).reset_index(drop=True)
+
+
+def fitness_gated_persistence_errors(
+    panel: pd.DataFrame,
+    origins: list[int],
+    *,
+    eligibility_column: str = "growth_eligible",
+    outcome_column: str = "future_growth",
+) -> pd.DataFrame:
+    """Return row-level errors for the same locked fitness-gated baseline ladder."""
+    gated = fitness_gated_forecast_panel(panel, eligibility_column=eligibility_column)
+    usable_origins = _validate_multi_origin_oos(gated, origins)
+    result = rolling_baseline_errors(gated, usable_origins, outcome_column=outcome_column)
+    result = result.loc[result["model"].isin(PERSISTENCE_BASELINE_MODELS)].copy()
+    if result.empty:
+        raise SourceSchemaError("No persistence-stage row-level errors were produced")
+    result["fitness_gate"] = eligibility_column
+    result["fitness_gate_enforced"] = True
+    result["benchmark_stage"] = "persistence_only"
+    return result.reset_index(drop=True)

--- a/tests/test_forecast_fitness.py
+++ b/tests/test_forecast_fitness.py
@@ -1,0 +1,72 @@
+import pandas as pd
+import pytest
+
+from urban_growth.forecast_fitness import (
+    evaluate_fitness_gated_persistence_baselines,
+    fitness_gated_forecast_panel,
+    fitness_gated_persistence_errors,
+)
+from urban_growth.io import SourceSchemaError
+
+
+def forecast_panel() -> pd.DataFrame:
+    rows = []
+    specs = {
+        "A": [(2000, 2005, 0.010, 0.012), (2005, 2010, 0.012, 0.014), (2010, 2015, 0.014, 0.013)],
+        "B": [(2000, 2005, 0.020, 0.018), (2005, 2010, 0.018, 0.016), (2010, 2015, 0.016, 0.015)],
+        "C": [(2000, 2005, -0.005, -0.004), (2005, 2010, -0.004, -0.002), (2010, 2015, -0.002, 0.001)],
+    }
+    for city_id, intervals in specs.items():
+        for start, end, recent, future in intervals:
+            rows.append(
+                {
+                    "city_id": city_id,
+                    "country_code": "AAA" if city_id != "C" else "BBB",
+                    "period_start": start,
+                    "period_end": end,
+                    "population_start": 50_000,
+                    "recent_growth": recent,
+                    "future_growth": future,
+                    "growth_eligible": True,
+                }
+            )
+    frame = pd.DataFrame(rows)
+    frame.loc[
+        (frame["city_id"] == "B") & (frame["period_start"] == 2010),
+        "growth_eligible",
+    ] = False
+    return frame
+
+
+def test_fitness_gate_requires_explicit_boolean_eligibility() -> None:
+    panel = forecast_panel().drop(columns="growth_eligible")
+    with pytest.raises(SourceSchemaError, match="growth_eligible"):
+        fitness_gated_forecast_panel(panel)
+
+
+def test_fitness_gate_excludes_ineligible_rows() -> None:
+    result = fitness_gated_forecast_panel(forecast_panel())
+    assert not ((result["city_id"] == "B") & (result["period_start"] == 2010)).any()
+    assert result["forecast_fitness_gate_passed"].all()
+
+
+def test_persistence_oos_requires_multiple_usable_origins() -> None:
+    with pytest.raises(SourceSchemaError, match="at least two rolling origins"):
+        evaluate_fitness_gated_persistence_baselines(forecast_panel(), [2005])
+
+
+def test_persistence_oos_scores_only_fitness_eligible_test_rows() -> None:
+    result = evaluate_fitness_gated_persistence_baselines(forecast_panel(), [2005, 2010])
+    assert {"zero_growth", "persistence"}.issubset(set(result["model"]))
+    assert result["fitness_gate_enforced"].all()
+    assert result["benchmark_stage"].eq("persistence_only").all()
+    counts = result.pivot(index="origin", columns="model", values="n")
+    assert counts.loc[2005, "persistence"] == 3
+    assert counts.loc[2010, "persistence"] == 2
+
+
+def test_row_level_errors_cannot_reintroduce_ineligible_rows() -> None:
+    errors = fitness_gated_persistence_errors(forecast_panel(), [2005, 2010])
+    excluded = errors.loc[(errors["city_id"] == "B") & (errors["origin"] == 2010)]
+    assert excluded.empty
+    assert errors["fitness_gate_enforced"].all()

--- a/tests/test_forecast_fitness_single_interval.py
+++ b/tests/test_forecast_fitness_single_interval.py
@@ -1,0 +1,24 @@
+import pandas as pd
+import pytest
+
+from urban_growth.forecast_fitness import evaluate_fitness_gated_persistence_baselines
+from urban_growth.io import SourceSchemaError
+
+
+def test_single_interval_census_like_panel_is_not_mislabeled_oos() -> None:
+    panel = pd.DataFrame(
+        [
+            {
+                "city_id": "US_PLACE_2010_0100001",
+                "country_code": "USA",
+                "period_start": 2010,
+                "period_end": 2020,
+                "population_start": 40_000,
+                "recent_growth": 0.01,
+                "future_growth": 0.02,
+                "growth_eligible": True,
+            }
+        ]
+    )
+    with pytest.raises(SourceSchemaError):
+        evaluate_fitness_gated_persistence_baselines(panel, [2010])


### PR DESCRIPTION
Implements the next locked forecasting step after the City Data Fitness Standard.

### Changes
- adds a forecasting-layer gate that requires explicit boolean fitness eligibility before any train/test split;
- evaluates only the simple persistence-stage baseline ladder (zero growth, city persistence, and available leave-city-out national/regional comparators);
- preserves row-level errors for later subgroup analysis without adding size/rank/spatial covariates;
- requires at least two usable chronological rolling origins after fitness screening;
- explicitly refuses to treat the single 2010–2020 U.S. Census pilot interval as out-of-sample persistence evidence;
- adds contract tests for gate bypass, exclusion propagation, multi-origin requirements, and row-level errors.

No empirical persistence result is claimed in this PR. The U.S. pilot has one registered interval, so the next registered result must use a multi-origin source after source-specific fitness evidence is mapped into the common gate.