### PR TITLE
Add GHSL fixed-boundary persistence sensitivity gate

### DIFF
--- a/docs/ghsl-fixed-fitness-persistence.md
+++ b/docs/ghsl-fixed-fitness-persistence.md
@@ -1,0 +1,55 @@
+# GHSL fixed-boundary persistence fitness decision
+
+## Decision
+
+The GHSL R2024A v1.2 thematic stream is the first repository source with enough multi-origin coverage and an internally stable geographic unit to exercise the fitness-gated persistence benchmark. It is admitted only as a **retrospective stable-footprint sensitivity**, not as headline or deployable-at-origin evidence.
+
+## Why this source can enter the persistence benchmark
+
+Every historical GHSL thematic statistic is calculated inside the same 2025 urban-centre footprint. The repository has already reconciled the fixed thematic and multi-temporal streams at their documented common 2025 epoch, requiring one-to-one identifier/country agreement, exact area agreement, and population agreement within publisher rounding precision.
+
+That makes within-entity population growth geographically stable for the narrow question: how well does recent population change inside today's footprint predict later population change inside that same footprint?
+
+The source-specific fitness adapter therefore requires:
+
+- `boundary_mode = fixed`;
+- `boundary_product = ucdb_fixed_2025_boundary`;
+- `boundary_reference_year = 2025`;
+- `boundary_temporally_fixed = true`;
+- `boundary_history_uses_future_reference = true`;
+- completed 2025 fixed/dynamic cross-stream reconciliation.
+
+Rows satisfying those conditions can be `growth_eligible` for retrospective sensitivity analysis.
+
+## Why this is not headline forecast evidence
+
+The fixed polygon is defined using 2025 settlement extent. An analyst standing at a 1985, 1990, or 2000 forecast origin would not have known that future footprint. Geography therefore leaks future information even though population outcomes themselves remain chronologically separated.
+
+For that reason the source-specific adapter forcibly sets:
+
+- `headline_eligible = false`;
+- `deployable_at_origin = false`;
+- `boundary_information_leakage = true`;
+- `benchmark_interpretation = retrospective_stable_footprint_sensitivity`.
+
+The runner repeats these labels on every metrics/error output. A good persistence result here would establish that the persistence signal survives a stable-footprint definition. It would **not** establish a deployable historical forecast or remove survivorship concerns.
+
+## Remaining selection problem
+
+The fixed thematic archive contains the 2025 quality-controlled urban-centre universe measured backward through time. This is a future-survivor cohort by construction. The fitness mapping records `survivorship_exposure = material`. The common headline gate therefore rejects it independently of the future-boundary override.
+
+GHSL multi-temporal histories are not an escape from this issue: their active population observations are threshold-selected at 50,000 and their polygons change through time. WUP F21 is also threshold-truncated below 50,000. Neither should be promoted merely because it offers more forecast origins.
+
+## Execution
+
+With the already registered raw GHSL thematic and MTUC files available locally:
+
+```bash
+uv run --locked python scripts/run_ghsl_fixed_fitness_persistence.py
+```
+
+The script rebuilds both streams, validates their 2025 reconciliation, constructs fixed-boundary forecast intervals, applies the City Data Fitness gate, and then runs only the locked persistence-stage baseline ladder. Generated files remain under `outputs/` and are not committed as empirical claims without result-manifest registration.
+
+## Next evidence requirement
+
+After this sensitivity path, the next headline-capable persistence result still requires a source with multiple historical origins whose geographic identity can be established without future-boundary information and whose threshold/survivorship exposure is acceptable for the intended claim. National census locality concordances remain the preferred route for that test.

--- a/scripts/run_ghsl_fixed_fitness_persistence.py
+++ b/scripts/run_ghsl_fixed_fitness_persistence.py
@@ -1,0 +1,83 @@
+"""Run the persistence-only benchmark on fitness-qualified GHSL fixed histories."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from urban_growth.adapters.ghsl_ucdb import (
+    fixed_2025_theme_panel,
+    multitemporal_boundary_panel,
+    read_ghsl_mtuc_csv,
+    read_ghsl_theme_csv,
+    reconcile_2025_streams,
+)
+from urban_growth.forecast import build_ghsl_fixed_forecast_intervals
+from urban_growth.forecast_fitness import (
+    evaluate_fitness_gated_persistence_baselines,
+    fitness_gated_persistence_errors,
+)
+from urban_growth.ghsl_fitness import apply_ghsl_fixed_forecast_fitness
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=Path("data/raw/GHS_UCDB_THEME_GHSL_GLOBE_R2024A.csv"),
+    )
+    parser.add_argument(
+        "--dynamic-input",
+        type=Path,
+        default=Path("data/raw/GHS_UCDB_MTUC_GLOBE_R2024A.csv"),
+    )
+    parser.add_argument(
+        "--metrics-output",
+        type=Path,
+        default=Path("outputs/ghsl_fixed_fitness_persistence_metrics.csv"),
+    )
+    parser.add_argument(
+        "--errors-output",
+        type=Path,
+        default=Path("outputs/ghsl_fixed_fitness_persistence_errors.csv"),
+    )
+    parser.add_argument(
+        "--fitness-output",
+        type=Path,
+        default=Path("outputs/ghsl_fixed_forecast_fitness.csv"),
+    )
+    args = parser.parse_args()
+
+    fixed = fixed_2025_theme_panel(read_ghsl_theme_csv(str(args.input)))
+    dynamic = multitemporal_boundary_panel(read_ghsl_mtuc_csv(str(args.dynamic_input)))
+    reconciliation = reconcile_2025_streams(fixed, dynamic)
+    intervals = build_ghsl_fixed_forecast_intervals(
+        fixed,
+        list(range(1980, 2025, 5)),
+        reconciliation=reconciliation,
+    )
+    fitted = apply_ghsl_fixed_forecast_fitness(intervals)
+    origins = list(range(1985, 2025, 5))
+    metrics = evaluate_fitness_gated_persistence_baselines(fitted, origins)
+    errors = fitness_gated_persistence_errors(fitted, origins)
+
+    for frame in (metrics, errors):
+        frame["source_id"] = "ghsl_ucdb_r2024a_v1_2_fixed"
+        frame["result_class"] = "retrospective_stable_footprint_sensitivity"
+        frame["deployable_at_origin"] = False
+        frame["headline_result"] = False
+        frame["boundary_information_leakage"] = True
+
+    for path, frame in [
+        (args.fitness_output, fitted),
+        (args.metrics_output, metrics),
+        (args.errors_output, errors),
+    ]:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        frame.to_csv(path, index=False)
+        print(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/urban_growth/ghsl_fitness.py
+++ b/src/urban_growth/ghsl_fitness.py
@@ -1,0 +1,79 @@
+"""Source-specific City Data Fitness mapping for GHSL fixed-boundary forecasts."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from urban_growth.data_fitness import evaluate_city_data_fitness
+from urban_growth.io import SourceSchemaError, require_columns
+
+
+def apply_ghsl_fixed_forecast_fitness(panel: pd.DataFrame) -> pd.DataFrame:
+    """Map GHSL fixed-2025 forecast intervals into the common fitness vocabulary.
+
+    The thematic GHSL stream is temporally fixed because every historical statistic is
+    measured inside the 2025 urban-centre footprint. That makes growth comparisons
+    internally stable, but it also uses future boundary information relative to earlier
+    forecast origins. Rows can therefore be used for retrospective persistence
+    sensitivity analysis, but never as deployable-at-origin or headline evidence.
+    """
+    require_columns(
+        panel,
+        {
+            "city_id",
+            "country_code",
+            "period_start",
+            "period_end",
+            "boundary_mode",
+            "boundary_product",
+            "boundary_reference_year",
+            "boundary_temporally_fixed",
+            "boundary_history_uses_future_reference",
+            "cross_stream_reconciled",
+        },
+        source_name="GHSL fixed forecast panel",
+    )
+    if panel["boundary_mode"].ne("fixed").any():
+        raise SourceSchemaError("GHSL fixed fitness requires fixed-boundary rows only")
+    if panel["boundary_product"].ne("ucdb_fixed_2025_boundary").any():
+        raise SourceSchemaError("GHSL fixed fitness requires the registered thematic boundary product")
+    if panel["boundary_reference_year"].ne(2025).any():
+        raise SourceSchemaError("GHSL fixed fitness requires the 2025 reference boundary")
+    if not panel["boundary_temporally_fixed"].eq(True).all():
+        raise SourceSchemaError("GHSL fixed fitness requires temporally fixed boundaries")
+    if not panel["boundary_history_uses_future_reference"].eq(True).all():
+        raise SourceSchemaError("GHSL fixed histories must declare use of the 2025 future reference")
+    if not panel["cross_stream_reconciled"].eq(True).all():
+        raise SourceSchemaError("GHSL fixed forecast rows require completed 2025 cross-stream reconciliation")
+
+    evidence = panel.copy()
+    evidence["source_id"] = "ghsl_ucdb_r2024a_v1_2_fixed"
+    evidence["population_concept"] = "ghsl_urban_centre_population_inside_2025_footprint"
+    evidence["geographic_unit"] = "urban_centre_fixed_2025_polygon"
+    evidence["reference_date"] = evidence["period_start"]
+    evidence["observation_type"] = "retrospective_model_epoch"
+    evidence["temporal_comparable"] = True
+    evidence["geographic_comparable"] = True
+    evidence["concordance_status"] = "stable"
+    evidence["boundary_change_status"] = "none_within_fixed_2025_footprint"
+    evidence["administrative_reclassification"] = False
+    evidence["methodology_change"] = False
+    evidence["minimum_reporting_threshold"] = "not_applicable_fixed_thematic_stream"
+    evidence["truncation_exposure"] = "low"
+    evidence["survivorship_exposure"] = "material"
+    evidence["known_inconsistency"] = False
+    evidence["validation_status"] = "passed"
+    evidence["coordinates_validated"] = False
+    evidence["network_geography_validated"] = False
+
+    evaluated = evaluate_city_data_fitness(evidence)
+    # Source-specific override: retrospective fixed-footprint growth is analytically
+    # usable, but a 2025 boundary is future information for earlier forecast origins.
+    evaluated["headline_eligible"] = False
+    evaluated["headline_exclusion_reasons"] = evaluated["headline_exclusion_reasons"].apply(
+        lambda value: ";".join(filter(None, [value, "future_boundary_reference"]))
+    )
+    evaluated["deployable_at_origin"] = False
+    evaluated["benchmark_interpretation"] = "retrospective_stable_footprint_sensitivity"
+    evaluated["boundary_information_leakage"] = True
+    return evaluated

--- a/tests/test_ghsl_fitness.py
+++ b/tests/test_ghsl_fitness.py
@@ -1,0 +1,54 @@
+import pandas as pd
+import pytest
+
+from urban_growth.ghsl_fitness import apply_ghsl_fixed_forecast_fitness
+from urban_growth.io import SourceSchemaError
+
+
+def fixed_row(**overrides):
+    row = {
+        "city_id": "G1",
+        "country_code": "AAA",
+        "period_start": 2000,
+        "period_end": 2005,
+        "recent_growth": 0.02,
+        "future_growth": 0.015,
+        "boundary_mode": "fixed",
+        "boundary_product": "ucdb_fixed_2025_boundary",
+        "boundary_reference_year": 2025,
+        "boundary_temporally_fixed": True,
+        "boundary_history_uses_future_reference": True,
+        "cross_stream_reconciled": True,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_ghsl_fixed_is_growth_eligible_but_not_headline_or_deployable() -> None:
+    result = apply_ghsl_fixed_forecast_fitness(pd.DataFrame([fixed_row()]))
+    assert result.loc[0, "growth_eligible"]
+    assert not result.loc[0, "headline_eligible"]
+    assert not result.loc[0, "deployable_at_origin"]
+    assert result.loc[0, "boundary_information_leakage"]
+    assert "future_boundary_reference" in result.loc[0, "headline_exclusion_reasons"]
+    assert result.loc[0, "benchmark_interpretation"] == "retrospective_stable_footprint_sensitivity"
+
+
+def test_ghsl_fixed_is_not_spatially_eligible_without_validated_network_geography() -> None:
+    result = apply_ghsl_fixed_forecast_fitness(pd.DataFrame([fixed_row()]))
+    assert not result.loc[0, "spatial_eligible"]
+    reasons = result.loc[0, "spatial_exclusion_reasons"]
+    assert "coordinates_not_validated" in reasons
+    assert "network_geography_not_validated" in reasons
+
+
+def test_ghsl_fixed_requires_cross_stream_reconciliation() -> None:
+    with pytest.raises(SourceSchemaError, match="reconciliation"):
+        apply_ghsl_fixed_forecast_fitness(
+            pd.DataFrame([fixed_row(cross_stream_reconciled=False)])
+        )
+
+
+def test_ghsl_fixed_rejects_dynamic_boundaries() -> None:
+    with pytest.raises(SourceSchemaError, match="fixed-boundary"):
+        apply_ghsl_fixed_forecast_fitness(pd.DataFrame([fixed_row(boundary_mode="dynamic")]))


### PR DESCRIPTION
Implements the first defensible multi-origin persistence path after the common forecast gate.

### Changes
- adds source-specific City Data Fitness mapping for GHSL fixed-2025 forecast intervals;
- requires the registered fixed thematic product, 2025 reference boundary, temporal fixation, explicit future-boundary declaration, and completed 2025 cross-stream reconciliation;
- permits growth analysis only as a retrospective stable-footprint sensitivity;
- forcibly marks rows non-headline and non-deployable because the 2025 boundary leaks future geography and the thematic universe is survivor-selected;
- adds a dedicated persistence-only runner using the locked fitness-gated benchmark layer;
- adds tests for fixed-boundary enforcement, reconciliation, spatial ineligibility, and headline/deployability exclusions;
- documents why WUP and GHSL dynamic are not promoted as headline substitutes.

No empirical metrics are committed in this PR. The runner consumes the already registered local GHSL raw files and writes generated outputs under `outputs/` for later result-manifest registration.