### PR TITLE
Add Mexico multiwave concordance contract

### DIFF
--- a/docs/mexico-multiwave-oos-contract.md
+++ b/docs/mexico-multiwave-oos-contract.md
@@ -1,0 +1,57 @@
+# Mexico multiwave locality OOS contract
+
+## Decision
+
+Mexico can potentially supply the first national-census-family, multi-origin persistence test without future-boundary leakage, but only if each adjacent locality transition is independently concorded and audited.
+
+INEGI SCITEL exposes locality-level population for the 1990 census, 1995 population count, 2000 census, 2005 population count, 2010 census, and 2020 census. The 1995 and 2005 products are national population counts with locality-level geographic breakdown; they are not silently treated as identical to censuses. Every census/count transition therefore requires an explicit `methodology_comparable` decision before it may enter a growth predictor or outcome.
+
+## Why the 1995 and 2005 counts matter
+
+A decennial-only 2000–2010–2020 panel yields only one usable rolling forecast origin once a prior growth interval is required. Adding the official 1995 and 2005 locality counts creates candidate five-year chains such as:
+
+- 1990–1995 history → 1995–2000 outcome;
+- 1995–2000 history → 2000–2005 outcome;
+- 2000–2005 history → 2005–2010 outcome.
+
+The 2010–2020 transition may also be evaluated, but its ten-year horizon is not automatically pooled with five-year outcomes. Horizon-specific results must remain separate unless an explicit annualized-growth estimand and pooling rule are registered.
+
+## No-future-boundary rule
+
+Each adjacent transition is evaluated using only official relationship, locality-history, and vintage-geometry evidence available no later than that transition endpoint. A 2005 or 2010 geographic relationship cannot be used to redefine the 1990–1995 or 1995–2000 predictor geography.
+
+For a forecast row at origin `t`:
+
+1. the immediately prior transition ending at `t` must independently pass the concordance and methodology rules;
+2. the outcome transition beginning at `t` must independently pass;
+3. later geography cannot repair either transition;
+4. a failed prior transition makes the forecast row ineligible even when the outcome transition is clean.
+
+This is the central protection against using future geographic knowledge to manufacture persistence.
+
+## Transition acceptance
+
+Accepted statuses remain:
+
+- `stable_geometry`;
+- `official_crosswalk`;
+- `harmonized_common_geography`.
+
+One-to-one matches require an official relationship and at least 99.5% polygon overlap against both endpoint units. Harmonized split/merge/transfer cases require all official components, complete population aggregation, no double counting, and the same polygon-union overlap rule. Name equality, fuzzy matching, or coordinate proximity may generate candidates but cannot establish acceptance.
+
+Each accepted transition additionally requires `methodology_comparable = true`. This field is deliberately separate from geographic concordance because a geographically stable locality can still be unsuitable for a population-growth comparison if census/count concepts or coverage differ materially.
+
+## Coverage gate
+
+Coverage is calculated before unresolved records are removed. For every transition and the registered 25,000–100,000 origin cohort, report both:
+
+- locality-count coverage;
+- origin-population-weighted coverage.
+
+The existing proposed Mexico gate remains at least 85% count coverage and at least 90% population coverage, with every detected split, merger, annexation, or municipal transfer resolved or explicitly excluded. These thresholds remain provisional until the exact national files are acquired and the first full transition audit is run.
+
+## Forecast use
+
+`src/urban_growth/mexico_concordance.py` converts accepted adjacent transitions into forecast rows only when both the prior-history and current-outcome transitions pass. The resulting rows expose `recent_growth`, `future_growth`, `period_start`, `period_end`, `growth_eligible`, and explicit no-future-boundary flags for the common persistence benchmark layer.
+
+No empirical Mexico persistence result is registered by this contract. Exact ITER/SCITEL files, official equivalence records, vintage Marco Geoestadístico layers, retrieval dates, URLs, and hashes must be acquired and registered first.

--- a/src/urban_growth/mexico_concordance.py
+++ b/src/urban_growth/mexico_concordance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pandas as pd
 
 from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
@@ -15,12 +16,7 @@ ALLOWED_EVENT_TYPES = {"census", "population_count"}
 
 
 def validate_mexico_locality_transition(transition: pd.DataFrame) -> pd.DataFrame:
-    """Validate one locality transition without borrowing future geography.
-
-    Each row represents one origin-locality analytical unit for a single adjacent
-    observation transition. Harmonized rows may aggregate identified components, but
-    the evidence used to define the origin-side history cannot post-date the transition.
-    """
+    """Validate one locality transition without borrowing future geography."""
     required = {
         "analysis_id",
         "origin_year",
@@ -59,7 +55,8 @@ def validate_mexico_locality_transition(transition: pd.DataFrame) -> pd.DataFram
         numeric = pd.to_numeric(out[column], errors="coerce")
         if numeric.isna().any() or numeric.le(0).any():
             raise SourceSchemaError(f"{column} must contain positive direct counts")
-    if (pd.to_numeric(out["evidence_reference_year"], errors="coerce") > out["endpoint_year"]).any():
+    evidence_year = pd.to_numeric(out["evidence_reference_year"], errors="coerce")
+    if evidence_year.isna().any() or (evidence_year > out["endpoint_year"]).any():
         raise SourceSchemaError(
             "Mexico concordance evidence may not post-date its transition endpoint"
         )
@@ -97,35 +94,39 @@ def validate_mexico_locality_transition(transition: pd.DataFrame) -> pd.DataFram
 
     out["transition_eligible"] = accepted & methodology
     out["transition_exclusion_reason"] = out["exclusion_reason"].fillna("").astype(str)
-    out.loc[accepted & ~methodology, "transition_exclusion_reason"] = "methodology_not_comparable"
-    out.loc[~accepted & out["transition_exclusion_reason"].eq(""), "transition_exclusion_reason"] = (
+    out.loc[accepted & ~methodology, "transition_exclusion_reason"] = (
+        "methodology_not_comparable"
+    )
+    unresolved_without_reason = ~accepted & out["transition_exclusion_reason"].eq("")
+    out.loc[unresolved_without_reason, "transition_exclusion_reason"] = (
         "unresolved_concordance"
     )
     return out
 
 
 def build_mexico_multiwave_history(transitions: pd.DataFrame) -> pd.DataFrame:
-    """Build adjacent-transition histories without future-boundary leakage.
+    """Build adjacent-transition forecast rows without future-boundary leakage.
 
-    A locality is eligible for a historical growth predictor only if the immediately
-    preceding transition passed on its own evidence. Later transitions cannot repair or
-    redefine an earlier predictor interval.
+    A forecast row is eligible only when both its outcome transition and the immediately
+    preceding transition used for recent growth pass independently. Later geography cannot
+    repair an earlier predictor interval.
     """
     checked = validate_mexico_locality_transition(transitions)
     checked = checked.sort_values(["analysis_id", "origin_year", "endpoint_year"]).copy()
-    checked["history_growth"] = (
-        pd.Series(pd.to_numeric(checked["endpoint_population"]))
-        .groupby(checked["analysis_id"])
-        .transform(lambda _: pd.NA)
-    )
     duration = checked["endpoint_year"] - checked["origin_year"]
     checked["interval_log_growth"] = (
-        pd.to_numeric(checked["endpoint_population"]).map(float).map(__import__("math").log)
-        - pd.to_numeric(checked["origin_population"]).map(float).map(__import__("math").log)
+        np.log(pd.to_numeric(checked["endpoint_population"]))
+        - np.log(pd.to_numeric(checked["origin_population"]))
     ) / duration
 
     previous = checked[
-        ["analysis_id", "origin_year", "endpoint_year", "interval_log_growth", "transition_eligible"]
+        [
+            "analysis_id",
+            "origin_year",
+            "endpoint_year",
+            "interval_log_growth",
+            "transition_eligible",
+        ]
     ].rename(
         columns={
             "origin_year": "previous_origin_year",
@@ -174,6 +175,7 @@ def mexico_transition_coverage(
     for (origin_year, endpoint_year), group in cohort.groupby(["origin_year", "endpoint_year"]):
         eligible = group["transition_eligible"]
         population = pd.to_numeric(group["origin_population"])
+        eligible_population = population.loc[eligible].sum()
         rows.append(
             {
                 "origin_year": int(origin_year),
@@ -182,8 +184,8 @@ def mexico_transition_coverage(
                 "eligible_localities": int(eligible.sum()),
                 "count_coverage": float(eligible.mean()),
                 "origin_population": float(population.sum()),
-                "eligible_origin_population": float(population.loc[eligible].sum()),
-                "population_coverage": float(population.loc[eligible].sum() / population.sum()),
+                "eligible_origin_population": float(eligible_population),
+                "population_coverage": float(eligible_population / population.sum()),
             }
         )
     return pd.DataFrame(rows).sort_values(["origin_year", "endpoint_year"]).reset_index(drop=True)

--- a/src/urban_growth/mexico_concordance.py
+++ b/src/urban_growth/mexico_concordance.py
@@ -1,0 +1,189 @@
+"""Contracts for leakage-resistant Mexico locality concordance chains."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
+
+ACCEPTED_MATCH_STATUS = {
+    "stable_geometry",
+    "official_crosswalk",
+    "harmonized_common_geography",
+}
+ALLOWED_EVENT_TYPES = {"census", "population_count"}
+
+
+def validate_mexico_locality_transition(transition: pd.DataFrame) -> pd.DataFrame:
+    """Validate one locality transition without borrowing future geography.
+
+    Each row represents one origin-locality analytical unit for a single adjacent
+    observation transition. Harmonized rows may aggregate identified components, but
+    the evidence used to define the origin-side history cannot post-date the transition.
+    """
+    required = {
+        "analysis_id",
+        "origin_year",
+        "endpoint_year",
+        "origin_population",
+        "endpoint_population",
+        "origin_event_type",
+        "endpoint_event_type",
+        "match_status",
+        "relationship_cardinality",
+        "origin_overlap_ratio",
+        "endpoint_overlap_ratio",
+        "official_relationship_verified",
+        "all_components_identified",
+        "population_aggregation_complete",
+        "double_count_free",
+        "methodology_comparable",
+        "evidence_reference_year",
+        "uses_future_boundary_reference",
+        "exclusion_reason",
+    }
+    require_columns(transition, required, source_name="Mexico locality transition")
+    reject_duplicate_keys(
+        transition,
+        ["analysis_id", "origin_year", "endpoint_year"],
+        source_name="Mexico locality transition",
+    )
+    out = transition.copy()
+    if (out["endpoint_year"] <= out["origin_year"]).any():
+        raise SourceSchemaError("Mexico transition endpoint must follow origin year")
+    if not out["origin_event_type"].isin(ALLOWED_EVENT_TYPES).all():
+        raise SourceSchemaError("Mexico transition has unsupported origin event type")
+    if not out["endpoint_event_type"].isin(ALLOWED_EVENT_TYPES).all():
+        raise SourceSchemaError("Mexico transition has unsupported endpoint event type")
+    for column in ("origin_population", "endpoint_population"):
+        numeric = pd.to_numeric(out[column], errors="coerce")
+        if numeric.isna().any() or numeric.le(0).any():
+            raise SourceSchemaError(f"{column} must contain positive direct counts")
+    if (pd.to_numeric(out["evidence_reference_year"], errors="coerce") > out["endpoint_year"]).any():
+        raise SourceSchemaError(
+            "Mexico concordance evidence may not post-date its transition endpoint"
+        )
+    if out["uses_future_boundary_reference"].fillna(False).astype(bool).any():
+        raise SourceSchemaError(
+            "Mexico concordance may not use a boundary reference after the transition"
+        )
+
+    accepted = out["match_status"].isin(ACCEPTED_MATCH_STATUS)
+    one_to_one = out["relationship_cardinality"].eq("one_to_one")
+    harmonized = out["match_status"].eq("harmonized_common_geography")
+    geometry_pass = (
+        pd.to_numeric(out["origin_overlap_ratio"], errors="coerce").ge(0.995)
+        & pd.to_numeric(out["endpoint_overlap_ratio"], errors="coerce").ge(0.995)
+    )
+    official = out["official_relationship_verified"].fillna(False).astype(bool)
+    components = out["all_components_identified"].fillna(False).astype(bool)
+    aggregation = out["population_aggregation_complete"].fillna(False).astype(bool)
+    no_double_count = out["double_count_free"].fillna(False).astype(bool)
+    methodology = out["methodology_comparable"].fillna(False).astype(bool)
+
+    invalid_one_to_one = accepted & ~harmonized & (~one_to_one | ~official | ~geometry_pass)
+    if invalid_one_to_one.any():
+        raise SourceSchemaError(
+            "Accepted Mexico one-to-one matches require official relationship and 99.5% overlap"
+        )
+    invalid_harmonized = harmonized & (
+        ~official | ~components | ~aggregation | ~no_double_count | ~geometry_pass
+    )
+    if invalid_harmonized.any():
+        raise SourceSchemaError(
+            "Harmonized Mexico matches require complete official components, aggregation, "
+            "no double counting, and 99.5% union overlap"
+        )
+
+    out["transition_eligible"] = accepted & methodology
+    out["transition_exclusion_reason"] = out["exclusion_reason"].fillna("").astype(str)
+    out.loc[accepted & ~methodology, "transition_exclusion_reason"] = "methodology_not_comparable"
+    out.loc[~accepted & out["transition_exclusion_reason"].eq(""), "transition_exclusion_reason"] = (
+        "unresolved_concordance"
+    )
+    return out
+
+
+def build_mexico_multiwave_history(transitions: pd.DataFrame) -> pd.DataFrame:
+    """Build adjacent-transition histories without future-boundary leakage.
+
+    A locality is eligible for a historical growth predictor only if the immediately
+    preceding transition passed on its own evidence. Later transitions cannot repair or
+    redefine an earlier predictor interval.
+    """
+    checked = validate_mexico_locality_transition(transitions)
+    checked = checked.sort_values(["analysis_id", "origin_year", "endpoint_year"]).copy()
+    checked["history_growth"] = (
+        pd.Series(pd.to_numeric(checked["endpoint_population"]))
+        .groupby(checked["analysis_id"])
+        .transform(lambda _: pd.NA)
+    )
+    duration = checked["endpoint_year"] - checked["origin_year"]
+    checked["interval_log_growth"] = (
+        pd.to_numeric(checked["endpoint_population"]).map(float).map(__import__("math").log)
+        - pd.to_numeric(checked["origin_population"]).map(float).map(__import__("math").log)
+    ) / duration
+
+    previous = checked[
+        ["analysis_id", "origin_year", "endpoint_year", "interval_log_growth", "transition_eligible"]
+    ].rename(
+        columns={
+            "origin_year": "previous_origin_year",
+            "endpoint_year": "origin_year",
+            "interval_log_growth": "recent_growth",
+            "transition_eligible": "history_transition_eligible",
+        }
+    )
+    current = checked.merge(
+        previous,
+        on=["analysis_id", "origin_year"],
+        how="left",
+        validate="one_to_one",
+    )
+    current["forecast_interval_eligible"] = (
+        current["transition_eligible"]
+        & current["history_transition_eligible"].fillna(False).astype(bool)
+        & current["previous_origin_year"].notna()
+    )
+    current["future_growth"] = current["interval_log_growth"]
+    current["period_start"] = current["origin_year"]
+    current["period_end"] = current["endpoint_year"]
+    current["country_code"] = "MEX"
+    current["city_id"] = current["analysis_id"].astype(str)
+    current["growth_eligible"] = current["forecast_interval_eligible"]
+    current["headline_eligible"] = current["forecast_interval_eligible"]
+    current["boundary_history_uses_future_reference"] = False
+    current["forecast_deployable_at_origin"] = current["forecast_interval_eligible"]
+    return current
+
+
+def mexico_transition_coverage(
+    transition: pd.DataFrame,
+    *,
+    cohort_min: int = 25_000,
+    cohort_max: int = 100_000,
+) -> pd.DataFrame:
+    """Report count- and population-weighted coverage before dropping exclusions."""
+    checked = validate_mexico_locality_transition(transition)
+    cohort = checked.loc[
+        pd.to_numeric(checked["origin_population"]).between(cohort_min, cohort_max)
+    ].copy()
+    if cohort.empty:
+        raise SourceSchemaError("Mexico transition has no registered threshold cohort")
+    rows = []
+    for (origin_year, endpoint_year), group in cohort.groupby(["origin_year", "endpoint_year"]):
+        eligible = group["transition_eligible"]
+        population = pd.to_numeric(group["origin_population"])
+        rows.append(
+            {
+                "origin_year": int(origin_year),
+                "endpoint_year": int(endpoint_year),
+                "origin_localities": int(len(group)),
+                "eligible_localities": int(eligible.sum()),
+                "count_coverage": float(eligible.mean()),
+                "origin_population": float(population.sum()),
+                "eligible_origin_population": float(population.loc[eligible].sum()),
+                "population_coverage": float(population.loc[eligible].sum() / population.sum()),
+            }
+        )
+    return pd.DataFrame(rows).sort_values(["origin_year", "endpoint_year"]).reset_index(drop=True)

--- a/src/urban_growth/mexico_concordance.py
+++ b/src/urban_growth/mexico_concordance.py
@@ -180,7 +180,7 @@ def mexico_transition_coverage(
             {
                 "origin_year": int(origin_year),
                 "endpoint_year": int(endpoint_year),
-                "origin_localities": int(len(group)),
+                "origin_localities": len(group),
                 "eligible_localities": int(eligible.sum()),
                 "count_coverage": float(eligible.mean()),
                 "origin_population": float(population.sum()),

--- a/tests/test_mexico_concordance.py
+++ b/tests/test_mexico_concordance.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from urban_growth.io import SourceSchemaError
+from urban_growth.mexico_concordance import (
+    build_mexico_multiwave_history,
+    mexico_transition_coverage,
+    validate_mexico_locality_transition,
+)
+
+
+def row(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "analysis_id": "MEX_LOC_001",
+        "origin_year": 1995,
+        "endpoint_year": 2000,
+        "origin_population": 40_000,
+        "endpoint_population": 44_000,
+        "origin_event_type": "population_count",
+        "endpoint_event_type": "census",
+        "match_status": "stable_geometry",
+        "relationship_cardinality": "one_to_one",
+        "origin_overlap_ratio": 0.999,
+        "endpoint_overlap_ratio": 0.999,
+        "official_relationship_verified": True,
+        "all_components_identified": True,
+        "population_aggregation_complete": True,
+        "double_count_free": True,
+        "methodology_comparable": True,
+        "evidence_reference_year": 2000,
+        "uses_future_boundary_reference": False,
+        "exclusion_reason": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_transition_rejects_future_boundary_evidence() -> None:
+    frame = pd.DataFrame([row(evidence_reference_year=2005)])
+    with pytest.raises(SourceSchemaError, match="may not post-date"):
+        validate_mexico_locality_transition(frame)
+
+
+def test_harmonized_transition_requires_complete_components() -> None:
+    frame = pd.DataFrame(
+        [
+            row(
+                match_status="harmonized_common_geography",
+                relationship_cardinality="one_to_many",
+                all_components_identified=False,
+            )
+        ]
+    )
+    with pytest.raises(SourceSchemaError, match="complete official components"):
+        validate_mexico_locality_transition(frame)
+
+
+def test_methodology_failure_is_retained_but_ineligible() -> None:
+    result = validate_mexico_locality_transition(
+        pd.DataFrame([row(methodology_comparable=False)])
+    )
+    assert not result.loc[0, "transition_eligible"]
+    assert result.loc[0, "transition_exclusion_reason"] == "methodology_not_comparable"
+
+
+def test_multiwave_history_uses_only_immediately_prior_transition() -> None:
+    transitions = pd.DataFrame(
+        [
+            row(),
+            row(
+                origin_year=2000,
+                endpoint_year=2005,
+                origin_population=44_000,
+                endpoint_population=48_000,
+                origin_event_type="census",
+                endpoint_event_type="population_count",
+                evidence_reference_year=2005,
+            ),
+            row(
+                origin_year=2005,
+                endpoint_year=2010,
+                origin_population=48_000,
+                endpoint_population=53_000,
+                origin_event_type="population_count",
+                endpoint_event_type="census",
+                evidence_reference_year=2010,
+            ),
+        ]
+    )
+    result = build_mexico_multiwave_history(transitions)
+    first = result.loc[result["origin_year"].eq(1995)].iloc[0]
+    second = result.loc[result["origin_year"].eq(2000)].iloc[0]
+    third = result.loc[result["origin_year"].eq(2005)].iloc[0]
+    assert not first["forecast_interval_eligible"]
+    assert second["forecast_interval_eligible"]
+    assert third["forecast_interval_eligible"]
+    assert second["previous_origin_year"] == 1995
+    assert third["previous_origin_year"] == 2000
+    assert not result["boundary_history_uses_future_reference"].any()
+
+
+def test_failed_prior_transition_blocks_next_forecast_origin() -> None:
+    transitions = pd.DataFrame(
+        [
+            row(methodology_comparable=False),
+            row(
+                origin_year=2000,
+                endpoint_year=2005,
+                origin_population=44_000,
+                endpoint_population=48_000,
+                origin_event_type="census",
+                endpoint_event_type="population_count",
+                evidence_reference_year=2005,
+            ),
+        ]
+    )
+    result = build_mexico_multiwave_history(transitions)
+    current = result.loc[result["origin_year"].eq(2000)].iloc[0]
+    assert not current["forecast_interval_eligible"]
+
+
+def test_coverage_keeps_unresolved_records_in_denominator() -> None:
+    frame = pd.DataFrame(
+        [
+            row(analysis_id="A", origin_population=40_000),
+            row(
+                analysis_id="B",
+                origin_population=60_000,
+                endpoint_population=65_000,
+                match_status="unresolved",
+                relationship_cardinality="one_to_many",
+                official_relationship_verified=False,
+                origin_overlap_ratio=0.5,
+                endpoint_overlap_ratio=0.5,
+                exclusion_reason="split_unresolved",
+            ),
+        ]
+    )
+    coverage = mexico_transition_coverage(frame)
+    assert coverage.loc[0, "origin_localities"] == 2
+    assert coverage.loc[0, "eligible_localities"] == 1
+    assert coverage.loc[0, "count_coverage"] == 0.5
+    assert coverage.loc[0, "population_coverage"] == 0.4


### PR DESCRIPTION
Implements the next headline-data prerequisite for Mexico without claiming an empirical result.

### Changes
- adds a transition-level Mexico locality concordance validator;
- accepts only stable, official one-to-one, or fully harmonized common geography;
- requires 99.5% endpoint polygon overlap for accepted geography;
- requires complete components, no double counting, and complete population aggregation for harmonized split/merge cases;
- separates geographic acceptance from explicit census/count methodology comparability;
- prohibits evidence or boundary references that post-date a transition endpoint;
- builds multiwave forecast rows only when both the immediately prior history transition and current outcome transition independently pass;
- retains unresolved rows in count- and population-weighted coverage denominators;
- documents use of INEGI 1990/1995/2000/2005/2010/2020 locality events and why 1995/2005 counts can create multiple rolling origins without treating them as censuses.

No Mexico empirical result or G2 pass is claimed. Exact raw files, equivalence records, vintage geometry, URLs, retrieval dates, hashes, and transition-specific methodology decisions are still required before the persistence runner may be executed.