### PR TITLE
Add Mexico acquisition preflight gate

### DIFF
--- a/data/mexico_acquisition_registry_template.csv
+++ b/data/mexico_acquisition_registry_template.csv
@@ -1,0 +1,15 @@
+role,event_year,event_type,publisher,dataset,retrieved_at,source_url,local_path,sha256,license_reviewed,completeness_verified,national_record_cap_avoided,status
+population,1990,census,INEGI,SCITEL/ITER locality population 1990,,,,,false,false,false,required_unresolved
+population,1995,population_count,INEGI,SCITEL/ITER locality population 1995,,,,,false,false,false,required_unresolved
+population,2000,census,INEGI,SCITEL/ITER locality population 2000,,,,,false,false,false,required_unresolved
+population,2005,population_count,INEGI,SCITEL/ITER locality population 2005,,,,,false,false,false,required_unresolved
+population,2010,census,INEGI,SCITEL/ITER locality population 2010,,,,,false,false,false,required_unresolved
+population,2020,census,INEGI,SCITEL/ITER locality population 2020,,,,,false,false,false,required_unresolved
+vintage_geometry,1990,census,INEGI,Marco Geoestadistico locality geometry 1990,,,,,false,false,false,required_unresolved
+vintage_geometry,1995,population_count,INEGI,Marco Geoestadistico locality geometry 1995,,,,,false,false,false,required_unresolved
+vintage_geometry,2000,census,INEGI,Marco Geoestadistico locality geometry 2000,,,,,false,false,false,required_unresolved
+vintage_geometry,2005,population_count,INEGI,Marco Geoestadistico locality geometry 2005,,,,,false,false,false,required_unresolved
+vintage_geometry,2010,census,INEGI,Marco Geoestadistico locality geometry 2010,,,,,false,false,false,required_unresolved
+vintage_geometry,2020,census,INEGI,Marco Geoestadistico locality geometry 2020,,,,,false,false,false,required_unresolved
+official_relationships,2020,census,INEGI,Official locality equivalence relationships,,,,,false,false,false,required_unresolved
+locality_history,2020,census,INEGI,Archivo Historico de Localidades export,,,,,false,false,false,required_unresolved

--- a/docs/mexico-acquisition-preflight.md
+++ b/docs/mexico-acquisition-preflight.md
@@ -1,0 +1,39 @@
+# Mexico acquisition preflight
+
+## Purpose
+
+The Mexico locality persistence path must not begin concordance from partially inventoried or truncated source extracts. This preflight separates **source discovery** from **source acquisition** and fails closed until every required wave and geography input is registered.
+
+## Required waves
+
+Population must be registered for 1990, 1995, 2000, 2005, 2010 and 2020. The 1995 and 2005 products are population counts, not censuses, and remain separately identified so transition-specific methodology comparability can be tested later.
+
+SCITEL exposes locality-level geographic identifiers and total population for the historical census/intercensal series. Its national query interface warns that a national result can return only 30,000 records. Therefore an extract is not considered complete merely because it was downloaded from the national option. Acquisition must use state-level files or another demonstrably exhaustive extraction method, and `national_record_cap_avoided` must be true for every acquired row.
+
+## Required supporting evidence
+
+The preflight also requires:
+
+- vintage locality geometry corresponding to every population wave;
+- official locality relationship/equivalence evidence;
+- locality-history evidence for rekeys, splits, mergers, annexations and municipal transfers.
+
+A current landing page is discovery evidence only. It is not an acquired source row.
+
+## Registration fields
+
+Every acquired input must record an exact source URL or reproducible service query, retrieval date, local path, SHA-256 checksum, license-review status, completeness verification and the record-cap check. The template is `data/mexico_acquisition_registry_template.csv`.
+
+`urban_growth.mexico_acquisition.require_mexico_acquisition_ready` raises an error until all six population waves, all six vintage-geometry waves and both support roles are registered as acquired.
+
+## Sequencing
+
+1. Acquire population extracts for all six events without triggering the 30,000-row national cap.
+2. Acquire or identify event-vintage locality geometry for all six events.
+3. Export official equivalence relationships and locality-history evidence.
+4. Hash files before normalization and complete the registry.
+5. Run the acquisition preflight.
+6. Only then construct transition-level concordances and measure count- and population-weighted coverage.
+7. Only transitions passing geography and methodology checks may enter the persistence forecast panel.
+
+No Mexico empirical result or G2 pass should be registered from the template itself.

--- a/src/urban_growth/mexico_acquisition.py
+++ b/src/urban_growth/mexico_acquisition.py
@@ -1,0 +1,93 @@
+"""Acquisition preflight for the Mexico multiwave locality panel."""
+
+from __future__ import annotations
+
+import re
+
+import pandas as pd
+
+from urban_growth.io import SourceSchemaError, require_columns
+
+REQUIRED_POPULATION_YEARS = (1990, 1995, 2000, 2005, 2010, 2020)
+REQUIRED_SUPPORT_ROLES = {
+    "official_relationships",
+    "locality_history",
+}
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+def validate_mexico_acquisition_registry(registry: pd.DataFrame) -> pd.DataFrame:
+    """Validate source registration before any Mexico concordance run.
+
+    Registration is intentionally stricter than source discovery. A landing page is not
+    an acquired input: each row must identify an exact local file/export, retrieval date,
+    exact source URL or reproducible service query, checksum, license review status, and
+    an explicit completeness assertion.
+    """
+    required = {
+        "role",
+        "event_year",
+        "event_type",
+        "publisher",
+        "dataset",
+        "retrieved_at",
+        "source_url",
+        "local_path",
+        "sha256",
+        "license_reviewed",
+        "completeness_verified",
+        "national_record_cap_avoided",
+        "status",
+    }
+    require_columns(registry, required, source_name="Mexico acquisition registry")
+    out = registry.copy()
+
+    duplicate_key = ["role", "event_year", "local_path"]
+    if out.duplicated(duplicate_key).any():
+        raise SourceSchemaError("Mexico acquisition registry has duplicate source rows")
+
+    complete = out["status"].eq("acquired")
+    for column in ("publisher", "dataset", "retrieved_at", "source_url", "local_path"):
+        if out.loc[complete, column].fillna("").astype(str).str.strip().eq("").any():
+            raise SourceSchemaError(f"Acquired Mexico rows require {column}")
+
+    hashes = out.loc[complete, "sha256"].fillna("").astype(str).str.lower()
+    if (~hashes.map(lambda value: bool(SHA256_PATTERN.fullmatch(value)))).any():
+        raise SourceSchemaError("Acquired Mexico rows require lowercase SHA-256 checksums")
+
+    for column in ("license_reviewed", "completeness_verified", "national_record_cap_avoided"):
+        if not pd.api.types.is_bool_dtype(out[column].dtype):
+            raise SourceSchemaError(f"{column} must be boolean")
+        if (~out.loc[complete, column]).any():
+            raise SourceSchemaError(f"Acquired Mexico rows must pass {column}")
+
+    population = out.loc[out["role"].eq("population")]
+    acquired_population_years = set(population.loc[population["status"].eq("acquired"), "event_year"])
+    missing_population_years = sorted(set(REQUIRED_POPULATION_YEARS) - acquired_population_years)
+
+    acquired_roles = set(out.loc[out["status"].eq("acquired"), "role"])
+    missing_support_roles = sorted(REQUIRED_SUPPORT_ROLES - acquired_roles)
+
+    geometry = out.loc[out["role"].eq("vintage_geometry") & out["status"].eq("acquired")]
+    acquired_geometry_years = set(geometry["event_year"])
+    missing_geometry_years = sorted(set(REQUIRED_POPULATION_YEARS) - acquired_geometry_years)
+
+    ready = not missing_population_years and not missing_support_roles and not missing_geometry_years
+    out.attrs["mexico_acquisition_ready"] = ready
+    out.attrs["missing_population_years"] = missing_population_years
+    out.attrs["missing_geometry_years"] = missing_geometry_years
+    out.attrs["missing_support_roles"] = missing_support_roles
+    return out
+
+
+def require_mexico_acquisition_ready(registry: pd.DataFrame) -> pd.DataFrame:
+    """Fail closed until all population and geography waves are actually registered."""
+    checked = validate_mexico_acquisition_registry(registry)
+    if not checked.attrs["mexico_acquisition_ready"]:
+        raise SourceSchemaError(
+            "Mexico acquisition is incomplete: "
+            f"population years={checked.attrs['missing_population_years']}; "
+            f"geometry years={checked.attrs['missing_geometry_years']}; "
+            f"support roles={checked.attrs['missing_support_roles']}"
+        )
+    return checked

--- a/tests/test_mexico_acquisition.py
+++ b/tests/test_mexico_acquisition.py
@@ -44,7 +44,7 @@ def test_missing_population_wave_fails_closed():
     registry = registry.loc[~((registry["role"] == "population") & (registry["event_year"] == 1995))]
     checked = validate_mexico_acquisition_registry(registry)
     assert checked.attrs["missing_population_years"] == [1995]
-    with pytest.raises(SourceSchemaError, match="population years=\[1995\]"):
+    with pytest.raises(SourceSchemaError, match=r"population years=\[1995\]"):
         require_mexico_acquisition_ready(registry)
 
 
@@ -67,5 +67,5 @@ def test_missing_vintage_geometry_blocks_readiness():
     registry = registry.loc[
         ~((registry["role"] == "vintage_geometry") & (registry["event_year"] == 2005))
     ]
-    with pytest.raises(SourceSchemaError, match="geometry years=\[2005\]"):
+    with pytest.raises(SourceSchemaError, match=r"geometry years=\[2005\]"):
         require_mexico_acquisition_ready(registry)

--- a/tests/test_mexico_acquisition.py
+++ b/tests/test_mexico_acquisition.py
@@ -1,0 +1,71 @@
+import pandas as pd
+import pytest
+
+from urban_growth.io import SourceSchemaError
+from urban_growth.mexico_acquisition import (
+    require_mexico_acquisition_ready,
+    validate_mexico_acquisition_registry,
+)
+
+
+def _row(role, year, *, status="acquired"):
+    return {
+        "role": role,
+        "event_year": year,
+        "event_type": "census" if year not in {1995, 2005} else "population_count",
+        "publisher": "INEGI",
+        "dataset": f"test {role} {year}",
+        "retrieved_at": "2026-08-31",
+        "source_url": "https://www.inegi.org.mx/example",
+        "local_path": f"data/raw/{role}_{year}.csv",
+        "sha256": "a" * 64,
+        "license_reviewed": True,
+        "completeness_verified": True,
+        "national_record_cap_avoided": True,
+        "status": status,
+    }
+
+
+def _complete_registry():
+    years = [1990, 1995, 2000, 2005, 2010, 2020]
+    rows = [_row("population", year) for year in years]
+    rows += [_row("vintage_geometry", year) for year in years]
+    rows += [_row("official_relationships", 2020), _row("locality_history", 2020)]
+    return pd.DataFrame(rows)
+
+
+def test_complete_registry_is_ready():
+    checked = require_mexico_acquisition_ready(_complete_registry())
+    assert checked.attrs["mexico_acquisition_ready"] is True
+
+
+def test_missing_population_wave_fails_closed():
+    registry = _complete_registry()
+    registry = registry.loc[~((registry["role"] == "population") & (registry["event_year"] == 1995))]
+    checked = validate_mexico_acquisition_registry(registry)
+    assert checked.attrs["missing_population_years"] == [1995]
+    with pytest.raises(SourceSchemaError, match="population years=\[1995\]"):
+        require_mexico_acquisition_ready(registry)
+
+
+def test_national_record_cap_must_be_avoided():
+    registry = _complete_registry()
+    registry.loc[registry.index[0], "national_record_cap_avoided"] = False
+    with pytest.raises(SourceSchemaError, match="national_record_cap_avoided"):
+        validate_mexico_acquisition_registry(registry)
+
+
+def test_landing_page_without_hash_is_not_acquired_input():
+    registry = _complete_registry()
+    registry.loc[registry.index[0], "sha256"] = ""
+    with pytest.raises(SourceSchemaError, match="SHA-256"):
+        validate_mexico_acquisition_registry(registry)
+
+
+def test_missing_vintage_geometry_blocks_readiness():
+    registry = _complete_registry()
+    registry = registry.loc[
+        ~((registry["role"] == "vintage_geometry") & (registry["event_year"] == 2005))
+    ]
+    with pytest.raises(SourceSchemaError, match="geometry years=\[2005\]"):
+        require_mexico_acquisition_ready(registry)


### PR DESCRIPTION
Turns the Mexico source bottleneck into a fail-closed acquisition contract.

### Changes
- adds a Mexico acquisition registry validator and readiness gate;
- requires population waves for 1990, 1995, 2000, 2005, 2010 and 2020;
- requires corresponding vintage locality geometry for all six events;
- requires official relationship/equivalence evidence and locality-history evidence;
- requires exact local file/export metadata, retrieval date, exact URL or reproducible service query, SHA-256, license review and completeness verification;
- makes avoidance of SCITEL's 30,000-record national query cap an explicit required boolean;
- adds a registry template whose unresolved rows cannot be mistaken for acquired evidence;
- adds tests for missing waves, missing geometry, missing hashes and record-cap failures;
- documents the acquisition sequence and why discovery pages do not satisfy the empirical source contract.

No Mexico empirical result or G2 pass is claimed. The next step after this PR is to populate the registry from actual INEGI files/exports and run the preflight before concordance.