### PR TITLE
Add point-in-time forecast availability gate

### DIFF
--- a/docs/forecast-data-availability.md
+++ b/docs/forecast-data-availability.md
@@ -1,0 +1,37 @@
+# Forecast data availability and publication-lag rule
+
+## Problem
+
+A reference year is not a data-availability date. A census, population count, geographic concordance, boundary relationship file, or revised historical series may be published after the date it describes. Treating the reference date as if the evidence were already observable creates look-ahead leakage and overstates real-time forecast performance.
+
+This issue is independent of geographic comparability, threshold truncation, survivorship, and model overfitting. A row can pass all of those checks and still be unavailable to an analyst at the claimed forecast origin.
+
+## Locked rule
+
+Any result described as **deployable at origin**, **real-time**, or a point-in-time forecast must record:
+
+- `predictor_available_date`: first date the population/statistical information needed for the predictor was available to the analyst;
+- `concordance_available_date`: first date the geography/crosswalk evidence needed to construct the comparable predictor was available;
+- a forecast-origin date precise enough to compare with those availability dates.
+
+Both evidence dates must be on or before the forecast origin. Missing availability dates fail closed. Reference year, enumeration date, period end, file vintage, and current download date are not substitutes for first availability.
+
+`src/urban_growth/forecast_availability.py` implements this rule and produces `point_in_time_available` plus explicit exclusion reasons.
+
+## Consequences
+
+Retrospective analyses may still use later-released evidence when clearly labeled retrospective. They must not be promoted to deployable-at-origin evidence.
+
+For rolling persistence tests, an outcome observed through an origin year is not automatically training information at that origin. If its required source release occurred after the origin, it cannot enter the real-time training set until a later origin.
+
+For Mexico, this means census/count reference dates and locality-equivalence evidence require actual release/availability dates before the multiwave panel can be called deployable. The existing year-only `evidence_reference_year <= endpoint_year` concordance check prevents future-reference geography but does not by itself establish point-in-time availability.
+
+For revised international products such as current-vintage WUP, WPP, or retrospective GHSL histories, the same distinction applies: current-vintage historical observations can support retrospective sensitivity analysis without constituting historical real-time information.
+
+## Result classification
+
+- `point_in_time_available = true`: required predictor and concordance evidence existed by the origin.
+- `point_in_time_available = false`: retrospective-only for that origin.
+- unknown evidence availability: fail closed; do not infer availability from the reference period.
+
+This gate is orthogonal to the City Data Fitness Standard and should be applied in addition to source-specific growth/headline eligibility before a forecast is described as deployable.

--- a/src/urban_growth/forecast_availability.py
+++ b/src/urban_growth/forecast_availability.py
@@ -1,0 +1,79 @@
+"""Point-in-time availability gate for rolling forecast panels."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
+
+
+def apply_forecast_availability_gate(
+    panel: pd.DataFrame,
+    *,
+    origin_column: str = "period_start",
+    predictor_available_column: str = "predictor_available_date",
+    concordance_available_column: str = "concordance_available_date",
+) -> pd.DataFrame:
+    """Mark whether predictor evidence was actually available at forecast origin.
+
+    Reference periods are not publication dates. A historical predictor may only be
+    called deployable at an origin when both its population/statistical payload and
+    any geography/concordance evidence needed to construct it were available no
+    later than that origin date.
+    """
+    require_columns(
+        panel,
+        {
+            "city_id",
+            "period_start",
+            "period_end",
+            origin_column,
+            predictor_available_column,
+            concordance_available_column,
+        },
+        source_name="forecast availability panel",
+    )
+    reject_duplicate_keys(
+        panel,
+        ["city_id", "period_start", "period_end"],
+        source_name="forecast availability panel",
+    )
+    out = panel.copy()
+    origin = pd.to_datetime(out[origin_column], errors="coerce")
+    predictor_available = pd.to_datetime(out[predictor_available_column], errors="coerce")
+    concordance_available = pd.to_datetime(out[concordance_available_column], errors="coerce")
+    if origin.isna().any():
+        raise SourceSchemaError(f"{origin_column} must contain valid forecast-origin dates")
+    if predictor_available.isna().any():
+        raise SourceSchemaError(f"{predictor_available_column} must be known for every forecast row")
+    if concordance_available.isna().any():
+        raise SourceSchemaError(f"{concordance_available_column} must be known for every forecast row")
+
+    out["predictor_available_at_origin"] = predictor_available.le(origin)
+    out["concordance_available_at_origin"] = concordance_available.le(origin)
+    out["point_in_time_available"] = (
+        out["predictor_available_at_origin"] & out["concordance_available_at_origin"]
+    )
+    out["availability_exclusion_reason"] = ""
+    out.loc[~out["predictor_available_at_origin"], "availability_exclusion_reason"] = (
+        "predictor_not_available_at_origin"
+    )
+    out.loc[
+        out["predictor_available_at_origin"] & ~out["concordance_available_at_origin"],
+        "availability_exclusion_reason",
+    ] = "concordance_not_available_at_origin"
+    out["forecast_deployable_at_origin"] = out["point_in_time_available"]
+    return out
+
+
+def point_in_time_forecast_sample(panel: pd.DataFrame) -> pd.DataFrame:
+    """Return only rows whose required predictor evidence existed at the origin."""
+    require_columns(
+        panel,
+        {"point_in_time_available"},
+        source_name="forecast availability panel",
+    )
+    eligible = panel["point_in_time_available"]
+    if not pd.api.types.is_bool_dtype(eligible.dtype):
+        raise SourceSchemaError("point_in_time_available must be boolean")
+    return panel.loc[eligible].copy().reset_index(drop=True)

--- a/tests/test_forecast_availability.py
+++ b/tests/test_forecast_availability.py
@@ -1,0 +1,48 @@
+import pandas as pd
+import pytest
+
+from urban_growth.forecast_availability import (
+    apply_forecast_availability_gate,
+    point_in_time_forecast_sample,
+)
+from urban_growth.io import SourceSchemaError
+
+
+def _panel() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "city_id": ["A", "B"],
+            "period_start": ["2000-01-01", "2000-01-01"],
+            "period_end": ["2005-01-01", "2005-01-01"],
+            "predictor_available_date": ["1999-12-01", "2000-06-01"],
+            "concordance_available_date": ["1999-11-01", "1999-11-01"],
+        }
+    )
+
+
+def test_availability_gate_blocks_post_origin_predictor() -> None:
+    result = apply_forecast_availability_gate(_panel())
+    assert bool(result.loc[0, "point_in_time_available"])
+    assert not bool(result.loc[1, "point_in_time_available"])
+    assert result.loc[1, "availability_exclusion_reason"] == "predictor_not_available_at_origin"
+
+
+def test_availability_gate_blocks_post_origin_concordance() -> None:
+    frame = _panel().iloc[[0]].copy()
+    frame["concordance_available_date"] = "2001-01-01"
+    result = apply_forecast_availability_gate(frame)
+    assert not bool(result.loc[0, "point_in_time_available"])
+    assert result.loc[0, "availability_exclusion_reason"] == "concordance_not_available_at_origin"
+
+
+def test_availability_gate_requires_known_dates() -> None:
+    frame = _panel().iloc[[0]].copy()
+    frame["predictor_available_date"] = None
+    with pytest.raises(SourceSchemaError, match="must be known"):
+        apply_forecast_availability_gate(frame)
+
+
+def test_point_in_time_sample_cannot_reintroduce_late_rows() -> None:
+    result = apply_forecast_availability_gate(_panel())
+    sample = point_in_time_forecast_sample(result)
+    assert sample["city_id"].tolist() == ["A"]


### PR DESCRIPTION
Addresses an independent look-ahead problem in the forecasting architecture: period/reference dates are not publication dates.

Adds a fail-closed availability gate requiring the predictor payload and any concordance evidence needed to construct it to have been available by the claimed forecast origin. Missing availability dates fail rather than being inferred from reference years.

This separates retrospective forecast sensitivity from genuinely deployable-at-origin evaluation and applies beyond Mexico to revised international historical products.

Includes tests for post-origin predictor release, post-origin concordance release, missing dates, and sample filtering.