### PR TITLE
Make missing selection exposure fail headline fitness gate

### DIFF
--- a/docs/city-data-fitness-standard.md
+++ b/docs/city-data-fitness-standard.md
@@ -53,8 +53,11 @@ Headline eligibility is intentionally strict. A record must be growth-eligible a
 - validation status `passed`;
 - a stable or accepted harmonized concordance;
 - no unresolved geographic change;
+- explicit truncation and survivorship exposure assessments;
 - no material or unknown survivorship/truncation exposure for threshold-sensitive analyses;
 - no known unresolved inconsistency.
+
+Missing `truncation_exposure` or `survivorship_exposure` is not interpreted as low risk. Missing evidence fails headline eligibility with `missing_truncation_exposure` or `missing_survivorship_exposure`. The row may remain eligible for non-headline growth analysis when the other requirements for that use are met.
 
 The exact analysis can impose additional requirements. The standard is a minimum gate, not permission to ignore estimator-specific assumptions.
 
@@ -72,7 +75,7 @@ A changing administrative boundary can still support growth analysis only when t
 
 ## Threshold-selection rules
 
-For analyses near a population threshold, `truncation_exposure` and `survivorship_exposure` must not be `material` or `unknown` for headline use. These fields do not mechanically remove observations from unrelated analyses; they are analysis-specific warnings and gates.
+For analyses near a population threshold, `truncation_exposure` and `survivorship_exposure` must be explicitly assessed and must not be `material` or `unknown` for headline use. Blank or missing values fail the headline gate rather than being treated as absence of exposure. These fields do not mechanically remove observations from unrelated analyses; they are analysis-specific warnings and gates.
 
 Sample construction should use earlier-period population wherever possible. Entry, exit, threshold crossing, and lower-tail coverage should be reported separately.
 

--- a/src/urban_growth/data_fitness.py
+++ b/src/urban_growth/data_fitness.py
@@ -135,10 +135,17 @@ def _evaluate_row(row: pd.Series) -> dict[str, object]:
         headline_reasons.append("concordance_not_accepted")
     if boundary_change_status in UNRESOLVED_BOUNDARY and not harmonized:
         headline_reasons.append("unresolved_boundary_change")
-    if truncation_exposure in BAD_EXPOSURE:
+
+    if not truncation_exposure:
+        headline_reasons.append("missing_truncation_exposure")
+    elif truncation_exposure in BAD_EXPOSURE:
         headline_reasons.append("truncation_exposure")
-    if survivorship_exposure in BAD_EXPOSURE:
+
+    if not survivorship_exposure:
+        headline_reasons.append("missing_survivorship_exposure")
+    elif survivorship_exposure in BAD_EXPOSURE:
         headline_reasons.append("survivorship_exposure")
+
     if _truthy(row.get("known_inconsistency")):
         headline_reasons.append("known_inconsistency")
 

--- a/tests/test_data_fitness.py
+++ b/tests/test_data_fitness.py
@@ -93,6 +93,25 @@ def test_threshold_selection_exposure_blocks_headline_only():
     assert "truncation_exposure" in result["headline_exclusion_reasons"]
 
 
+def test_missing_truncation_exposure_fails_headline_closed():
+    row = stable_row()
+    row.pop("truncation_exposure")
+    result = evaluate_city_data_fitness(pd.DataFrame([row])).iloc[0]
+
+    assert bool(result["growth_eligible"])
+    assert not bool(result["headline_eligible"])
+    assert "missing_truncation_exposure" in result["headline_exclusion_reasons"]
+
+
+def test_missing_survivorship_exposure_fails_headline_closed():
+    row = stable_row(survivorship_exposure=None)
+    result = evaluate_city_data_fitness(pd.DataFrame([row])).iloc[0]
+
+    assert bool(result["growth_eligible"])
+    assert not bool(result["headline_eligible"])
+    assert "missing_survivorship_exposure" in result["headline_exclusion_reasons"]
+
+
 def test_spatial_use_requires_validated_coordinates_and_network_geography():
     result = evaluate_city_data_fitness(
         pd.DataFrame(


### PR DESCRIPTION
Fixes a common-gate loophole: missing `truncation_exposure` or `survivorship_exposure` previously normalized to blank and did not trigger the headline exclusion logic.

Changes:
- missing truncation exposure now adds `missing_truncation_exposure`;
- missing survivorship exposure now adds `missing_survivorship_exposure`;
- non-headline growth eligibility remains unchanged when other growth requirements pass;
- adds regression tests for absent/None exposure evidence;
- updates the City Data Fitness Standard to state explicitly that missing exposure evidence is not interpreted as low risk.

This is intentionally fail-closed only for headline use, preserving the standard's analysis-specific design.