### PR TITLE
Require geographic comparability for growth fitness

### DIFF
--- a/docs/city-data-fitness-standard.md
+++ b/docs/city-data-fitness-standard.md
@@ -63,6 +63,8 @@ The exact analysis can impose additional requirements. The standard is a minimum
 
 ## Geographic rules
 
+Growth analysis requires `geographic_comparable=true` in addition to an accepted concordance state. An accepted status label cannot override an explicit determination that the compared observations are not geographically comparable.
+
 Accepted concordance states for stable growth analysis are:
 
 - `stable`;
@@ -71,7 +73,7 @@ Accepted concordance states for stable growth analysis are:
 
 `uncertain` and `unresolved` matches are excluded from headline analyses. They may be retained for robustness tests if explicitly requested.
 
-A changing administrative boundary can still support growth analysis only when the observations have been harmonized to a common geography and the concordance status records that fact. A simple name match is not sufficient.
+A changing administrative boundary can still support growth analysis only when the observations have been harmonized to a common geography, `geographic_comparable=true`, and the concordance status records that fact. A simple name match is not sufficient.
 
 ## Threshold-selection rules
 

--- a/src/urban_growth/data_fitness.py
+++ b/src/urban_growth/data_fitness.py
@@ -92,6 +92,7 @@ def _evaluate_row(row: pd.Series) -> dict[str, object]:
 
     if not geographic_comparable:
         level_reasons.append("geography_not_comparable")
+        growth_reasons.append("geography_not_comparable")
 
     if not temporal_comparable:
         growth_reasons.append("time_not_comparable")

--- a/tests/test_data_fitness.py
+++ b/tests/test_data_fitness.py
@@ -74,6 +74,18 @@ def test_harmonized_common_geography_can_restore_growth_eligibility():
     assert bool(result["headline_eligible"])
 
 
+def test_geographic_comparability_is_required_for_growth_and_headline():
+    result = evaluate_city_data_fitness(
+        pd.DataFrame([stable_row(geographic_comparable=False)])
+    ).iloc[0]
+
+    assert not bool(result["level_eligible"])
+    assert not bool(result["growth_eligible"])
+    assert not bool(result["headline_eligible"])
+    assert "geography_not_comparable" in result["growth_exclusion_reasons"]
+    assert "not_growth_eligible" in result["headline_exclusion_reasons"]
+
+
 def test_methodology_change_blocks_growth_without_rewriting_raw_value():
     frame = pd.DataFrame([stable_row(methodology_change=True, raw_value=49_999)])
     result = evaluate_city_data_fitness(frame).iloc[0]


### PR DESCRIPTION
Fixes an internal inconsistency in the common City Data Fitness gate: a row with `geographic_comparable=false` could still pass `growth_eligible` and therefore `headline_eligible` if its concordance status and boundary fields otherwise looked acceptable.

Changes:
- `geographic_comparable=false` now adds `geography_not_comparable` to growth exclusions as well as level exclusions;
- headline eligibility therefore fails through the existing `not_growth_eligible` path;
- adds a regression test for the contradictory state;
- documents that accepted concordance labels cannot override an explicit non-comparability determination.

This preserves the distinction between concordance status and the substantive comparability conclusion rather than allowing them to conflict silently.