### PR TITLE
Fail closed on unknown adverse fitness evidence

### DIFF
--- a/docs/city-data-fitness-standard.md
+++ b/docs/city-data-fitness-standard.md
@@ -46,6 +46,18 @@ Each record receives four independent flags:
 
 Each flag has a corresponding semicolon-delimited reason field. A `fitness_reasons` field contains the union of all reasons.
 
+## Negative-evidence rule
+
+Fields that assert the absence or presence of an adverse condition must distinguish **clear absence** from **unknown**. Missing, `unknown`, `uncertain`, `unresolved`, or `not_reviewed` values are not treated as `false`.
+
+In particular:
+
+- unknown `methodology_change` fails growth eligibility with `methodology_change_unknown`;
+- unknown `administrative_reclassification` fails growth eligibility unless the observations are already harmonized to a common geography;
+- unknown `known_inconsistency` fails level, growth, spatial, and headline eligibility.
+
+This prevents permissive boolean parsing from turning lack of evidence into evidence of absence.
+
 ## Headline gate
 
 Headline eligibility is intentionally strict. A record must be growth-eligible and must also have:
@@ -55,7 +67,7 @@ Headline eligibility is intentionally strict. A record must be growth-eligible a
 - no unresolved geographic change;
 - explicit truncation and survivorship exposure assessments;
 - no material or unknown survivorship/truncation exposure for threshold-sensitive analyses;
-- no known unresolved inconsistency.
+- no known or unresolved inconsistency.
 
 Missing `truncation_exposure` or `survivorship_exposure` is not interpreted as low risk. Missing evidence fails headline eligibility with `missing_truncation_exposure` or `missing_survivorship_exposure`. The row may remain eligible for non-headline growth analysis when the other requirements for that use are met.
 

--- a/src/urban_growth/data_fitness.py
+++ b/src/urban_growth/data_fitness.py
@@ -12,6 +12,7 @@ ACCEPTED_CONCORDANCE = {
 
 PASS_VALIDATION = {"passed"}
 BAD_EXPOSURE = {"material", "unknown"}
+UNKNOWN_EVIDENCE = {"unknown", "uncertain", "unresolved", "not_reviewed", "not reviewed"}
 UNRESOLVED_BOUNDARY = {
     "annexation",
     "merger",
@@ -45,6 +46,21 @@ def _truthy(value: object) -> bool:
     return _norm(value) in {"1", "true", "yes", "y", "passed", "valid"}
 
 
+def _negative_evidence_state(value: object) -> str:
+    """Return clear / present / unknown for evidence asserting an adverse condition.
+
+    These fields answer questions such as whether a methodology changed or a known
+    inconsistency exists. Missing or explicitly uncertain evidence must not be
+    interpreted as evidence that the adverse condition is absent.
+    """
+    normalized = _norm(value)
+    if not normalized or normalized in UNKNOWN_EVIDENCE:
+        return "unknown"
+    if _truthy(value):
+        return "present"
+    return "clear"
+
+
 def _join_reasons(reasons: Iterable[str]) -> str:
     return ";".join(sorted(set(reasons)))
 
@@ -63,6 +79,9 @@ def _evaluate_row(row: pd.Series) -> dict[str, object]:
     boundary_change_status = _norm(row.get("boundary_change_status"))
     truncation_exposure = _norm(row.get("truncation_exposure"))
     survivorship_exposure = _norm(row.get("survivorship_exposure"))
+    reclassification_state = _negative_evidence_state(row.get("administrative_reclassification"))
+    methodology_state = _negative_evidence_state(row.get("methodology_change"))
+    inconsistency_state = _negative_evidence_state(row.get("known_inconsistency"))
 
     if not source_id:
         level_reasons.append("missing_source_id")
@@ -107,16 +126,25 @@ def _evaluate_row(row: pd.Series) -> dict[str, object]:
     if boundary_change_status in UNRESOLVED_BOUNDARY and not harmonized:
         growth_reasons.append("unresolved_boundary_change")
 
-    if _truthy(row.get("administrative_reclassification")) and not harmonized:
-        growth_reasons.append("administrative_reclassification")
+    if not harmonized:
+        if reclassification_state == "present":
+            growth_reasons.append("administrative_reclassification")
+        elif reclassification_state == "unknown":
+            growth_reasons.append("administrative_reclassification_unknown")
 
-    if _truthy(row.get("methodology_change")):
+    if methodology_state == "present":
         growth_reasons.append("methodology_change")
+    elif methodology_state == "unknown":
+        growth_reasons.append("methodology_change_unknown")
 
-    if _truthy(row.get("known_inconsistency")):
+    if inconsistency_state == "present":
         level_reasons.append("known_inconsistency")
         growth_reasons.append("known_inconsistency")
         spatial_reasons.append("known_inconsistency")
+    elif inconsistency_state == "unknown":
+        level_reasons.append("known_inconsistency_unknown")
+        growth_reasons.append("known_inconsistency_unknown")
+        spatial_reasons.append("known_inconsistency_unknown")
 
     if not _truthy(row.get("coordinates_validated")):
         spatial_reasons.append("coordinates_not_validated")
@@ -147,8 +175,10 @@ def _evaluate_row(row: pd.Series) -> dict[str, object]:
     elif survivorship_exposure in BAD_EXPOSURE:
         headline_reasons.append("survivorship_exposure")
 
-    if _truthy(row.get("known_inconsistency")):
+    if inconsistency_state == "present":
         headline_reasons.append("known_inconsistency")
+    elif inconsistency_state == "unknown":
+        headline_reasons.append("known_inconsistency_unknown")
 
     headline_eligible = not headline_reasons
 

--- a/tests/test_data_fitness.py
+++ b/tests/test_data_fitness.py
@@ -95,6 +95,49 @@ def test_methodology_change_blocks_growth_without_rewriting_raw_value():
     assert "methodology_change" in result["growth_exclusion_reasons"]
 
 
+def test_unknown_methodology_change_fails_growth_closed():
+    result = evaluate_city_data_fitness(
+        pd.DataFrame([stable_row(methodology_change="unknown")])
+    ).iloc[0]
+
+    assert not bool(result["growth_eligible"])
+    assert not bool(result["headline_eligible"])
+    assert "methodology_change_unknown" in result["growth_exclusion_reasons"]
+
+
+def test_unknown_administrative_reclassification_fails_growth_unless_harmonized():
+    result = evaluate_city_data_fitness(
+        pd.DataFrame([stable_row(administrative_reclassification="uncertain")])
+    ).iloc[0]
+    harmonized = evaluate_city_data_fitness(
+        pd.DataFrame(
+            [
+                stable_row(
+                    administrative_reclassification="uncertain",
+                    concordance_status="harmonized_common_geography",
+                    boundary_temporally_fixed=False,
+                )
+            ]
+        )
+    ).iloc[0]
+
+    assert not bool(result["growth_eligible"])
+    assert "administrative_reclassification_unknown" in result["growth_exclusion_reasons"]
+    assert bool(harmonized["growth_eligible"])
+
+
+def test_unknown_inconsistency_fails_all_analytical_uses_closed():
+    result = evaluate_city_data_fitness(
+        pd.DataFrame([stable_row(known_inconsistency="not_reviewed")])
+    ).iloc[0]
+
+    assert not bool(result["level_eligible"])
+    assert not bool(result["growth_eligible"])
+    assert not bool(result["spatial_eligible"])
+    assert not bool(result["headline_eligible"])
+    assert "known_inconsistency_unknown" in result["fitness_reasons"]
+
+
 def test_threshold_selection_exposure_blocks_headline_only():
     result = evaluate_city_data_fitness(
         pd.DataFrame([stable_row(truncation_exposure="material")])


### PR DESCRIPTION
Fixes a fail-open behavior in the City Data Fitness Standard: adverse-condition fields were parsed with a truthy helper, so values like `unknown`, `uncertain`, `unresolved`, or `not_reviewed` could be interpreted the same as explicit `False`.

Changes:
- adds explicit tri-state handling for negative evidence;
- unknown methodology-change evidence now fails growth eligibility;
- unknown administrative-reclassification evidence fails growth unless the geography is already harmonized;
- unknown inconsistency evidence fails level, growth, spatial, and headline eligibility;
- preserves explicit `False` as clear absence of the adverse condition;
- adds regression tests and documentation.

This prevents lack of evidence from being treated as evidence of absence.