### PR TITLE
Require controlled vocabulary for adverse fitness evidence

### DIFF
--- a/docs/adverse-evidence-vocabulary.md
+++ b/docs/adverse-evidence-vocabulary.md
@@ -1,0 +1,9 @@
+# Adverse evidence controlled vocabulary
+
+Fields that assert a potentially disqualifying condition — currently `administrative_reclassification`, `methodology_change`, and `known_inconsistency` — are evaluated as tri-state evidence.
+
+Accepted evidence of presence is limited to explicit values such as boolean `true`, `1`, `true`, `yes`, `y`, `passed`, `valid`, or `present`. Accepted evidence of absence is limited to boolean `false`, `0`, `false`, `no`, `n`, `clear`, `none`, or `absent`.
+
+Blank, missing, explicitly uncertain values, and any unrecognized string are treated as `unknown`. They do not count as evidence that the adverse condition is absent. This rule is intentionally fail-closed because source adapters and manually curated registries can otherwise introduce silent eligibility errors through typos or novel labels.
+
+The City Data Fitness evaluator therefore distinguishes confirmed absence from unavailable or malformed evidence rather than coercing arbitrary strings to false.

--- a/src/urban_growth/data_fitness.py
+++ b/src/urban_growth/data_fitness.py
@@ -13,6 +13,8 @@ ACCEPTED_CONCORDANCE = {
 PASS_VALIDATION = {"passed"}
 BAD_EXPOSURE = {"material", "unknown"}
 UNKNOWN_EVIDENCE = {"unknown", "uncertain", "unresolved", "not_reviewed", "not reviewed"}
+PRESENT_EVIDENCE = {"1", "true", "yes", "y", "passed", "valid", "present"}
+CLEAR_EVIDENCE = {"0", "false", "no", "n", "clear", "none", "absent"}
 UNRESOLVED_BOUNDARY = {
     "annexation",
     "merger",
@@ -43,22 +45,25 @@ def _norm(value: object) -> str:
 def _truthy(value: object) -> bool:
     if isinstance(value, bool):
         return value
-    return _norm(value) in {"1", "true", "yes", "y", "passed", "valid"}
+    return _norm(value) in PRESENT_EVIDENCE
 
 
 def _negative_evidence_state(value: object) -> str:
     """Return clear / present / unknown for evidence asserting an adverse condition.
 
     These fields answer questions such as whether a methodology changed or a known
-    inconsistency exists. Missing or explicitly uncertain evidence must not be
+    inconsistency exists. Only explicit clear/present values are accepted. Missing,
+    uncertain, or unrecognized values remain unknown so lack of evidence cannot be
     interpreted as evidence that the adverse condition is absent.
     """
+    if isinstance(value, bool):
+        return "present" if value else "clear"
     normalized = _norm(value)
-    if not normalized or normalized in UNKNOWN_EVIDENCE:
-        return "unknown"
-    if _truthy(value):
+    if normalized in PRESENT_EVIDENCE:
         return "present"
-    return "clear"
+    if normalized in CLEAR_EVIDENCE:
+        return "clear"
+    return "unknown"
 
 
 def _join_reasons(reasons: Iterable[str]) -> str:

--- a/tests/test_data_fitness.py
+++ b/tests/test_data_fitness.py
@@ -105,6 +105,15 @@ def test_unknown_methodology_change_fails_growth_closed():
     assert "methodology_change_unknown" in result["growth_exclusion_reasons"]
 
 
+def test_unrecognized_methodology_value_fails_growth_closed():
+    result = evaluate_city_data_fitness(
+        pd.DataFrame([stable_row(methodology_change="partial")])
+    ).iloc[0]
+
+    assert not bool(result["growth_eligible"])
+    assert "methodology_change_unknown" in result["growth_exclusion_reasons"]
+
+
 def test_unknown_administrative_reclassification_fails_growth_unless_harmonized():
     result = evaluate_city_data_fitness(
         pd.DataFrame([stable_row(administrative_reclassification="uncertain")])
@@ -136,6 +145,36 @@ def test_unknown_inconsistency_fails_all_analytical_uses_closed():
     assert not bool(result["spatial_eligible"])
     assert not bool(result["headline_eligible"])
     assert "known_inconsistency_unknown" in result["fitness_reasons"]
+
+
+def test_unrecognized_inconsistency_value_fails_all_uses_closed():
+    result = evaluate_city_data_fitness(
+        pd.DataFrame([stable_row(known_inconsistency="maybe")])
+    ).iloc[0]
+
+    assert not bool(result["level_eligible"])
+    assert not bool(result["growth_eligible"])
+    assert not bool(result["spatial_eligible"])
+    assert not bool(result["headline_eligible"])
+    assert "known_inconsistency_unknown" in result["fitness_reasons"]
+
+
+def test_explicit_clear_adverse_evidence_remains_eligible():
+    result = evaluate_city_data_fitness(
+        pd.DataFrame(
+            [
+                stable_row(
+                    administrative_reclassification="no",
+                    methodology_change="none",
+                    known_inconsistency="absent",
+                )
+            ]
+        )
+    ).iloc[0]
+
+    assert bool(result["level_eligible"])
+    assert bool(result["growth_eligible"])
+    assert bool(result["headline_eligible"])
 
 
 def test_threshold_selection_exposure_blocks_headline_only():


### PR DESCRIPTION
Closes a remaining fail-open path in the City Data Fitness evaluator. After PR #98, explicitly unknown adverse evidence failed closed, but arbitrary unrecognized strings still fell through as clear evidence.

Changes:
- defines explicit present and clear vocabularies for adverse-condition fields;
- treats blank, uncertain, and any unrecognized value as unknown;
- preserves explicit booleans and common clear/present labels;
- adds regression tests for `partial`, `maybe`, and explicit clear labels;
- documents the controlled vocabulary rule.

This prevents typos or novel source labels from silently becoming evidence of absence.