### PR TITLE
Fail closed on unknown boundary change status

### DIFF
--- a/src/urban_growth/data_fitness.py
+++ b/src/urban_growth/data_fitness.py
@@ -15,6 +15,7 @@ BAD_EXPOSURE = {"material", "unknown"}
 UNKNOWN_EVIDENCE = {"unknown", "uncertain", "unresolved", "not_reviewed", "not reviewed"}
 PRESENT_EVIDENCE = {"1", "true", "yes", "y", "passed", "valid", "present"}
 CLEAR_EVIDENCE = {"0", "false", "no", "n", "clear", "none", "absent"}
+CLEAR_BOUNDARY_STATUS = {"none", "stable", "unchanged", "harmonized"}
 UNRESOLVED_BOUNDARY = {
     "annexation",
     "merger",
@@ -66,6 +67,16 @@ def _negative_evidence_state(value: object) -> str:
     return "unknown"
 
 
+def _boundary_status_state(value: object) -> str:
+    """Return clear / changed / unknown for boundary-change evidence."""
+    normalized = _norm(value)
+    if normalized in CLEAR_BOUNDARY_STATUS:
+        return "clear"
+    if normalized in UNRESOLVED_BOUNDARY:
+        return "changed"
+    return "unknown"
+
+
 def _join_reasons(reasons: Iterable[str]) -> str:
     return ";".join(sorted(set(reasons)))
 
@@ -82,6 +93,7 @@ def _evaluate_row(row: pd.Series) -> dict[str, object]:
     validation_status = _norm(row.get("validation_status"))
     concordance_status = _norm(row.get("concordance_status"))
     boundary_change_status = _norm(row.get("boundary_change_status"))
+    boundary_status_state = _boundary_status_state(boundary_change_status)
     truncation_exposure = _norm(row.get("truncation_exposure"))
     survivorship_exposure = _norm(row.get("survivorship_exposure"))
     reclassification_state = _negative_evidence_state(row.get("administrative_reclassification"))
@@ -128,8 +140,11 @@ def _evaluate_row(row: pd.Series) -> dict[str, object]:
     if not boundary_resolved:
         growth_reasons.append("boundary_not_stable_or_harmonized")
 
-    if boundary_change_status in UNRESOLVED_BOUNDARY and not harmonized:
-        growth_reasons.append("unresolved_boundary_change")
+    if not harmonized:
+        if boundary_status_state == "changed":
+            growth_reasons.append("unresolved_boundary_change")
+        elif boundary_status_state == "unknown":
+            growth_reasons.append("boundary_change_status_unknown")
 
     if not harmonized:
         if reclassification_state == "present":
@@ -167,8 +182,11 @@ def _evaluate_row(row: pd.Series) -> dict[str, object]:
         headline_reasons.append("validation_not_passed")
     if concordance_status not in ACCEPTED_CONCORDANCE:
         headline_reasons.append("concordance_not_accepted")
-    if boundary_change_status in UNRESOLVED_BOUNDARY and not harmonized:
-        headline_reasons.append("unresolved_boundary_change")
+    if not harmonized:
+        if boundary_status_state == "changed":
+            headline_reasons.append("unresolved_boundary_change")
+        elif boundary_status_state == "unknown":
+            headline_reasons.append("boundary_change_status_unknown")
 
     if not truncation_exposure:
         headline_reasons.append("missing_truncation_exposure")

--- a/src/urban_growth/data_fitness.py
+++ b/src/urban_growth/data_fitness.py
@@ -15,7 +15,14 @@ BAD_EXPOSURE = {"material", "unknown"}
 UNKNOWN_EVIDENCE = {"unknown", "uncertain", "unresolved", "not_reviewed", "not reviewed"}
 PRESENT_EVIDENCE = {"1", "true", "yes", "y", "passed", "valid", "present"}
 CLEAR_EVIDENCE = {"0", "false", "no", "n", "clear", "none", "absent"}
-CLEAR_BOUNDARY_STATUS = {"none", "stable", "unchanged", "harmonized"}
+CLEAR_BOUNDARY_STATUS = {
+    "none",
+    "stable",
+    "unchanged",
+    "harmonized",
+    "official_crosswalk",
+    "none_within_fixed_2025_footprint",
+}
 UNRESOLVED_BOUNDARY = {
     "annexation",
     "merger",

--- a/tests/test_data_fitness.py
+++ b/tests/test_data_fitness.py
@@ -74,6 +74,45 @@ def test_harmonized_common_geography_can_restore_growth_eligibility():
     assert bool(result["headline_eligible"])
 
 
+def test_unknown_boundary_status_fails_growth_and_headline_closed():
+    result = evaluate_city_data_fitness(
+        pd.DataFrame([stable_row(boundary_change_status="partial")])
+    ).iloc[0]
+
+    assert bool(result["level_eligible"])
+    assert not bool(result["growth_eligible"])
+    assert not bool(result["headline_eligible"])
+    assert "boundary_change_status_unknown" in result["growth_exclusion_reasons"]
+    assert "boundary_change_status_unknown" in result["headline_exclusion_reasons"]
+
+
+def test_missing_boundary_status_fails_growth_and_headline_closed():
+    result = evaluate_city_data_fitness(
+        pd.DataFrame([stable_row(boundary_change_status=None)])
+    ).iloc[0]
+
+    assert not bool(result["growth_eligible"])
+    assert not bool(result["headline_eligible"])
+    assert "boundary_change_status_unknown" in result["growth_exclusion_reasons"]
+
+
+def test_harmonized_geography_can_resolve_unknown_boundary_status():
+    result = evaluate_city_data_fitness(
+        pd.DataFrame(
+            [
+                stable_row(
+                    boundary_change_status="partial",
+                    boundary_temporally_fixed=False,
+                    concordance_status="harmonized_common_geography",
+                )
+            ]
+        )
+    ).iloc[0]
+
+    assert bool(result["growth_eligible"])
+    assert bool(result["headline_eligible"])
+
+
 def test_geographic_comparability_is_required_for_growth_and_headline():
     result = evaluate_city_data_fitness(
         pd.DataFrame([stable_row(geographic_comparable=False)])


### PR DESCRIPTION
Tightens boundary-change evidence handling in the City Data Fitness gate. Blank or unrecognized boundary status values now fail growth and headline eligibility unless geography is already harmonized. Explicitly recognizes resolved source-specific statuses such as official crosswalks and fixed-footprint histories, and adds regression tests for missing/unrecognized boundary states.