### PR TITLE
Require controlled vocabulary for exposure statuses

### DIFF
--- a/docs/exposure-status-vocabulary.md
+++ b/docs/exposure-status-vocabulary.md
@@ -1,0 +1,16 @@
+# Exposure status controlled vocabulary
+
+`truncation_exposure` and `survivorship_exposure` are headline-gating evidence, not free-form notes.
+
+Accepted values are limited to:
+
+- `none`
+- `low`
+- `material`
+- `unknown`
+
+`none` and `low` can satisfy the generic headline exposure gate. `material` and `unknown` block headline eligibility. Blank values remain separately identified as missing evidence.
+
+Any other value is treated as unrecognized/unknown evidence and fails headline eligibility with an explicit reason. This prevents typos, novel adapter labels, or source-specific phrases such as `moderate` or `not_applicable` from silently being interpreted as acceptable exposure.
+
+Source-specific adapters that need a different exposure concept should map it deliberately into the common vocabulary or keep it in a separate descriptive field rather than expanding the common gate implicitly.

--- a/src/urban_growth/data_fitness.py
+++ b/src/urban_growth/data_fitness.py
@@ -11,6 +11,7 @@ ACCEPTED_CONCORDANCE = {
 }
 
 PASS_VALIDATION = {"passed"}
+ACCEPTED_EXPOSURE = {"none", "low", "material", "unknown"}
 BAD_EXPOSURE = {"material", "unknown"}
 UNKNOWN_EVIDENCE = {"unknown", "uncertain", "unresolved", "not_reviewed", "not reviewed"}
 PRESENT_EVIDENCE = {"1", "true", "yes", "y", "passed", "valid", "present"}
@@ -197,11 +198,15 @@ def _evaluate_row(row: pd.Series) -> dict[str, object]:
 
     if not truncation_exposure:
         headline_reasons.append("missing_truncation_exposure")
+    elif truncation_exposure not in ACCEPTED_EXPOSURE:
+        headline_reasons.append("truncation_exposure_unknown")
     elif truncation_exposure in BAD_EXPOSURE:
         headline_reasons.append("truncation_exposure")
 
     if not survivorship_exposure:
         headline_reasons.append("missing_survivorship_exposure")
+    elif survivorship_exposure not in ACCEPTED_EXPOSURE:
+        headline_reasons.append("survivorship_exposure_unknown")
     elif survivorship_exposure in BAD_EXPOSURE:
         headline_reasons.append("survivorship_exposure")
 

--- a/tests/test_exposure_vocabulary.py
+++ b/tests/test_exposure_vocabulary.py
@@ -1,0 +1,60 @@
+import pandas as pd
+
+from urban_growth.data_fitness import evaluate_city_data_fitness
+
+
+def _row(**overrides):
+    row = {
+        "city_id": "example:1",
+        "source_id": "source-a",
+        "population_concept": "locality",
+        "geographic_unit": "locality",
+        "validation_status": "passed",
+        "concordance_status": "stable",
+        "boundary_change_status": "none",
+        "boundary_temporally_fixed": True,
+        "geographic_comparable": True,
+        "temporal_comparable": True,
+        "administrative_reclassification": False,
+        "methodology_change": False,
+        "known_inconsistency": False,
+        "truncation_exposure": "none",
+        "survivorship_exposure": "none",
+        "coordinates_validated": True,
+        "network_geography_validated": True,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_unrecognized_truncation_exposure_fails_headline_closed():
+    result = evaluate_city_data_fitness(
+        pd.DataFrame([_row(truncation_exposure="moderate")])
+    ).iloc[0]
+
+    assert bool(result["growth_eligible"])
+    assert not bool(result["headline_eligible"])
+    assert "truncation_exposure_unknown" in result["headline_exclusion_reasons"]
+
+
+def test_unrecognized_survivorship_exposure_fails_headline_closed():
+    result = evaluate_city_data_fitness(
+        pd.DataFrame([_row(survivorship_exposure="not_applicable")])
+    ).iloc[0]
+
+    assert bool(result["growth_eligible"])
+    assert not bool(result["headline_eligible"])
+    assert "survivorship_exposure_unknown" in result["headline_exclusion_reasons"]
+
+
+def test_registered_exposure_vocabulary_retains_expected_semantics():
+    low = evaluate_city_data_fitness(
+        pd.DataFrame([_row(truncation_exposure="low", survivorship_exposure="low")])
+    ).iloc[0]
+    unknown = evaluate_city_data_fitness(
+        pd.DataFrame([_row(truncation_exposure="unknown")])
+    ).iloc[0]
+
+    assert bool(low["headline_eligible"])
+    assert not bool(unknown["headline_eligible"])
+    assert "truncation_exposure" in unknown["headline_exclusion_reasons"]


### PR DESCRIPTION
Closes a remaining fail-open path in headline fitness gating. `truncation_exposure` and `survivorship_exposure` previously blocked only `material`, `unknown`, or blank values, allowing arbitrary strings to pass.

Changes:
- defines the common exposure vocabulary as `none`, `low`, `material`, `unknown`;
- treats any unrecognized exposure label as unknown evidence for headline use;
- preserves non-headline growth eligibility where exposure is not otherwise required;
- adds regression tests and documentation.

This prevents typos and source-specific free text from silently becoming acceptable threshold/survivorship evidence.