### PR TITLE
Require explicit forecast origin dates

### DIFF
--- a/docs/forecast-data-availability.md
+++ b/docs/forecast-data-availability.md
@@ -6,17 +6,19 @@ A reference year is not a data-availability date. A census, population count, ge
 
 This issue is independent of geographic comparability, threshold truncation, survivorship, and model overfitting. A row can pass all of those checks and still be unavailable to an analyst at the claimed forecast origin.
 
+The repository's core rolling-forecast panels use integer years in `period_start` and `period_end`. Those fields are reference-period identifiers, not timestamps. In particular, passing an integer year such as `2000` to generic datetime coercion does not mean January 1, 2000 and must never be used to establish historical availability.
+
 ## Locked rule
 
 Any result described as **deployable at origin**, **real-time**, or a point-in-time forecast must record:
 
+- `forecast_origin_date`: the actual as-of date at which the forecast is claimed to have been formed;
 - `predictor_available_date`: first date the population/statistical information needed for the predictor was available to the analyst;
-- `concordance_available_date`: first date the geography/crosswalk evidence needed to construct the comparable predictor was available;
-- a forecast-origin date precise enough to compare with those availability dates.
+- `concordance_available_date`: first date the geography/crosswalk evidence needed to construct the comparable predictor was available.
 
-Both evidence dates must be on or before the forecast origin. Missing availability dates fail closed. Reference year, enumeration date, period end, file vintage, and current download date are not substitutes for first availability.
+Both evidence dates must be on or before `forecast_origin_date`. Missing origin or availability dates fail closed. Reference year, enumeration date, `period_start`, period end, file vintage, and current download date are not substitutes for first availability.
 
-`src/urban_growth/forecast_availability.py` implements this rule and produces `point_in_time_available` plus explicit exclusion reasons.
+`src/urban_growth/forecast_availability.py` implements this rule and produces `point_in_time_available` plus explicit exclusion reasons. The default origin field is `forecast_origin_date`; callers may override the column name only when they supply another explicit date field with the same semantics.
 
 ## Consequences
 
@@ -30,8 +32,8 @@ For revised international products such as current-vintage WUP, WPP, or retrospe
 
 ## Result classification
 
-- `point_in_time_available = true`: required predictor and concordance evidence existed by the origin.
+- `point_in_time_available = true`: required predictor and concordance evidence existed by the explicit forecast-origin date.
 - `point_in_time_available = false`: retrospective-only for that origin.
-- unknown evidence availability: fail closed; do not infer availability from the reference period.
+- unknown evidence availability or missing forecast-origin date: fail closed; do not infer availability from the reference period.
 
 This gate is orthogonal to the City Data Fitness Standard and should be applied in addition to source-specific growth/headline eligibility before a forecast is described as deployable.

--- a/src/urban_growth/forecast_availability.py
+++ b/src/urban_growth/forecast_availability.py
@@ -10,16 +10,17 @@ from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_co
 def apply_forecast_availability_gate(
     panel: pd.DataFrame,
     *,
-    origin_column: str = "period_start",
+    origin_column: str = "forecast_origin_date",
     predictor_available_column: str = "predictor_available_date",
     concordance_available_column: str = "concordance_available_date",
 ) -> pd.DataFrame:
     """Mark whether predictor evidence was actually available at forecast origin.
 
-    Reference periods are not publication dates. A historical predictor may only be
-    called deployable at an origin when both its population/statistical payload and
-    any geography/concordance evidence needed to construct it were available no
-    later than that origin date.
+    Reference periods are not publication dates, and integer origin years are not
+    timestamps. A historical predictor may only be called deployable at an origin
+    when an explicit forecast-origin date is supplied and both its statistical
+    payload and any geography/concordance evidence needed to construct it were
+    available no later than that date.
     """
     require_columns(
         panel,

--- a/tests/test_forecast_availability.py
+++ b/tests/test_forecast_availability.py
@@ -12,8 +12,9 @@ def _panel() -> pd.DataFrame:
     return pd.DataFrame(
         {
             "city_id": ["A", "B"],
-            "period_start": ["2000-01-01", "2000-01-01"],
-            "period_end": ["2005-01-01", "2005-01-01"],
+            "period_start": [2000, 2000],
+            "period_end": [2005, 2005],
+            "forecast_origin_date": ["2000-01-01", "2000-01-01"],
             "predictor_available_date": ["1999-12-01", "2000-06-01"],
             "concordance_available_date": ["1999-11-01", "1999-11-01"],
         }
@@ -40,6 +41,18 @@ def test_availability_gate_requires_known_dates() -> None:
     frame["predictor_available_date"] = None
     with pytest.raises(SourceSchemaError, match="must be known"):
         apply_forecast_availability_gate(frame)
+
+
+def test_integer_period_start_is_not_used_as_timestamp() -> None:
+    frame = _panel().iloc[[0]].drop(columns=["forecast_origin_date"])
+    with pytest.raises(SourceSchemaError, match="forecast_origin_date"):
+        apply_forecast_availability_gate(frame)
+
+
+def test_explicit_origin_column_can_be_overridden() -> None:
+    frame = _panel().iloc[[0]].rename(columns={"forecast_origin_date": "as_of_date"})
+    result = apply_forecast_availability_gate(frame, origin_column="as_of_date")
+    assert bool(result.loc[0, "point_in_time_available"])
 
 
 def test_point_in_time_sample_cannot_reintroduce_late_rows() -> None:


### PR DESCRIPTION
Fixes a point-in-time availability bug caused by treating integer reference years as datetimes.

Changes:
- makes `forecast_origin_date` the default deployability origin field;
- keeps `period_start`/`period_end` as integer reference-year identifiers;
- fails closed when no explicit forecast-origin date is supplied;
- preserves an override for an equivalent explicit as-of date column;
- adds regression coverage for integer-year panels and updates the availability contract.

This prevents `pd.to_datetime(2000)`-style coercion from corrupting historical availability checks.