### PR TITLE
Enforce point-in-time availability in deployable persistence tests

### DIFF
--- a/docs/point-in-time-persistence-gate.md
+++ b/docs/point-in-time-persistence-gate.md
@@ -1,0 +1,12 @@
+# Point-in-time persistence evaluation gate
+
+A persistence benchmark can be out-of-sample in reference-year terms while still using predictor or concordance evidence that was not actually available at the forecast origin. The existing fitness-gated persistence evaluator is therefore classified as a retrospective benchmark unless a separate point-in-time availability gate is enforced.
+
+Deployable persistence evaluation requires both:
+
+- the source-specific City Data Fitness eligibility flag (normally `growth_eligible`); and
+- `point_in_time_available = true`, produced by the forecast availability gate using an explicit forecast-origin date.
+
+`evaluate_point_in_time_persistence_baselines` and `point_in_time_persistence_errors` enforce both conditions before constructing rolling-origin train/test samples. Missing or non-boolean point-in-time evidence fails closed.
+
+The original `evaluate_fitness_gated_persistence_baselines` remains available for retrospective sensitivity analysis and must not by itself be described as real-time or deployable-at-origin performance.

--- a/src/urban_growth/forecast_fitness.py
+++ b/src/urban_growth/forecast_fitness.py
@@ -57,6 +57,26 @@ def fitness_gated_forecast_panel(
     return result.reset_index(drop=True)
 
 
+def point_in_time_fitness_gated_forecast_panel(
+    panel: pd.DataFrame,
+    *,
+    eligibility_column: str = "growth_eligible",
+    availability_column: str = "point_in_time_available",
+) -> pd.DataFrame:
+    """Return rows that pass both data-fitness and point-in-time availability gates."""
+    require_columns(panel, {availability_column}, source_name="point-in-time forecast panel")
+    availability = panel[availability_column]
+    if not pd.api.types.is_bool_dtype(availability.dtype):
+        raise SourceSchemaError(f"{availability_column} must be boolean")
+    gated = fitness_gated_forecast_panel(panel, eligibility_column=eligibility_column)
+    result = gated.loc[gated[availability_column]].copy()
+    if result.empty:
+        raise SourceSchemaError("No forecast rows pass both fitness and point-in-time gates")
+    result["forecast_availability_gate"] = availability_column
+    result["forecast_availability_gate_passed"] = True
+    return result.reset_index(drop=True)
+
+
 def _validate_multi_origin_oos(panel: pd.DataFrame, origins: list[int]) -> list[int]:
     if not origins or len(set(origins)) != len(origins):
         raise SourceSchemaError("Forecast origins must be unique and non-empty")
@@ -79,15 +99,14 @@ def _validate_multi_origin_oos(panel: pd.DataFrame, origins: list[int]) -> list[
     return usable
 
 
-def evaluate_fitness_gated_persistence_baselines(
-    panel: pd.DataFrame,
+def _evaluate_persistence_baselines(
+    gated: pd.DataFrame,
     origins: list[int],
     *,
-    eligibility_column: str = "growth_eligible",
-    outcome_column: str = "future_growth",
+    eligibility_column: str,
+    outcome_column: str,
+    benchmark_stage: str,
 ) -> pd.DataFrame:
-    """Evaluate the locked simple-baseline ladder on eligible rows only."""
-    gated = fitness_gated_forecast_panel(panel, eligibility_column=eligibility_column)
     usable_origins = _validate_multi_origin_oos(gated, origins)
     result = evaluate_rolling_baselines(gated, usable_origins, outcome_column=outcome_column)
     result = result.loc[result["model"].isin(PERSISTENCE_BASELINE_MODELS)].copy()
@@ -97,8 +116,52 @@ def evaluate_fitness_gated_persistence_baselines(
         raise SourceSchemaError("Zero-growth baseline was not produced")
     result["fitness_gate"] = eligibility_column
     result["fitness_gate_enforced"] = True
-    result["benchmark_stage"] = "persistence_only"
+    result["benchmark_stage"] = benchmark_stage
     return result.sort_values(["origin", "model"]).reset_index(drop=True)
+
+
+def evaluate_fitness_gated_persistence_baselines(
+    panel: pd.DataFrame,
+    origins: list[int],
+    *,
+    eligibility_column: str = "growth_eligible",
+    outcome_column: str = "future_growth",
+) -> pd.DataFrame:
+    """Evaluate retrospective persistence baselines on fitness-eligible rows only."""
+    gated = fitness_gated_forecast_panel(panel, eligibility_column=eligibility_column)
+    return _evaluate_persistence_baselines(
+        gated,
+        origins,
+        eligibility_column=eligibility_column,
+        outcome_column=outcome_column,
+        benchmark_stage="retrospective_persistence_only",
+    )
+
+
+def evaluate_point_in_time_persistence_baselines(
+    panel: pd.DataFrame,
+    origins: list[int],
+    *,
+    eligibility_column: str = "growth_eligible",
+    availability_column: str = "point_in_time_available",
+    outcome_column: str = "future_growth",
+) -> pd.DataFrame:
+    """Evaluate deployable persistence baselines after both required gates."""
+    gated = point_in_time_fitness_gated_forecast_panel(
+        panel,
+        eligibility_column=eligibility_column,
+        availability_column=availability_column,
+    )
+    result = _evaluate_persistence_baselines(
+        gated,
+        origins,
+        eligibility_column=eligibility_column,
+        outcome_column=outcome_column,
+        benchmark_stage="point_in_time_persistence_only",
+    )
+    result["availability_gate"] = availability_column
+    result["availability_gate_enforced"] = True
+    return result
 
 
 def fitness_gated_persistence_errors(
@@ -108,7 +171,7 @@ def fitness_gated_persistence_errors(
     eligibility_column: str = "growth_eligible",
     outcome_column: str = "future_growth",
 ) -> pd.DataFrame:
-    """Return row-level errors for the same locked fitness-gated baseline ladder."""
+    """Return retrospective row-level errors for the fitness-gated baseline ladder."""
     gated = fitness_gated_forecast_panel(panel, eligibility_column=eligibility_column)
     usable_origins = _validate_multi_origin_oos(gated, origins)
     result = rolling_baseline_errors(gated, usable_origins, outcome_column=outcome_column)
@@ -117,5 +180,32 @@ def fitness_gated_persistence_errors(
         raise SourceSchemaError("No persistence-stage row-level errors were produced")
     result["fitness_gate"] = eligibility_column
     result["fitness_gate_enforced"] = True
-    result["benchmark_stage"] = "persistence_only"
+    result["benchmark_stage"] = "retrospective_persistence_only"
+    return result.reset_index(drop=True)
+
+
+def point_in_time_persistence_errors(
+    panel: pd.DataFrame,
+    origins: list[int],
+    *,
+    eligibility_column: str = "growth_eligible",
+    availability_column: str = "point_in_time_available",
+    outcome_column: str = "future_growth",
+) -> pd.DataFrame:
+    """Return row-level errors after both fitness and point-in-time gates."""
+    gated = point_in_time_fitness_gated_forecast_panel(
+        panel,
+        eligibility_column=eligibility_column,
+        availability_column=availability_column,
+    )
+    usable_origins = _validate_multi_origin_oos(gated, origins)
+    result = rolling_baseline_errors(gated, usable_origins, outcome_column=outcome_column)
+    result = result.loc[result["model"].isin(PERSISTENCE_BASELINE_MODELS)].copy()
+    if result.empty:
+        raise SourceSchemaError("No point-in-time persistence row-level errors were produced")
+    result["fitness_gate"] = eligibility_column
+    result["fitness_gate_enforced"] = True
+    result["availability_gate"] = availability_column
+    result["availability_gate_enforced"] = True
+    result["benchmark_stage"] = "point_in_time_persistence_only"
     return result.reset_index(drop=True)

--- a/tests/test_forecast_fitness.py
+++ b/tests/test_forecast_fitness.py
@@ -3,8 +3,11 @@ import pytest
 
 from urban_growth.forecast_fitness import (
     evaluate_fitness_gated_persistence_baselines,
+    evaluate_point_in_time_persistence_baselines,
     fitness_gated_forecast_panel,
     fitness_gated_persistence_errors,
+    point_in_time_fitness_gated_forecast_panel,
+    point_in_time_persistence_errors,
 )
 from urban_growth.io import SourceSchemaError
 
@@ -28,6 +31,7 @@ def forecast_panel() -> pd.DataFrame:
                     "recent_growth": recent,
                     "future_growth": future,
                     "growth_eligible": True,
+                    "point_in_time_available": True,
                 }
             )
     frame = pd.DataFrame(rows)
@@ -50,6 +54,24 @@ def test_fitness_gate_excludes_ineligible_rows() -> None:
     assert result["forecast_fitness_gate_passed"].all()
 
 
+def test_point_in_time_gate_requires_explicit_boolean_availability() -> None:
+    panel = forecast_panel().drop(columns="point_in_time_available")
+    with pytest.raises(SourceSchemaError, match="point_in_time_available"):
+        point_in_time_fitness_gated_forecast_panel(panel)
+
+
+def test_point_in_time_gate_excludes_late_rows_after_fitness_gate() -> None:
+    panel = forecast_panel()
+    panel.loc[
+        (panel["city_id"] == "C") & (panel["period_start"] == 2010),
+        "point_in_time_available",
+    ] = False
+    result = point_in_time_fitness_gated_forecast_panel(panel)
+    assert not ((result["city_id"] == "B") & (result["period_start"] == 2010)).any()
+    assert not ((result["city_id"] == "C") & (result["period_start"] == 2010)).any()
+    assert result["forecast_availability_gate_passed"].all()
+
+
 def test_persistence_oos_requires_multiple_usable_origins() -> None:
     with pytest.raises(SourceSchemaError, match="at least two rolling origins"):
         evaluate_fitness_gated_persistence_baselines(forecast_panel(), [2005])
@@ -59,10 +81,24 @@ def test_persistence_oos_scores_only_fitness_eligible_test_rows() -> None:
     result = evaluate_fitness_gated_persistence_baselines(forecast_panel(), [2005, 2010])
     assert {"zero_growth", "persistence"}.issubset(set(result["model"]))
     assert result["fitness_gate_enforced"].all()
-    assert result["benchmark_stage"].eq("persistence_only").all()
+    assert result["benchmark_stage"].eq("retrospective_persistence_only").all()
     counts = result.pivot(index="origin", columns="model", values="n")
     assert counts.loc[2005, "persistence"] == 3
     assert counts.loc[2010, "persistence"] == 2
+
+
+def test_point_in_time_persistence_cannot_score_late_test_rows() -> None:
+    panel = forecast_panel()
+    panel.loc[
+        (panel["city_id"] == "C") & (panel["period_start"] == 2010),
+        "point_in_time_available",
+    ] = False
+    result = evaluate_point_in_time_persistence_baselines(panel, [2005, 2010])
+    counts = result.pivot(index="origin", columns="model", values="n")
+    assert counts.loc[2010, "persistence"] == 1
+    assert result["fitness_gate_enforced"].all()
+    assert result["availability_gate_enforced"].all()
+    assert result["benchmark_stage"].eq("point_in_time_persistence_only").all()
 
 
 def test_row_level_errors_cannot_reintroduce_ineligible_rows() -> None:
@@ -70,3 +106,15 @@ def test_row_level_errors_cannot_reintroduce_ineligible_rows() -> None:
     excluded = errors.loc[(errors["city_id"] == "B") & (errors["origin"] == 2010)]
     assert excluded.empty
     assert errors["fitness_gate_enforced"].all()
+
+
+def test_point_in_time_errors_cannot_reintroduce_late_rows() -> None:
+    panel = forecast_panel()
+    panel.loc[
+        (panel["city_id"] == "C") & (panel["period_start"] == 2010),
+        "point_in_time_available",
+    ] = False
+    errors = point_in_time_persistence_errors(panel, [2005, 2010])
+    excluded = errors.loc[(errors["city_id"] == "C") & (errors["origin"] == 2010)]
+    assert excluded.empty
+    assert errors["availability_gate_enforced"].all()


### PR DESCRIPTION
Adds a structurally separate deployable persistence path that requires both source-specific fitness eligibility and `point_in_time_available` before rolling-origin training/test construction. The existing fitness-only evaluator is retained and explicitly classified as retrospective. Adds row-level and aggregate regression tests plus a contract note.