### PR TITLE
Enforce forecast horizon comparability

### DIFF
--- a/docs/forecast-horizon-comparability.md
+++ b/docs/forecast-horizon-comparability.md
@@ -1,0 +1,11 @@
+# Forecast horizon comparability
+
+Annualizing population growth does not make forecast errors from different horizons directly comparable. A five-year forecast and a ten-year forecast have different information sets, shock exposure, and error variance even when both targets are expressed as annualized log growth.
+
+## Locked rule
+
+Persistence benchmark evaluation must use one forecast horizon at a time. Every eligible row must carry a positive `forecast_horizon_years` value, either supplied explicitly by the source-specific builder or deterministically derived from `period_end - period_start` when the forecast interval itself defines the target horizon.
+
+If more than one horizon is present after fitness and point-in-time gates are applied, the common persistence evaluator fails closed. Callers must stratify the panel to a single horizon before computing aggregate metrics or row-level errors.
+
+For Mexico locality histories, `build_mexico_multiwave_history` records `forecast_horizon_years = endpoint_year - origin_year`. This is necessary because the planned event sequence contains both five-year and ten-year transitions. Those intervals may be analyzed separately, but they must not be pooled into one persistence-performance estimate merely because `future_growth` is annualized.

--- a/src/urban_growth/forecast_fitness.py
+++ b/src/urban_growth/forecast_fitness.py
@@ -17,6 +17,21 @@ PERSISTENCE_BASELINE_MODELS = {
 }
 
 
+def _attach_forecast_horizon(panel: pd.DataFrame) -> pd.DataFrame:
+    """Attach a positive forecast horizon, preserving an explicit source value when present."""
+    out = panel.copy()
+    if "forecast_horizon_years" in out.columns:
+        horizon = pd.to_numeric(out["forecast_horizon_years"], errors="coerce")
+    else:
+        horizon = pd.to_numeric(out["period_end"], errors="coerce") - pd.to_numeric(
+            out["period_start"], errors="coerce"
+        )
+    if horizon.isna().any() or horizon.le(0).any():
+        raise SourceSchemaError("forecast_horizon_years must be positive and known for every row")
+    out["forecast_horizon_years"] = horizon.astype(float)
+    return out
+
+
 def fitness_gated_forecast_panel(
     panel: pd.DataFrame,
     *,
@@ -49,7 +64,7 @@ def fitness_gated_forecast_panel(
     eligibility = panel[eligibility_column]
     if not pd.api.types.is_bool_dtype(eligibility.dtype):
         raise SourceSchemaError(f"{eligibility_column} must be boolean")
-    result = panel.loc[eligibility].copy()
+    result = _attach_forecast_horizon(panel.loc[eligibility].copy())
     if result.empty:
         raise SourceSchemaError("No forecast rows pass the declared data-fitness gate")
     result["forecast_fitness_gate"] = eligibility_column
@@ -75,6 +90,16 @@ def point_in_time_fitness_gated_forecast_panel(
     result["forecast_availability_gate"] = availability_column
     result["forecast_availability_gate_passed"] = True
     return result.reset_index(drop=True)
+
+
+def _validate_single_horizon(panel: pd.DataFrame) -> float:
+    horizons = sorted(pd.unique(panel["forecast_horizon_years"]))
+    if len(horizons) != 1:
+        raise SourceSchemaError(
+            "Persistence benchmark cannot pool mixed forecast horizons; stratify to one "
+            f"forecast_horizon_years value before evaluation: {horizons}"
+        )
+    return float(horizons[0])
 
 
 def _validate_multi_origin_oos(panel: pd.DataFrame, origins: list[int]) -> list[int]:
@@ -107,6 +132,7 @@ def _evaluate_persistence_baselines(
     outcome_column: str,
     benchmark_stage: str,
 ) -> pd.DataFrame:
+    horizon = _validate_single_horizon(gated)
     usable_origins = _validate_multi_origin_oos(gated, origins)
     result = evaluate_rolling_baselines(gated, usable_origins, outcome_column=outcome_column)
     result = result.loc[result["model"].isin(PERSISTENCE_BASELINE_MODELS)].copy()
@@ -117,6 +143,7 @@ def _evaluate_persistence_baselines(
     result["fitness_gate"] = eligibility_column
     result["fitness_gate_enforced"] = True
     result["benchmark_stage"] = benchmark_stage
+    result["forecast_horizon_years"] = horizon
     return result.sort_values(["origin", "model"]).reset_index(drop=True)
 
 
@@ -173,6 +200,7 @@ def fitness_gated_persistence_errors(
 ) -> pd.DataFrame:
     """Return retrospective row-level errors for the fitness-gated baseline ladder."""
     gated = fitness_gated_forecast_panel(panel, eligibility_column=eligibility_column)
+    horizon = _validate_single_horizon(gated)
     usable_origins = _validate_multi_origin_oos(gated, origins)
     result = rolling_baseline_errors(gated, usable_origins, outcome_column=outcome_column)
     result = result.loc[result["model"].isin(PERSISTENCE_BASELINE_MODELS)].copy()
@@ -181,6 +209,7 @@ def fitness_gated_persistence_errors(
     result["fitness_gate"] = eligibility_column
     result["fitness_gate_enforced"] = True
     result["benchmark_stage"] = "retrospective_persistence_only"
+    result["forecast_horizon_years"] = horizon
     return result.reset_index(drop=True)
 
 
@@ -198,6 +227,7 @@ def point_in_time_persistence_errors(
         eligibility_column=eligibility_column,
         availability_column=availability_column,
     )
+    horizon = _validate_single_horizon(gated)
     usable_origins = _validate_multi_origin_oos(gated, origins)
     result = rolling_baseline_errors(gated, usable_origins, outcome_column=outcome_column)
     result = result.loc[result["model"].isin(PERSISTENCE_BASELINE_MODELS)].copy()
@@ -208,4 +238,5 @@ def point_in_time_persistence_errors(
     result["availability_gate"] = availability_column
     result["availability_gate_enforced"] = True
     result["benchmark_stage"] = "point_in_time_persistence_only"
+    result["forecast_horizon_years"] = horizon
     return result.reset_index(drop=True)

--- a/src/urban_growth/mexico_concordance.py
+++ b/src/urban_growth/mexico_concordance.py
@@ -109,7 +109,8 @@ def build_mexico_multiwave_history(transitions: pd.DataFrame) -> pd.DataFrame:
 
     A forecast row is eligible only when both its outcome transition and the immediately
     preceding transition used for recent growth pass independently. Later geography cannot
-    repair an earlier predictor interval.
+    repair an earlier predictor interval. Forecast horizon is retained explicitly because
+    annualized growth rates from different horizons are not interchangeable error targets.
     """
     checked = validate_mexico_locality_transition(transitions)
     checked = checked.sort_values(["analysis_id", "origin_year", "endpoint_year"]).copy()
@@ -149,6 +150,7 @@ def build_mexico_multiwave_history(transitions: pd.DataFrame) -> pd.DataFrame:
     current["future_growth"] = current["interval_log_growth"]
     current["period_start"] = current["origin_year"]
     current["period_end"] = current["endpoint_year"]
+    current["forecast_horizon_years"] = current["endpoint_year"] - current["origin_year"]
     current["country_code"] = "MEX"
     current["city_id"] = current["analysis_id"].astype(str)
     current["growth_eligible"] = current["forecast_interval_eligible"]

--- a/tests/test_forecast_fitness.py
+++ b/tests/test_forecast_fitness.py
@@ -52,6 +52,7 @@ def test_fitness_gate_excludes_ineligible_rows() -> None:
     result = fitness_gated_forecast_panel(forecast_panel())
     assert not ((result["city_id"] == "B") & (result["period_start"] == 2010)).any()
     assert result["forecast_fitness_gate_passed"].all()
+    assert result["forecast_horizon_years"].eq(5.0).all()
 
 
 def test_point_in_time_gate_requires_explicit_boolean_availability() -> None:
@@ -82,9 +83,17 @@ def test_persistence_oos_scores_only_fitness_eligible_test_rows() -> None:
     assert {"zero_growth", "persistence"}.issubset(set(result["model"]))
     assert result["fitness_gate_enforced"].all()
     assert result["benchmark_stage"].eq("retrospective_persistence_only").all()
+    assert result["forecast_horizon_years"].eq(5.0).all()
     counts = result.pivot(index="origin", columns="model", values="n")
     assert counts.loc[2005, "persistence"] == 3
     assert counts.loc[2010, "persistence"] == 2
+
+
+def test_persistence_oos_rejects_mixed_forecast_horizons() -> None:
+    panel = forecast_panel()
+    panel.loc[(panel["city_id"] == "A") & (panel["period_start"] == 2000), "period_end"] = 2010
+    with pytest.raises(SourceSchemaError, match="cannot pool mixed forecast horizons"):
+        evaluate_fitness_gated_persistence_baselines(panel, [2005, 2010])
 
 
 def test_point_in_time_persistence_cannot_score_late_test_rows() -> None:
@@ -106,6 +115,7 @@ def test_row_level_errors_cannot_reintroduce_ineligible_rows() -> None:
     excluded = errors.loc[(errors["city_id"] == "B") & (errors["origin"] == 2010)]
     assert excluded.empty
     assert errors["fitness_gate_enforced"].all()
+    assert errors["forecast_horizon_years"].eq(5.0).all()
 
 
 def test_point_in_time_errors_cannot_reintroduce_late_rows() -> None:

--- a/tests/test_forecast_horizon_contract.py
+++ b/tests/test_forecast_horizon_contract.py
@@ -1,0 +1,74 @@
+import pandas as pd
+import pytest
+
+from urban_growth.forecast_fitness import evaluate_fitness_gated_persistence_baselines
+from urban_growth.io import SourceSchemaError
+from urban_growth.mexico_concordance import build_mexico_multiwave_history
+
+
+def _mexico_row(**overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "analysis_id": "MEX_LOC_001",
+        "origin_year": 1995,
+        "endpoint_year": 2000,
+        "origin_population": 40_000,
+        "endpoint_population": 44_000,
+        "origin_event_type": "population_count",
+        "endpoint_event_type": "census",
+        "match_status": "stable_geometry",
+        "relationship_cardinality": "one_to_one",
+        "origin_overlap_ratio": 0.999,
+        "endpoint_overlap_ratio": 0.999,
+        "official_relationship_verified": True,
+        "all_components_identified": True,
+        "population_aggregation_complete": True,
+        "double_count_free": True,
+        "methodology_comparable": True,
+        "evidence_reference_year": 2000,
+        "uses_future_boundary_reference": False,
+        "exclusion_reason": "",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_mexico_history_records_each_forecast_horizon() -> None:
+    transitions = pd.DataFrame(
+        [
+            _mexico_row(),
+            _mexico_row(
+                origin_year=2000,
+                endpoint_year=2005,
+                origin_population=44_000,
+                endpoint_population=48_000,
+                origin_event_type="census",
+                endpoint_event_type="population_count",
+                evidence_reference_year=2005,
+            ),
+            _mexico_row(
+                origin_year=2005,
+                endpoint_year=2015,
+                origin_population=48_000,
+                endpoint_population=58_000,
+                origin_event_type="population_count",
+                endpoint_event_type="census",
+                evidence_reference_year=2015,
+            ),
+        ]
+    )
+    result = build_mexico_multiwave_history(transitions)
+    horizons = dict(zip(result["origin_year"], result["forecast_horizon_years"], strict=True))
+    assert horizons[2000] == 5
+    assert horizons[2005] == 10
+
+
+def test_explicit_mixed_horizons_cannot_be_pooled() -> None:
+    panel = pd.DataFrame(
+        [
+            {"city_id": "A", "country_code": "AAA", "period_start": 2000, "period_end": 2005, "recent_growth": 0.01, "future_growth": 0.01, "growth_eligible": True, "forecast_horizon_years": 5},
+            {"city_id": "A", "country_code": "AAA", "period_start": 2005, "period_end": 2010, "recent_growth": 0.01, "future_growth": 0.01, "growth_eligible": True, "forecast_horizon_years": 5},
+            {"city_id": "A", "country_code": "AAA", "period_start": 2010, "period_end": 2020, "recent_growth": 0.01, "future_growth": 0.01, "growth_eligible": True, "forecast_horizon_years": 10},
+        ]
+    )
+    with pytest.raises(SourceSchemaError, match="cannot pool mixed forecast horizons"):
+        evaluate_fitness_gated_persistence_baselines(panel, [2005, 2010])


### PR DESCRIPTION
Prevents persistence benchmark results from pooling different forecast horizons. Mexico multiwave history now records `forecast_horizon_years`; the common retrospective and point-in-time persistence evaluators require a single horizon after gating; mixed 5-year/10-year panels fail closed until explicitly stratified. Adds regression tests and documents the rule.