### PR TITLE
Separate Mexico source eligibility from headline and deployability

### DIFF
--- a/docs/mexico-multiwave-oos-contract.md
+++ b/docs/mexico-multiwave-oos-contract.md
@@ -52,6 +52,13 @@ The existing proposed Mexico gate remains at least 85% count coverage and at lea
 
 ## Forecast use
 
-`src/urban_growth/mexico_concordance.py` converts accepted adjacent transitions into forecast rows only when both the prior-history and current-outcome transitions pass. The resulting rows expose `recent_growth`, `future_growth`, `period_start`, `period_end`, `growth_eligible`, and explicit no-future-boundary flags for the common persistence benchmark layer.
+`src/urban_growth/mexico_concordance.py` converts accepted adjacent transitions into forecast rows only when both the prior-history and current-outcome transitions pass. The resulting rows expose `recent_growth`, `future_growth`, `period_start`, `period_end`, `forecast_horizon_years`, and source-specific `growth_eligible` for the common persistence benchmark layer.
+
+Source-specific transition eligibility is not sufficient for either a headline claim or a deployable forecast. The builder therefore fails both statuses closed:
+
+- `headline_eligible = false` with `common_city_data_fitness_not_applied` until the row has been evaluated under the common City Data Fitness Standard, including truncation/survivorship and adverse-evidence fields;
+- `forecast_deployable_at_origin = false` with `point_in_time_availability_not_applied` until explicit predictor/concordance availability dates have passed the point-in-time gate.
+
+A Mexico row may therefore be suitable for a retrospective source-specific growth benchmark while still being ineligible for headline or deployable classification. Downstream code must not infer those stronger statuses from `forecast_interval_eligible` or `growth_eligible`.
 
 No empirical Mexico persistence result is registered by this contract. Exact ITER/SCITEL files, official equivalence records, vintage Marco Geoestadístico layers, retrieval dates, URLs, and hashes must be acquired and registered first.

--- a/src/urban_growth/mexico_concordance.py
+++ b/src/urban_growth/mexico_concordance.py
@@ -107,10 +107,15 @@ def validate_mexico_locality_transition(transition: pd.DataFrame) -> pd.DataFram
 def build_mexico_multiwave_history(transitions: pd.DataFrame) -> pd.DataFrame:
     """Build adjacent-transition forecast rows without future-boundary leakage.
 
-    A forecast row is eligible only when both its outcome transition and the immediately
-    preceding transition used for recent growth pass independently. Later geography cannot
-    repair an earlier predictor interval. Forecast horizon is retained explicitly because
-    annualized growth rates from different horizons are not interchangeable error targets.
+    A forecast row is source-transition eligible only when both its outcome transition
+    and the immediately preceding transition used for recent growth pass independently.
+    Later geography cannot repair an earlier predictor interval. Forecast horizon is
+    retained explicitly because annualized growth rates from different horizons are not
+    interchangeable error targets.
+
+    Source-transition eligibility is not the common City Data Fitness Standard and is
+    not point-in-time availability. This builder therefore never promotes a row directly
+    to headline or deployable status.
     """
     checked = validate_mexico_locality_transition(transitions)
     checked = checked.sort_values(["analysis_id", "origin_year", "endpoint_year"]).copy()
@@ -154,9 +159,11 @@ def build_mexico_multiwave_history(transitions: pd.DataFrame) -> pd.DataFrame:
     current["country_code"] = "MEX"
     current["city_id"] = current["analysis_id"].astype(str)
     current["growth_eligible"] = current["forecast_interval_eligible"]
-    current["headline_eligible"] = current["forecast_interval_eligible"]
+    current["headline_eligible"] = False
+    current["headline_exclusion_reasons"] = "common_city_data_fitness_not_applied"
     current["boundary_history_uses_future_reference"] = False
-    current["forecast_deployable_at_origin"] = current["forecast_interval_eligible"]
+    current["forecast_deployable_at_origin"] = False
+    current["deployability_exclusion_reason"] = "point_in_time_availability_not_applied"
     return current
 
 

--- a/tests/test_mexico_concordance.py
+++ b/tests/test_mexico_concordance.py
@@ -101,6 +101,32 @@ def test_multiwave_history_uses_only_immediately_prior_transition() -> None:
     assert not result["boundary_history_uses_future_reference"].any()
 
 
+def test_transition_eligibility_does_not_self_promote_to_headline_or_deployable() -> None:
+    transitions = pd.DataFrame(
+        [
+            row(),
+            row(
+                origin_year=2000,
+                endpoint_year=2005,
+                origin_population=44_000,
+                endpoint_population=48_000,
+                origin_event_type="census",
+                endpoint_event_type="population_count",
+                evidence_reference_year=2005,
+            ),
+        ]
+    )
+    result = build_mexico_multiwave_history(transitions)
+    current = result.loc[result["origin_year"].eq(2000)].iloc[0]
+
+    assert current["forecast_interval_eligible"]
+    assert current["growth_eligible"]
+    assert not current["headline_eligible"]
+    assert current["headline_exclusion_reasons"] == "common_city_data_fitness_not_applied"
+    assert not current["forecast_deployable_at_origin"]
+    assert current["deployability_exclusion_reason"] == "point_in_time_availability_not_applied"
+
+
 def test_failed_prior_transition_blocks_next_forecast_origin() -> None:
     transitions = pd.DataFrame(
         [


### PR DESCRIPTION
Closes a source-specific gate bypass in the Mexico multiwave builder. `forecast_interval_eligible`/`growth_eligible` remain source-transition eligibility only; the builder no longer self-promotes those rows to `headline_eligible` or `forecast_deployable_at_origin`. Headline status now fails closed until the common City Data Fitness Standard is applied, and deployability fails closed until the point-in-time availability gate is applied. Adds regression coverage and updates the Mexico OOS contract.