### PR TITLE
Add moving-block bootstrap for overlapping origins

### DIFF
--- a/docs/overlapping-origin-bootstrap-policy.md
+++ b/docs/overlapping-origin-bootstrap-policy.md
@@ -1,0 +1,29 @@
+# Overlapping-origin bootstrap dependence policy
+
+## Problem
+
+Rolling forecast origins can overlap in outcome windows. For example, a 10-year forecast evaluated every 5 years reuses part of the same realized city trajectory in adjacent forecast outcomes. Annualizing growth does not remove that dependence.
+
+The existing `two_way_cluster_bootstrap_paired_difference` resamples countries and origins independently. Country resampling preserves each country's complete nested city-by-origin contribution, but origin resampling treats origins as exchangeable clusters and does not preserve adjacent temporal blocks. That estimator remains useful as a diagnostic, but it is not the primary pooled inference procedure when forecast windows overlap.
+
+## Locked rule
+
+For pooled paired-error inference across multiple origins:
+
+- declare the forecast horizon explicitly;
+- calculate the minimum spacing between evaluated origins;
+- if `forecast_horizon_years > minimum_origin_spacing_years`, classify the origins as overlapping;
+- overlapping origins must use the moving-block two-way bootstrap in `src/urban_growth/bootstrap_dependence.py`;
+- the exchangeable-origin two-way bootstrap may still be reported as a sensitivity diagnostic, but not as the sole headline uncertainty estimate for overlapping origins.
+
+The block length is derived conservatively as:
+
+`ceil(forecast_horizon_years / minimum_origin_spacing_years)`
+
+capped at the number of observed origins. Time blocks are sampled as circular moving blocks over sorted origins. Countries are still resampled as whole clusters, preserving nested city trajectories within sampled countries.
+
+## Interpretation
+
+This does not make overlapping rolling-origin errors independent. It changes the bootstrap resampling unit so adjacent-origin dependence is retained rather than deliberately broken. With very few origins, uncertainty remains weakly identified and should be described accordingly.
+
+When forecast horizons do not overlap, block length is one and the method reduces to exchangeable origin-cluster resampling combined with country-cluster resampling.

--- a/src/urban_growth/bootstrap_dependence.py
+++ b/src/urban_growth/bootstrap_dependence.py
@@ -1,0 +1,165 @@
+"""Dependence-aware bootstrap inference for pooled rolling-origin comparisons."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+
+from urban_growth.io import SourceSchemaError, require_columns
+
+
+def _circular_block_weights(
+    *,
+    cluster_count: int,
+    block_length: int,
+    repetitions: int,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """Draw circular moving blocks and return cluster multiplicities by repetition."""
+    if not 1 <= block_length <= cluster_count:
+        raise SourceSchemaError("Time block length must be between one and the origin count")
+    if block_length == 1:
+        return rng.multinomial(
+            cluster_count,
+            np.full(cluster_count, 1 / cluster_count),
+            size=repetitions,
+        )
+    blocks_per_draw = math.ceil(cluster_count / block_length)
+    starts = rng.integers(0, cluster_count, size=(repetitions, blocks_per_draw))
+    offsets = np.arange(block_length)
+    sampled = (starts[..., None] + offsets) % cluster_count
+    sampled = sampled.reshape(repetitions, -1)[:, :cluster_count]
+    weights = np.zeros((repetitions, cluster_count), dtype=int)
+    for repetition in range(repetitions):
+        weights[repetition] = np.bincount(sampled[repetition], minlength=cluster_count)
+    return weights
+
+
+def block_two_way_cluster_bootstrap_paired_difference(
+    errors: pd.DataFrame,
+    *,
+    forecast_horizon_years: int,
+    model_a: str = "persistence",
+    model_b: str = "country_mean_leave_city_out",
+    group_columns: list[str] | None = None,
+    country_column: str = "country_code",
+    time_column: str = "origin",
+    repetitions: int = 2_000,
+    seed: int = 20260827,
+    confidence: float = 0.95,
+) -> pd.DataFrame:
+    """Bootstrap paired MAE differences with country clusters and origin blocks.
+
+    Country draws preserve each sampled country's complete city-by-origin contribution.
+    Time dependence is handled with circular moving blocks over sorted forecast origins.
+    The block length is derived conservatively from the declared forecast horizon and
+    the minimum spacing between observed origins: ``ceil(horizon / min_origin_spacing)``.
+    Thus overlapping forecast windows cannot be treated as exchangeable one-origin
+    clusters merely because their annualized outcomes share a common scale.
+    """
+    groups = group_columns or []
+    required = {
+        "city_id",
+        "model",
+        "absolute_error",
+        country_column,
+        time_column,
+        *groups,
+    }
+    require_columns(errors, required, source_name="row-level forecast errors")
+    if forecast_horizon_years <= 0:
+        raise SourceSchemaError("Forecast horizon must be positive")
+    if repetitions < 100:
+        raise SourceSchemaError("Block two-way bootstrap requires at least 100 repetitions")
+    if not 0 < confidence < 1:
+        raise SourceSchemaError("Bootstrap confidence must be between zero and one")
+
+    subset = errors.loc[errors["model"].isin([model_a, model_b])]
+    index = list(dict.fromkeys(["city_id", country_column, time_column, *groups]))
+    paired = subset.pivot(index=index, columns="model", values="absolute_error").dropna()
+    if model_a not in paired or model_b not in paired:
+        raise SourceSchemaError("Requested models do not have matched row-level errors")
+    paired["difference"] = paired[model_a] - paired[model_b]
+    paired = paired.reset_index()
+
+    if groups:
+        grouper: str | list[str] = groups[0] if len(groups) == 1 else groups
+        grouped = paired.groupby(grouper, observed=True, sort=True)
+    else:
+        grouped = [((), paired)]
+
+    alpha = (1 - confidence) / 2
+    rng = np.random.default_rng(seed)
+    rows: list[dict[str, float | int | str | bool]] = []
+    for group_key, group in grouped:
+        countries = sorted(group[country_column].unique())
+        times = sorted(group[time_column].unique())
+        if len(countries) < 2 or len(times) < 2:
+            continue
+        time_array = np.asarray(times, dtype=float)
+        spacing = np.diff(time_array)
+        if not np.isfinite(spacing).all() or (spacing <= 0).any():
+            raise SourceSchemaError("Forecast origins must be strictly increasing numeric values")
+        minimum_spacing = float(spacing.min())
+        block_length = min(
+            len(times),
+            max(1, math.ceil(forecast_horizon_years / minimum_spacing)),
+        )
+        origins_overlap = forecast_horizon_years > minimum_spacing
+
+        cells = group.groupby([country_column, time_column])["difference"].agg(["sum", "count"])
+        sums = cells["sum"].unstack(fill_value=0).reindex(
+            index=countries, columns=times, fill_value=0
+        ).to_numpy()
+        counts = cells["count"].unstack(fill_value=0).reindex(
+            index=countries, columns=times, fill_value=0
+        ).to_numpy()
+        country_draws = rng.multinomial(
+            len(countries),
+            np.full(len(countries), 1 / len(countries)),
+            size=repetitions,
+        )
+        time_draws = _circular_block_weights(
+            cluster_count=len(times),
+            block_length=block_length,
+            repetitions=repetitions,
+            rng=rng,
+        )
+        sampled_sums = np.einsum("rc,ct,rt->r", country_draws, sums, time_draws)
+        sampled_counts = np.einsum("rc,ct,rt->r", country_draws, counts, time_draws)
+        if (sampled_counts <= 0).any():
+            raise SourceSchemaError("Bootstrap draw produced an empty paired sample")
+        estimates = sampled_sums / sampled_counts
+
+        keys = (group_key,) if len(groups) == 1 else group_key
+        row: dict[str, float | int | str | bool] = dict(zip(groups, keys, strict=True))
+        row.update(
+            {
+                "model_a": model_a,
+                "model_b": model_b,
+                "n": len(group),
+                "countries": len(countries),
+                "time_clusters": len(times),
+                "forecast_horizon_years": forecast_horizon_years,
+                "minimum_origin_spacing_years": minimum_spacing,
+                "origins_overlap": origins_overlap,
+                "time_block_length": block_length,
+                "time_resampling_scheme": (
+                    "circular_moving_origin_blocks" if block_length > 1 else "exchangeable_origin_clusters"
+                ),
+                "adjacent_origin_blocks_preserved": block_length > 1,
+                "country_cluster_preserves_nested_city_trajectories": True,
+                "observed_mean_difference": float(group["difference"].mean()),
+                "ci_lower": float(np.quantile(estimates, alpha)),
+                "ci_upper": float(np.quantile(estimates, 1 - alpha)),
+                "probability_model_a_better": float((estimates < 0).mean()),
+                "repetitions": repetitions,
+                "seed": seed,
+            }
+        )
+        rows.append(row)
+    if not rows:
+        raise SourceSchemaError("No groups had enough country and time clusters")
+    return pd.DataFrame(rows)

--- a/tests/test_bootstrap_dependence.py
+++ b/tests/test_bootstrap_dependence.py
@@ -1,0 +1,66 @@
+import pandas as pd
+import pytest
+
+from urban_growth.bootstrap_dependence import (
+    block_two_way_cluster_bootstrap_paired_difference,
+)
+from urban_growth.io import SourceSchemaError
+
+
+def _errors() -> pd.DataFrame:
+    rows = []
+    for origin in [2000, 2005, 2010, 2015]:
+        for city_id, country, difference in [
+            (1, "A", -0.01),
+            (2, "B", 0.02),
+            (3, "C", -0.02),
+        ]:
+            for model, error in [
+                ("persistence", 0.05 + difference),
+                ("country_mean_leave_city_out", 0.05),
+            ]:
+                rows.append(
+                    {
+                        "city_id": city_id,
+                        "country_code": country,
+                        "origin": origin,
+                        "model": model,
+                        "absolute_error": error,
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+def test_overlapping_origins_use_moving_blocks() -> None:
+    first = block_two_way_cluster_bootstrap_paired_difference(
+        _errors(), forecast_horizon_years=10, repetitions=200, seed=13
+    )
+    second = block_two_way_cluster_bootstrap_paired_difference(
+        _errors(), forecast_horizon_years=10, repetitions=200, seed=13
+    )
+    pd.testing.assert_frame_equal(first, second)
+    row = first.iloc[0]
+    assert row["origins_overlap"]
+    assert row["minimum_origin_spacing_years"] == pytest.approx(5.0)
+    assert row["time_block_length"] == 2
+    assert row["time_resampling_scheme"] == "circular_moving_origin_blocks"
+    assert row["adjacent_origin_blocks_preserved"]
+    assert row["country_cluster_preserves_nested_city_trajectories"]
+
+
+def test_nonoverlapping_origins_need_no_time_blocking() -> None:
+    result = block_two_way_cluster_bootstrap_paired_difference(
+        _errors(), forecast_horizon_years=5, repetitions=200, seed=13
+    )
+    row = result.iloc[0]
+    assert not row["origins_overlap"]
+    assert row["time_block_length"] == 1
+    assert row["time_resampling_scheme"] == "exchangeable_origin_clusters"
+    assert not row["adjacent_origin_blocks_preserved"]
+
+
+def test_block_bootstrap_requires_declared_positive_horizon() -> None:
+    with pytest.raises(SourceSchemaError, match="Forecast horizon must be positive"):
+        block_two_way_cluster_bootstrap_paired_difference(
+            _errors(), forecast_horizon_years=0, repetitions=200
+        )


### PR DESCRIPTION
Adds a dependence-aware pooled inference path for overlapping rolling forecast windows. The new two-way block bootstrap resamples whole country clusters and circular moving blocks of adjacent origins, with block length derived from the declared forecast horizon and minimum origin spacing. Overlapping 10-year outcomes on 5-year origins therefore use two-origin blocks instead of exchangeable single-origin resampling. Adds regression tests and a locked methodology policy; the existing exchangeable-origin bootstrap remains a diagnostic sensitivity for overlapping origins.