### PR TITLE
Fix forecast horizon semantics when outcomes start after origin

### DIFF
--- a/docs/forecast-horizon-comparability.md
+++ b/docs/forecast-horizon-comparability.md
@@ -4,7 +4,11 @@ Annualizing population growth does not make forecast errors from different horiz
 
 ## Locked rule
 
-Persistence benchmark evaluation must use one forecast horizon at a time. Every eligible row must carry a positive `forecast_horizon_years` value, either supplied explicitly by the source-specific builder or deterministically derived from `period_end - period_start` when the forecast interval itself defines the target horizon.
+Persistence benchmark evaluation must use one forecast horizon at a time. Every eligible row must carry a positive `forecast_horizon_years` value, either supplied explicitly by the source-specific builder or deterministically derived from the declared outcome interval.
+
+When an outcome gap exists, the forecast horizon is `period_end - outcome_start_year`, not `period_end - period_start`. If only `outcome_gap_years` is recorded, the equivalent derivation is `period_end - (period_start + outcome_gap_years)`. The pre-outcome gap is therefore never counted as target forecast horizon. If an explicit `forecast_horizon_years` value is present alongside derived interval fields, the values must agree or the common fitness gate fails closed.
+
+For simple contiguous intervals with no separate outcome-start or gap field, `period_end - period_start` remains the deterministic fallback.
 
 If more than one horizon is present after fitness and point-in-time gates are applied, the common persistence evaluator fails closed. Callers must stratify the panel to a single horizon before computing aggregate metrics or row-level errors.
 

--- a/src/urban_growth/forecast_fitness.py
+++ b/src/urban_growth/forecast_fitness.py
@@ -18,15 +18,34 @@ PERSISTENCE_BASELINE_MODELS = {
 
 
 def _attach_forecast_horizon(panel: pd.DataFrame) -> pd.DataFrame:
-    """Attach a positive forecast horizon, preserving an explicit source value when present."""
+    """Attach the target horizon without counting any pre-outcome gap as forecast time."""
     out = panel.copy()
+    period_end = pd.to_numeric(out["period_end"], errors="coerce")
+    period_start = pd.to_numeric(out["period_start"], errors="coerce")
+
+    derived: pd.Series | None = None
+    if "outcome_start_year" in out.columns:
+        outcome_start = pd.to_numeric(out["outcome_start_year"], errors="coerce")
+        derived = period_end - outcome_start
+    elif "outcome_gap_years" in out.columns:
+        outcome_gap = pd.to_numeric(out["outcome_gap_years"], errors="coerce")
+        derived = period_end - (period_start + outcome_gap)
+    elif "forecast_horizon_years" not in out.columns:
+        derived = period_end - period_start
+
+    explicit: pd.Series | None = None
     if "forecast_horizon_years" in out.columns:
-        horizon = pd.to_numeric(out["forecast_horizon_years"], errors="coerce")
-    else:
-        horizon = pd.to_numeric(out["period_end"], errors="coerce") - pd.to_numeric(
-            out["period_start"], errors="coerce"
-        )
-    if horizon.isna().any() or horizon.le(0).any():
+        explicit = pd.to_numeric(out["forecast_horizon_years"], errors="coerce")
+
+    if explicit is not None and derived is not None:
+        mismatch = explicit.notna() & derived.notna() & explicit.ne(derived)
+        if mismatch.any():
+            raise SourceSchemaError(
+                "Explicit forecast_horizon_years disagrees with the declared outcome interval"
+            )
+
+    horizon = explicit if explicit is not None else derived
+    if horizon is None or horizon.isna().any() or horizon.le(0).any():
         raise SourceSchemaError("forecast_horizon_years must be positive and known for every row")
     out["forecast_horizon_years"] = horizon.astype(float)
     return out

--- a/tests/test_forecast_horizon_gap.py
+++ b/tests/test_forecast_horizon_gap.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from urban_growth.forecast_fitness import fitness_gated_forecast_panel
+from urban_growth.io import SourceSchemaError
+
+
+def base_panel() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "city_id": "A",
+                "country_code": "AAA",
+                "period_start": 2000,
+                "period_end": 2010,
+                "outcome_start_year": 2005,
+                "outcome_gap_years": 5,
+                "recent_growth": 0.01,
+                "future_growth": 0.02,
+                "growth_eligible": True,
+            }
+        ]
+    )
+
+
+def test_horizon_excludes_pre_outcome_gap() -> None:
+    result = fitness_gated_forecast_panel(base_panel())
+    assert result.loc[0, "forecast_horizon_years"] == pytest.approx(5.0)
+
+
+def test_outcome_gap_can_derive_horizon_without_outcome_start_year() -> None:
+    panel = base_panel().drop(columns="outcome_start_year")
+    result = fitness_gated_forecast_panel(panel)
+    assert result.loc[0, "forecast_horizon_years"] == pytest.approx(5.0)
+
+
+def test_explicit_horizon_must_match_declared_outcome_interval() -> None:
+    panel = base_panel()
+    panel["forecast_horizon_years"] = 10
+    with pytest.raises(SourceSchemaError, match="disagrees with the declared outcome interval"):
+        fitness_gated_forecast_panel(panel)
+
+
+def test_explicit_matching_horizon_is_retained() -> None:
+    panel = base_panel()
+    panel["forecast_horizon_years"] = 5
+    result = fitness_gated_forecast_panel(panel)
+    assert result.loc[0, "forecast_horizon_years"] == pytest.approx(5.0)


### PR DESCRIPTION
Corrects the common horizon gate so a pre-outcome gap is not counted as forecast horizon. The gate now derives horizon from `period_end - outcome_start_year`, or equivalently from `outcome_gap_years` when present; simple contiguous panels retain the period-end minus period-start fallback. Explicit `forecast_horizon_years` values are cross-checked against the declared outcome interval and fail closed on disagreement. Adds regression tests and updates the horizon comparability contract.