### PR TITLE
Lock threshold cohorts to origin population

### DIFF
--- a/docs/us-census-threshold-pilot.md
+++ b/docs/us-census-threshold-pilot.md
@@ -9,10 +9,12 @@ identifiers and Census relationship files make this a comparatively favorable te
 the implementation rather than a demanding test of international harmonization.
 
 The first registered interval is 2010–2020. The origin cohort contains places with
-25,000–100,000 residents in 2010. A place crosses the WUP observation threshold when
-its directly enumerated population is below 50,000 in 2010 and at least 50,000 in
-2020. Crossing is interval-censored in the open interval `(2010, 2020)`; the code does
-not invent a point crossing year.
+25,000–100,000 residents in 2010. Cohort membership is defined **only** from the 2010
+origin population. The 2020 population is retained as an outcome and cannot add a
+future entrant, remove a later decliner, or otherwise redefine the origin risk set.
+A place crosses the WUP observation threshold when its directly enumerated population
+is below 50,000 in 2010 and at least 50,000 in 2020. Crossing is interval-censored in
+the open interval `(2010, 2020)`; the code does not invent a point crossing year.
 
 ## Official inputs
 
@@ -38,6 +40,19 @@ All other relationships are excluded rather than interpreted as demographic chan
 This land-overlap rule is a conservative feasibility screen. It is not proof that
 population was enumerated on perfectly identical geography, and the retained overlap
 ratios remain in the output for sensitivity analysis.
+
+## Origin-defined cohort rule
+
+`urban_growth.census_threshold.origin_defined_threshold_cohort` is the canonical
+constructor for the threshold-study risk set. It first validates comparable geography
+and complete endpoints, then applies the declared population bounds to
+`population_origin` only. It records `cohort_population_basis = population_origin`,
+`cohort_defined_at_origin = true`, and `cohort_uses_endpoint_population = false`.
+
+This means a locality with 20,000 people at origin and 70,000 at the endpoint remains
+outside a 25,000–100,000 origin cohort, while a locality with 80,000 at origin and
+30,000 at the endpoint remains inside. Endpoint growth, threshold crossing, and later
+survival therefore cannot determine sample membership.
 
 ## City Data Fitness gate
 

--- a/src/urban_growth/census_threshold.py
+++ b/src/urban_growth/census_threshold.py
@@ -66,3 +66,35 @@ def validate_boundary_cohort(frame: pd.DataFrame) -> None:
         raise SourceSchemaError("Boundary cohort contains unresolved or incomparable geography")
     if frame[["population_origin", "population_endpoint"]].isna().any().any():
         raise SourceSchemaError("Boundary cohort requires both population endpoints")
+
+
+def origin_defined_threshold_cohort(
+    frame: pd.DataFrame,
+    *,
+    cohort_min: float = 25_000,
+    cohort_max: float = 100_000,
+) -> pd.DataFrame:
+    """Select a threshold-study cohort using origin population only.
+
+    Endpoint population is retained as an outcome but never participates in membership.
+    This prevents future growth, threshold crossing, or survival at the endpoint from
+    redefining the risk set after the forecast origin.
+    """
+    validate_boundary_cohort(frame)
+    if cohort_min <= 0 or cohort_max <= cohort_min:
+        raise SourceSchemaError("Origin cohort bounds must be positive and increasing")
+    origin_population = pd.to_numeric(frame["population_origin"], errors="coerce")
+    endpoint_population = pd.to_numeric(frame["population_endpoint"], errors="coerce")
+    if origin_population.isna().any() or endpoint_population.isna().any():
+        raise SourceSchemaError("Threshold cohort populations must be numeric")
+    if origin_population.le(0).any() or endpoint_population.le(0).any():
+        raise SourceSchemaError("Threshold cohort populations must be positive")
+    selected = frame.loc[origin_population.between(cohort_min, cohort_max)].copy()
+    if selected.empty:
+        raise SourceSchemaError("No settlements fall within the declared origin cohort")
+    selected["cohort_population_basis"] = "population_origin"
+    selected["cohort_min_population"] = float(cohort_min)
+    selected["cohort_max_population"] = float(cohort_max)
+    selected["cohort_uses_endpoint_population"] = False
+    selected["cohort_defined_at_origin"] = True
+    return selected.reset_index(drop=True)

--- a/tests/test_census_threshold.py
+++ b/tests/test_census_threshold.py
@@ -4,6 +4,7 @@ import pytest
 from urban_growth.census_threshold import (
     classify_threshold_measurement_band,
     entry_delay_interval,
+    origin_defined_threshold_cohort,
     validate_boundary_cohort,
 )
 from urban_growth.io import SourceSchemaError
@@ -41,3 +42,57 @@ def test_boundary_cohort_rejects_unresolved_geography() -> None:
     )
     with pytest.raises(SourceSchemaError, match="unresolved"):
         validate_boundary_cohort(frame)
+
+
+def test_threshold_cohort_membership_uses_origin_population_only() -> None:
+    frame = pd.DataFrame(
+        {
+            "settlement_id": ["grower", "decliner", "future_entrant", "future_exit"],
+            "country_code": ["X"] * 4,
+            "origin_year": [2000] * 4,
+            "endpoint_year": [2010] * 4,
+            "population_origin": [40_000, 80_000, 20_000, 120_000],
+            "population_endpoint": [70_000, 30_000, 70_000, 80_000],
+            "geography_status": ["stable"] * 4,
+        }
+    )
+    result = origin_defined_threshold_cohort(frame)
+    assert set(result["settlement_id"]) == {"grower", "decliner"}
+    assert result["cohort_population_basis"].eq("population_origin").all()
+    assert not result["cohort_uses_endpoint_population"].any()
+    assert result["cohort_defined_at_origin"].all()
+
+
+def test_threshold_cohort_is_invariant_to_endpoint_population_changes() -> None:
+    frame = pd.DataFrame(
+        {
+            "settlement_id": ["a", "b", "c"],
+            "country_code": ["X"] * 3,
+            "origin_year": [2000] * 3,
+            "endpoint_year": [2010] * 3,
+            "population_origin": [30_000, 60_000, 110_000],
+            "population_endpoint": [35_000, 65_000, 115_000],
+            "geography_status": ["stable"] * 3,
+        }
+    )
+    first = origin_defined_threshold_cohort(frame)
+    changed = frame.copy()
+    changed["population_endpoint"] = [200_000, 1_000, 50_000]
+    second = origin_defined_threshold_cohort(changed)
+    assert first["settlement_id"].tolist() == second["settlement_id"].tolist() == ["a", "b"]
+
+
+def test_threshold_cohort_rejects_invalid_bounds() -> None:
+    frame = pd.DataFrame(
+        {
+            "settlement_id": ["a"],
+            "country_code": ["X"],
+            "origin_year": [2000],
+            "endpoint_year": [2010],
+            "population_origin": [40_000],
+            "population_endpoint": [60_000],
+            "geography_status": ["stable"],
+        }
+    )
+    with pytest.raises(SourceSchemaError, match="bounds"):
+        origin_defined_threshold_cohort(frame, cohort_min=100_000, cohort_max=25_000)


### PR DESCRIPTION
Prevents future-defined threshold sample membership. Adds a canonical origin-defined cohort constructor that validates comparable geography, applies the declared 25k–100k-style bounds to `population_origin` only, retains endpoint population strictly as an outcome, and records explicit cohort provenance flags. Regression tests show future entrants stay out, later decliners stay in, and cohort membership is invariant to endpoint-population changes. Updates the U.S. Census threshold pilot contract.