### PR TITLE
Require provenance for point-in-time availability

### DIFF
--- a/docs/forecast-data-availability.md
+++ b/docs/forecast-data-availability.md
@@ -14,26 +14,30 @@ Any result described as **deployable at origin**, **real-time**, or a point-in-t
 
 - `forecast_origin_date`: the actual as-of date at which the forecast is claimed to have been formed;
 - `predictor_available_date`: first date the population/statistical information needed for the predictor was available to the analyst;
-- `concordance_available_date`: first date the geography/crosswalk evidence needed to construct the comparable predictor was available.
+- `predictor_availability_source`: auditable source evidence supporting that first-availability date;
+- `concordance_available_date`: first date the geography/crosswalk evidence needed to construct the comparable predictor was available;
+- `concordance_availability_source`: auditable source evidence supporting that concordance first-availability date.
 
-Both evidence dates must be on or before `forecast_origin_date`. Missing origin or availability dates fail closed. Reference year, enumeration date, `period_start`, period end, file vintage, and current download date are not substitutes for first availability.
+Both evidence dates must be on or before `forecast_origin_date`. Missing origin or availability dates fail closed. Missing or blank availability-source provenance also fails closed. Reference year, enumeration date, `period_start`, period end, file vintage, current download date, and an unsupported analyst-entered date are not substitutes for first availability.
 
-`src/urban_growth/forecast_availability.py` implements this rule and produces `point_in_time_available` plus explicit exclusion reasons. The default origin field is `forecast_origin_date`; callers may override the column name only when they supply another explicit date field with the same semantics.
+`src/urban_growth/forecast_availability.py` implements this rule and produces `point_in_time_available`, `availability_provenance_verified`, and explicit exclusion reasons. The default origin field is `forecast_origin_date`; callers may override the column name only when they supply another explicit date field with the same semantics.
+
+A downstream persistence evaluator must not trust a manually supplied `point_in_time_available` flag by itself. The deployable persistence path also requires `availability_provenance_verified = true`, which is produced only after the availability gate validates the required provenance fields.
 
 ## Consequences
 
 Retrospective analyses may still use later-released evidence when clearly labeled retrospective. They must not be promoted to deployable-at-origin evidence.
 
-For rolling persistence tests, an outcome observed through an origin year is not automatically training information at that origin. If its required source release occurred after the origin, it cannot enter the real-time training set until a later origin.
+For rolling persistence tests, an outcome observed through an origin year is not automatically training information at that origin. If its required source release occurred after the origin, it cannot enter the real-time training set until a later origin. The deployable persistence evaluator therefore separately requires an explicit `outcome_available_date` for training outcomes.
 
-For Mexico, this means census/count reference dates and locality-equivalence evidence require actual release/availability dates before the multiwave panel can be called deployable. The existing year-only `evidence_reference_year <= endpoint_year` concordance check prevents future-reference geography but does not by itself establish point-in-time availability.
+For Mexico, this means census/count reference dates and locality-equivalence evidence require actual release/availability dates **and source evidence for those dates** before the multiwave panel can be called deployable. The existing year-only `evidence_reference_year <= endpoint_year` concordance check prevents future-reference geography but does not by itself establish point-in-time availability.
 
 For revised international products such as current-vintage WUP, WPP, or retrospective GHSL histories, the same distinction applies: current-vintage historical observations can support retrospective sensitivity analysis without constituting historical real-time information.
 
 ## Result classification
 
-- `point_in_time_available = true`: required predictor and concordance evidence existed by the explicit forecast-origin date.
+- `point_in_time_available = true`: required predictor and concordance evidence existed by the explicit forecast-origin date and the first-availability claims have recorded provenance.
 - `point_in_time_available = false`: retrospective-only for that origin.
-- unknown evidence availability or missing forecast-origin date: fail closed; do not infer availability from the reference period.
+- unknown evidence availability, missing forecast-origin date, or missing availability provenance: fail closed; do not infer availability from the reference period.
 
 This gate is orthogonal to the City Data Fitness Standard and should be applied in addition to source-specific growth/headline eligibility before a forecast is described as deployable.

--- a/src/urban_growth/forecast_availability.py
+++ b/src/urban_growth/forecast_availability.py
@@ -7,20 +7,33 @@ import pandas as pd
 from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
 
 
+def _require_availability_provenance(frame: pd.DataFrame, column: str) -> pd.Series:
+    """Return normalized nonblank provenance strings for an availability field."""
+    values = frame[column].astype("string").str.strip()
+    missing = values.isna() | values.eq("")
+    if missing.any():
+        raise SourceSchemaError(
+            f"{column} must identify the source evidence supporting every availability date"
+        )
+    return values
+
+
 def apply_forecast_availability_gate(
     panel: pd.DataFrame,
     *,
     origin_column: str = "forecast_origin_date",
     predictor_available_column: str = "predictor_available_date",
     concordance_available_column: str = "concordance_available_date",
+    predictor_provenance_column: str = "predictor_availability_source",
+    concordance_provenance_column: str = "concordance_availability_source",
 ) -> pd.DataFrame:
-    """Mark whether predictor evidence was actually available at forecast origin.
+    """Mark whether auditable predictor evidence was available at forecast origin.
 
     Reference periods are not publication dates, and integer origin years are not
     timestamps. A historical predictor may only be called deployable at an origin
-    when an explicit forecast-origin date is supplied and both its statistical
-    payload and any geography/concordance evidence needed to construct it were
-    available no later than that date.
+    when an explicit forecast-origin date is supplied, both statistical and
+    geography/concordance evidence were available no later than that date, and the
+    claimed first-availability dates have nonblank source provenance.
     """
     require_columns(
         panel,
@@ -31,6 +44,8 @@ def apply_forecast_availability_gate(
             origin_column,
             predictor_available_column,
             concordance_available_column,
+            predictor_provenance_column,
+            concordance_provenance_column,
         },
         source_name="forecast availability panel",
     )
@@ -50,10 +65,19 @@ def apply_forecast_availability_gate(
     if concordance_available.isna().any():
         raise SourceSchemaError(f"{concordance_available_column} must be known for every forecast row")
 
+    out[predictor_provenance_column] = _require_availability_provenance(
+        out, predictor_provenance_column
+    )
+    out[concordance_provenance_column] = _require_availability_provenance(
+        out, concordance_provenance_column
+    )
+    out["availability_provenance_verified"] = True
     out["predictor_available_at_origin"] = predictor_available.le(origin)
     out["concordance_available_at_origin"] = concordance_available.le(origin)
     out["point_in_time_available"] = (
-        out["predictor_available_at_origin"] & out["concordance_available_at_origin"]
+        out["predictor_available_at_origin"]
+        & out["concordance_available_at_origin"]
+        & out["availability_provenance_verified"]
     )
     out["availability_exclusion_reason"] = ""
     out.loc[~out["predictor_available_at_origin"], "availability_exclusion_reason"] = (
@@ -71,10 +95,13 @@ def point_in_time_forecast_sample(panel: pd.DataFrame) -> pd.DataFrame:
     """Return only rows whose required predictor evidence existed at the origin."""
     require_columns(
         panel,
-        {"point_in_time_available"},
+        {"point_in_time_available", "availability_provenance_verified"},
         source_name="forecast availability panel",
     )
     eligible = panel["point_in_time_available"]
+    provenance = panel["availability_provenance_verified"]
     if not pd.api.types.is_bool_dtype(eligible.dtype):
         raise SourceSchemaError("point_in_time_available must be boolean")
+    if not pd.api.types.is_bool_dtype(provenance.dtype) or not provenance.all():
+        raise SourceSchemaError("Point-in-time sample requires verified availability provenance")
     return panel.loc[eligible].copy().reset_index(drop=True)

--- a/src/urban_growth/forecast_fitness.py
+++ b/src/urban_growth/forecast_fitness.py
@@ -91,18 +91,32 @@ def point_in_time_fitness_gated_forecast_panel(
     *,
     eligibility_column: str = "growth_eligible",
     availability_column: str = "point_in_time_available",
+    provenance_column: str = "availability_provenance_verified",
 ) -> pd.DataFrame:
-    """Return rows that pass both data-fitness and predictor/concordance availability gates."""
-    require_columns(panel, {availability_column}, source_name="point-in-time forecast panel")
+    """Return rows passing fitness plus an auditable point-in-time availability gate."""
+    require_columns(
+        panel,
+        {availability_column, provenance_column},
+        source_name="point-in-time forecast panel",
+    )
     availability = panel[availability_column]
+    provenance = panel[provenance_column]
     if not pd.api.types.is_bool_dtype(availability.dtype):
         raise SourceSchemaError(f"{availability_column} must be boolean")
+    if not pd.api.types.is_bool_dtype(provenance.dtype):
+        raise SourceSchemaError(f"{provenance_column} must be boolean")
+    if not provenance.all():
+        raise SourceSchemaError(
+            "Point-in-time persistence requires verified availability provenance for every row"
+        )
     gated = fitness_gated_forecast_panel(panel, eligibility_column=eligibility_column)
-    result = gated.loc[gated[availability_column]].copy()
+    result = gated.loc[gated[availability_column] & gated[provenance_column]].copy()
     if result.empty:
         raise SourceSchemaError("No forecast rows pass both fitness and point-in-time gates")
     result["forecast_availability_gate"] = availability_column
     result["forecast_availability_gate_passed"] = True
+    result["forecast_availability_provenance_gate"] = provenance_column
+    result["forecast_availability_provenance_gate_passed"] = True
     return result.reset_index(drop=True)
 
 
@@ -231,15 +245,17 @@ def evaluate_point_in_time_persistence_baselines(
     *,
     eligibility_column: str = "growth_eligible",
     availability_column: str = "point_in_time_available",
+    provenance_column: str = "availability_provenance_verified",
     forecast_origin_date_column: str = "forecast_origin_date",
     outcome_available_column: str = "outcome_available_date",
     outcome_column: str = "future_growth",
 ) -> pd.DataFrame:
-    """Evaluate deployable persistence baselines with predictor and training-outcome timing gates."""
+    """Evaluate deployable persistence baselines with auditable timing gates."""
     gated = point_in_time_fitness_gated_forecast_panel(
         panel,
         eligibility_column=eligibility_column,
         availability_column=availability_column,
+        provenance_column=provenance_column,
     )
     horizon = _validate_single_horizon(gated)
     declared = _validate_declared_origins(gated, origins)
@@ -276,6 +292,8 @@ def evaluate_point_in_time_persistence_baselines(
     result["fitness_gate_enforced"] = True
     result["availability_gate"] = availability_column
     result["availability_gate_enforced"] = True
+    result["availability_provenance_gate"] = provenance_column
+    result["availability_provenance_gate_enforced"] = True
     result["training_outcome_availability_column"] = outcome_available_column
     result["benchmark_stage"] = "point_in_time_persistence_only"
     result["forecast_horizon_years"] = horizon
@@ -310,15 +328,17 @@ def point_in_time_persistence_errors(
     *,
     eligibility_column: str = "growth_eligible",
     availability_column: str = "point_in_time_available",
+    provenance_column: str = "availability_provenance_verified",
     forecast_origin_date_column: str = "forecast_origin_date",
     outcome_available_column: str = "outcome_available_date",
     outcome_column: str = "future_growth",
 ) -> pd.DataFrame:
-    """Return row-level errors after predictor and training-outcome timing gates."""
+    """Return row-level errors after auditable predictor and training-outcome timing gates."""
     gated = point_in_time_fitness_gated_forecast_panel(
         panel,
         eligibility_column=eligibility_column,
         availability_column=availability_column,
+        provenance_column=provenance_column,
     )
     horizon = _validate_single_horizon(gated)
     declared = _validate_declared_origins(gated, origins)
@@ -353,6 +373,8 @@ def point_in_time_persistence_errors(
     result["fitness_gate_enforced"] = True
     result["availability_gate"] = availability_column
     result["availability_gate_enforced"] = True
+    result["availability_provenance_gate"] = provenance_column
+    result["availability_provenance_gate_enforced"] = True
     result["training_outcome_availability_column"] = outcome_available_column
     result["benchmark_stage"] = "point_in_time_persistence_only"
     result["forecast_horizon_years"] = horizon

--- a/tests/test_forecast_availability.py
+++ b/tests/test_forecast_availability.py
@@ -17,6 +17,8 @@ def _panel() -> pd.DataFrame:
             "forecast_origin_date": ["2000-01-01", "2000-01-01"],
             "predictor_available_date": ["1999-12-01", "2000-06-01"],
             "concordance_available_date": ["1999-11-01", "1999-11-01"],
+            "predictor_availability_source": ["official statistical release", "official statistical release"],
+            "concordance_availability_source": ["official geography release", "official geography release"],
         }
     )
 
@@ -26,6 +28,7 @@ def test_availability_gate_blocks_post_origin_predictor() -> None:
     assert bool(result.loc[0, "point_in_time_available"])
     assert not bool(result.loc[1, "point_in_time_available"])
     assert result.loc[1, "availability_exclusion_reason"] == "predictor_not_available_at_origin"
+    assert result["availability_provenance_verified"].all()
 
 
 def test_availability_gate_blocks_post_origin_concordance() -> None:
@@ -40,6 +43,19 @@ def test_availability_gate_requires_known_dates() -> None:
     frame = _panel().iloc[[0]].copy()
     frame["predictor_available_date"] = None
     with pytest.raises(SourceSchemaError, match="must be known"):
+        apply_forecast_availability_gate(frame)
+
+
+def test_availability_gate_requires_predictor_provenance() -> None:
+    frame = _panel().iloc[[0]].copy()
+    frame["predictor_availability_source"] = "  "
+    with pytest.raises(SourceSchemaError, match="source evidence"):
+        apply_forecast_availability_gate(frame)
+
+
+def test_availability_gate_requires_concordance_provenance() -> None:
+    frame = _panel().iloc[[0]].drop(columns="concordance_availability_source")
+    with pytest.raises(SourceSchemaError, match="concordance_availability_source"):
         apply_forecast_availability_gate(frame)
 
 
@@ -59,3 +75,10 @@ def test_point_in_time_sample_cannot_reintroduce_late_rows() -> None:
     result = apply_forecast_availability_gate(_panel())
     sample = point_in_time_forecast_sample(result)
     assert sample["city_id"].tolist() == ["A"]
+
+
+def test_point_in_time_sample_rejects_unverified_provenance_flag() -> None:
+    result = apply_forecast_availability_gate(_panel())
+    result["availability_provenance_verified"] = False
+    with pytest.raises(SourceSchemaError, match="verified availability provenance"):
+        point_in_time_forecast_sample(result)

--- a/tests/test_forecast_fitness.py
+++ b/tests/test_forecast_fitness.py
@@ -32,6 +32,7 @@ def forecast_panel() -> pd.DataFrame:
                     "future_growth": future,
                     "growth_eligible": True,
                     "point_in_time_available": True,
+                    "availability_provenance_verified": True,
                     "forecast_origin_date": f"{start}-12-31",
                     "outcome_available_date": f"{end}-06-30",
                 }
@@ -63,6 +64,13 @@ def test_point_in_time_gate_requires_explicit_boolean_availability() -> None:
         point_in_time_fitness_gated_forecast_panel(panel)
 
 
+def test_point_in_time_gate_requires_verified_provenance() -> None:
+    panel = forecast_panel()
+    panel.loc[0, "availability_provenance_verified"] = False
+    with pytest.raises(SourceSchemaError, match="verified availability provenance"):
+        point_in_time_fitness_gated_forecast_panel(panel)
+
+
 def test_point_in_time_gate_excludes_late_rows_after_fitness_gate() -> None:
     panel = forecast_panel()
     panel.loc[
@@ -73,6 +81,7 @@ def test_point_in_time_gate_excludes_late_rows_after_fitness_gate() -> None:
     assert not ((result["city_id"] == "B") & (result["period_start"] == 2010)).any()
     assert not ((result["city_id"] == "C") & (result["period_start"] == 2010)).any()
     assert result["forecast_availability_gate_passed"].all()
+    assert result["forecast_availability_provenance_gate_passed"].all()
 
 
 def test_persistence_oos_requires_multiple_usable_origins() -> None:
@@ -109,6 +118,7 @@ def test_point_in_time_persistence_cannot_score_late_test_rows() -> None:
     assert counts.loc[2010, "persistence"] == 1
     assert result["fitness_gate_enforced"].all()
     assert result["availability_gate_enforced"].all()
+    assert result["availability_provenance_gate_enforced"].all()
     assert result["training_outcome_availability_enforced"].all()
     assert result["benchmark_stage"].eq("point_in_time_persistence_only").all()
 
@@ -147,4 +157,5 @@ def test_point_in_time_errors_cannot_reintroduce_late_rows() -> None:
     excluded = errors.loc[(errors["city_id"] == "C") & (errors["origin"] == 2010)]
     assert excluded.empty
     assert errors["availability_gate_enforced"].all()
+    assert errors["availability_provenance_gate_enforced"].all()
     assert errors["training_outcome_availability_enforced"].all()


### PR DESCRIPTION
Closes an auditability gap in the deployable forecast path. Parseable availability dates were previously sufficient even when no source evidence supported the claimed first-availability dates, and downstream persistence evaluation trusted a naked `point_in_time_available` boolean. The availability gate now requires nonblank predictor and concordance availability provenance, emits `availability_provenance_verified`, and the point-in-time persistence path requires that provenance gate in addition to the availability boolean. Adds regression tests for missing/blank provenance and downstream bypass attempts, and updates the locked availability contract.