### PR TITLE
Require provenance for training outcome availability

### DIFF
--- a/docs/point-in-time-persistence-gate.md
+++ b/docs/point-in-time-persistence-gate.md
@@ -5,11 +5,14 @@ A persistence benchmark can be out-of-sample in reference-year terms while still
 Deployable persistence evaluation requires all of the following:
 
 - the source-specific City Data Fitness eligibility flag (normally `growth_eligible`);
-- `point_in_time_available = true` for eligible forecast rows, produced from explicit predictor and concordance availability dates; and
-- an explicit `outcome_available_date` for every candidate training row.
+- `point_in_time_available = true` for eligible forecast rows, produced from explicit predictor and concordance availability dates with verified availability provenance;
+- an explicit `outcome_available_date` for every candidate training row; and
+- a nonblank `outcome_available_reference` identifying the evidence supporting that first-availability date.
 
 For each forecast origin, `evaluate_point_in_time_persistence_baselines` and `point_in_time_persistence_errors` resolve that origin's explicit `forecast_origin_date` and retain only historical rows whose outcomes were published on or before that date. A training interval whose reference period ended by the origin but whose statistical release occurred later is not valid training evidence for that origin. The same historical interval can become eligible training evidence at a later origin once its release date has passed.
 
-The deployable path reports both `candidate_training_rows` and `available_training_rows` and sets `training_outcome_availability_enforced = true`. Missing release dates, ambiguous forecast-origin dates, or fewer than two origins with published training outcomes fail closed.
+The deployable path reports both `candidate_training_rows` and `available_training_rows`, sets `training_outcome_availability_enforced = true`, and sets `training_outcome_provenance_enforced = true`. Missing release dates, missing or blank outcome-release provenance, ambiguous forecast-origin dates, or fewer than two origins with published training outcomes fail closed.
+
+Reference years, enumeration dates, endpoint years, current download dates, or analyst-entered assumptions are not sufficient provenance for `outcome_available_date`. The reference must point to the release notice, archived publication, metadata record, or equivalent evidence establishing when the outcome became observable.
 
 The original `evaluate_fitness_gated_persistence_baselines` remains available for retrospective sensitivity analysis and must not by itself be described as real-time or deployable-at-origin performance.

--- a/src/urban_growth/forecast_fitness.py
+++ b/src/urban_growth/forecast_fitness.py
@@ -163,13 +163,23 @@ def _origin_specific_point_in_time_panel(
     *,
     forecast_origin_date_column: str,
     outcome_available_column: str,
+    outcome_available_reference_column: str,
 ) -> tuple[pd.DataFrame, int, int]:
-    """Return one origin's test rows plus only training outcomes published by its as-of date."""
+    """Return one origin's test rows plus only auditable, published training outcomes."""
     require_columns(
         panel,
-        {forecast_origin_date_column, outcome_available_column},
+        {
+            forecast_origin_date_column,
+            outcome_available_column,
+            outcome_available_reference_column,
+        },
         source_name="point-in-time persistence panel",
     )
+    references = panel[outcome_available_reference_column].fillna("").astype(str).str.strip()
+    if references.eq("").any():
+        raise SourceSchemaError(
+            f"{outcome_available_reference_column} must provide provenance for every outcome release date"
+        )
     test = panel.loc[panel["period_start"].eq(origin)].copy()
     if test.empty:
         raise SourceSchemaError(f"Point-in-time panel lacks test rows for origin {origin}")
@@ -248,6 +258,7 @@ def evaluate_point_in_time_persistence_baselines(
     provenance_column: str = "availability_provenance_verified",
     forecast_origin_date_column: str = "forecast_origin_date",
     outcome_available_column: str = "outcome_available_date",
+    outcome_available_reference_column: str = "outcome_available_reference",
     outcome_column: str = "future_growth",
 ) -> pd.DataFrame:
     """Evaluate deployable persistence baselines with auditable timing gates."""
@@ -267,6 +278,7 @@ def evaluate_point_in_time_persistence_baselines(
                 origin,
                 forecast_origin_date_column=forecast_origin_date_column,
                 outcome_available_column=outcome_available_column,
+                outcome_available_reference_column=outcome_available_reference_column,
             )
         except SourceSchemaError as exc:
             if "No training outcomes were published" in str(exc):
@@ -279,6 +291,7 @@ def evaluate_point_in_time_persistence_baselines(
         scored["candidate_training_rows"] = candidate_train_n
         scored["available_training_rows"] = available_train_n
         scored["training_outcome_availability_enforced"] = True
+        scored["training_outcome_provenance_enforced"] = True
         frames.append(scored)
     if len(frames) < 2:
         raise SourceSchemaError(
@@ -295,6 +308,7 @@ def evaluate_point_in_time_persistence_baselines(
     result["availability_provenance_gate"] = provenance_column
     result["availability_provenance_gate_enforced"] = True
     result["training_outcome_availability_column"] = outcome_available_column
+    result["training_outcome_provenance_column"] = outcome_available_reference_column
     result["benchmark_stage"] = "point_in_time_persistence_only"
     result["forecast_horizon_years"] = horizon
     return result.sort_values(["origin", "model"]).reset_index(drop=True)
@@ -331,6 +345,7 @@ def point_in_time_persistence_errors(
     provenance_column: str = "availability_provenance_verified",
     forecast_origin_date_column: str = "forecast_origin_date",
     outcome_available_column: str = "outcome_available_date",
+    outcome_available_reference_column: str = "outcome_available_reference",
     outcome_column: str = "future_growth",
 ) -> pd.DataFrame:
     """Return row-level errors after auditable predictor and training-outcome timing gates."""
@@ -350,6 +365,7 @@ def point_in_time_persistence_errors(
                 origin,
                 forecast_origin_date_column=forecast_origin_date_column,
                 outcome_available_column=outcome_available_column,
+                outcome_available_reference_column=outcome_available_reference_column,
             )
         except SourceSchemaError as exc:
             if "No training outcomes were published" in str(exc):
@@ -362,6 +378,7 @@ def point_in_time_persistence_errors(
         scored["candidate_training_rows"] = candidate_train_n
         scored["available_training_rows"] = available_train_n
         scored["training_outcome_availability_enforced"] = True
+        scored["training_outcome_provenance_enforced"] = True
         frames.append(scored)
     if len(frames) < 2:
         raise SourceSchemaError(
@@ -376,6 +393,7 @@ def point_in_time_persistence_errors(
     result["availability_provenance_gate"] = provenance_column
     result["availability_provenance_gate_enforced"] = True
     result["training_outcome_availability_column"] = outcome_available_column
+    result["training_outcome_provenance_column"] = outcome_available_reference_column
     result["benchmark_stage"] = "point_in_time_persistence_only"
     result["forecast_horizon_years"] = horizon
     return result.reset_index(drop=True)

--- a/tests/test_forecast_fitness.py
+++ b/tests/test_forecast_fitness.py
@@ -35,6 +35,7 @@ def forecast_panel() -> pd.DataFrame:
                     "availability_provenance_verified": True,
                     "forecast_origin_date": f"{start}-12-31",
                     "outcome_available_date": f"{end}-06-30",
+                    "outcome_available_reference": f"official-release-{end}",
                 }
             )
     frame = pd.DataFrame(rows)
@@ -120,6 +121,7 @@ def test_point_in_time_persistence_cannot_score_late_test_rows() -> None:
     assert result["availability_gate_enforced"].all()
     assert result["availability_provenance_gate_enforced"].all()
     assert result["training_outcome_availability_enforced"].all()
+    assert result["training_outcome_provenance_enforced"].all()
     assert result["benchmark_stage"].eq("point_in_time_persistence_only").all()
 
 
@@ -131,11 +133,25 @@ def test_point_in_time_persistence_excludes_unpublished_training_outcomes() -> N
     assert at_2010["candidate_training_rows"].eq(6).all()
     assert at_2010["available_training_rows"].eq(3).all()
     assert at_2010["training_outcome_availability_enforced"].all()
+    assert at_2010["training_outcome_provenance_enforced"].all()
 
 
 def test_point_in_time_persistence_requires_outcome_release_dates() -> None:
     panel = forecast_panel().drop(columns="outcome_available_date")
     with pytest.raises(SourceSchemaError, match="outcome_available_date"):
+        evaluate_point_in_time_persistence_baselines(panel, [2005, 2010])
+
+
+def test_point_in_time_persistence_requires_outcome_release_provenance() -> None:
+    panel = forecast_panel().drop(columns="outcome_available_reference")
+    with pytest.raises(SourceSchemaError, match="outcome_available_reference"):
+        evaluate_point_in_time_persistence_baselines(panel, [2005, 2010])
+
+
+def test_point_in_time_persistence_rejects_blank_outcome_release_provenance() -> None:
+    panel = forecast_panel()
+    panel.loc[0, "outcome_available_reference"] = "  "
+    with pytest.raises(SourceSchemaError, match="provenance for every outcome release date"):
         evaluate_point_in_time_persistence_baselines(panel, [2005, 2010])
 
 
@@ -159,3 +175,4 @@ def test_point_in_time_errors_cannot_reintroduce_late_rows() -> None:
     assert errors["availability_gate_enforced"].all()
     assert errors["availability_provenance_gate_enforced"].all()
     assert errors["training_outcome_availability_enforced"].all()
+    assert errors["training_outcome_provenance_enforced"].all()


### PR DESCRIPTION
Closes the remaining manual-date bypass in deployable persistence evaluation. PR #111 required provenance for predictor and concordance first-availability dates, but `outcome_available_date` was still accepted without evidence. The point-in-time persistence path now requires nonblank `outcome_available_reference` provenance for every outcome release date, propagates explicit provenance-enforcement metadata into aggregate metrics and row-level errors, and fails closed on missing or blank references. Adds regression tests and updates the locked point-in-time persistence contract.