### PR TITLE
Register rolling forecast-origin dates

### DIFF
--- a/docs/forecast-data-availability.md
+++ b/docs/forecast-data-availability.md
@@ -13,31 +13,34 @@ The repository's core rolling-forecast panels use integer years in `period_start
 Any result described as **deployable at origin**, **real-time**, or a point-in-time forecast must record:
 
 - `forecast_origin_date`: the actual as-of date at which the forecast is claimed to have been formed;
+- `forecast_origin_registration`: the predeclared rule used to choose that as-of date;
 - `predictor_available_date`: first date the population/statistical information needed for the predictor was available to the analyst;
 - `predictor_availability_source`: auditable source evidence supporting that first-availability date;
 - `concordance_available_date`: first date the geography/crosswalk evidence needed to construct the comparable predictor was available;
 - `concordance_availability_source`: auditable source evidence supporting that concordance first-availability date.
 
+The forecast-origin date is a design choice, not an external publication event. To prevent ex-post timing choice, the generic rolling-origin gate requires the date to fall within the year declared by `period_start`, resolve to one as-of date per origin year, follow one month-day rule across rolling origins, and use one nonblank registered origin rule for the panel. A source-specific evaluator may define a different timing policy only by making that policy explicit rather than silently overriding the generic gate.
+
 Both evidence dates must be on or before `forecast_origin_date`. Missing origin or availability dates fail closed. Missing or blank availability-source provenance also fails closed. Reference year, enumeration date, `period_start`, period end, file vintage, current download date, and an unsupported analyst-entered date are not substitutes for first availability.
 
-`src/urban_growth/forecast_availability.py` implements this rule and produces `point_in_time_available`, `availability_provenance_verified`, and explicit exclusion reasons. The default origin field is `forecast_origin_date`; callers may override the column name only when they supply another explicit date field with the same semantics.
+`src/urban_growth/forecast_availability.py` implements this rule and produces `point_in_time_available`, `availability_provenance_verified`, `forecast_origin_registration_verified`, and explicit exclusion reasons. The default origin field is `forecast_origin_date`; callers may override the column name only when they supply another explicit date field with the same semantics.
 
-A downstream persistence evaluator must not trust a manually supplied `point_in_time_available` flag by itself. The deployable persistence path also requires `availability_provenance_verified = true`, which is produced only after the availability gate validates the required provenance fields.
+A downstream persistence evaluator must not trust a manually supplied `point_in_time_available` flag by itself. The deployable persistence path also requires the verified availability metadata produced by the point-in-time gate.
 
 ## Consequences
 
 Retrospective analyses may still use later-released evidence when clearly labeled retrospective. They must not be promoted to deployable-at-origin evidence.
 
-For rolling persistence tests, an outcome observed through an origin year is not automatically training information at that origin. If its required source release occurred after the origin, it cannot enter the real-time training set until a later origin. The deployable persistence evaluator therefore separately requires an explicit `outcome_available_date` for training outcomes.
+For rolling persistence tests, an outcome observed through an origin year is not automatically training information at that origin. If its required source release occurred after the origin, it cannot enter the real-time training set until a later origin. The deployable persistence evaluator therefore separately requires an explicit `outcome_available_date` and source-backed outcome-release evidence for training outcomes.
 
-For Mexico, this means census/count reference dates and locality-equivalence evidence require actual release/availability dates **and source evidence for those dates** before the multiwave panel can be called deployable. The existing year-only `evidence_reference_year <= endpoint_year` concordance check prevents future-reference geography but does not by itself establish point-in-time availability.
+For Mexico, this means census/count reference dates and locality-equivalence evidence require actual release/availability dates **and source evidence for those dates** before the multiwave panel can be called deployable. The forecast-origin calendar rule must also be registered before comparing those release dates to a claimed historical as-of date. The existing year-only `evidence_reference_year <= endpoint_year` concordance check prevents future-reference geography but does not by itself establish point-in-time availability.
 
 For revised international products such as current-vintage WUP, WPP, or retrospective GHSL histories, the same distinction applies: current-vintage historical observations can support retrospective sensitivity analysis without constituting historical real-time information.
 
 ## Result classification
 
-- `point_in_time_available = true`: required predictor and concordance evidence existed by the explicit forecast-origin date and the first-availability claims have recorded provenance.
+- `point_in_time_available = true`: required predictor and concordance evidence existed by a registered forecast-origin date and the first-availability claims have recorded provenance.
 - `point_in_time_available = false`: retrospective-only for that origin.
-- unknown evidence availability, missing forecast-origin date, or missing availability provenance: fail closed; do not infer availability from the reference period.
+- unknown evidence availability, missing or inconsistent forecast-origin registration, or missing availability provenance: fail closed; do not infer availability from the reference period.
 
 This gate is orthogonal to the City Data Fitness Standard and should be applied in addition to source-specific growth/headline eligibility before a forecast is described as deployable.

--- a/src/urban_growth/forecast_availability.py
+++ b/src/urban_growth/forecast_availability.py
@@ -18,6 +18,54 @@ def _require_availability_provenance(frame: pd.DataFrame, column: str) -> pd.Ser
     return values
 
 
+def _validate_forecast_origin_registration(
+    frame: pd.DataFrame,
+    *,
+    origin_column: str,
+    registration_column: str,
+) -> pd.Series:
+    """Validate that rolling forecast origins follow one registered calendar rule."""
+    registration = frame[registration_column].astype("string").str.strip()
+    if registration.isna().any() or registration.eq("").any():
+        raise SourceSchemaError(
+            f"{registration_column} must document the predeclared forecast-origin rule"
+        )
+
+    origin = pd.to_datetime(frame[origin_column], errors="coerce")
+    if origin.isna().any():
+        raise SourceSchemaError(f"{origin_column} must contain valid forecast-origin dates")
+
+    period_start = pd.to_numeric(frame["period_start"], errors="coerce")
+    if period_start.isna().any() or period_start.mod(1).ne(0).any():
+        raise SourceSchemaError("period_start must contain integer forecast-origin years")
+    origin_year = origin.dt.year.astype(float)
+    if origin_year.ne(period_start).any():
+        raise SourceSchemaError(
+            f"{origin_column} must fall within the year declared by period_start"
+        )
+
+    origin_frame = pd.DataFrame(
+        {
+            "period_start": period_start.astype(int),
+            "origin_date": origin.dt.normalize(),
+            "calendar_rule": origin.dt.strftime("%m-%d"),
+        }
+    )
+    if origin_frame.groupby("period_start")["origin_date"].nunique().gt(1).any():
+        raise SourceSchemaError(
+            f"{origin_column} must resolve to one as-of date per forecast-origin year"
+        )
+    if origin_frame["calendar_rule"].nunique() != 1:
+        raise SourceSchemaError(
+            f"{origin_column} must follow one registered month-day rule across rolling origins"
+        )
+    if registration.nunique() != 1:
+        raise SourceSchemaError(
+            f"{registration_column} must identify one registered origin rule for the panel"
+        )
+    return registration
+
+
 def apply_forecast_availability_gate(
     panel: pd.DataFrame,
     *,
@@ -26,14 +74,15 @@ def apply_forecast_availability_gate(
     concordance_available_column: str = "concordance_available_date",
     predictor_provenance_column: str = "predictor_availability_source",
     concordance_provenance_column: str = "concordance_availability_source",
+    origin_registration_column: str = "forecast_origin_registration",
 ) -> pd.DataFrame:
-    """Mark whether auditable predictor evidence was available at forecast origin.
+    """Mark whether auditable predictor evidence was available at a registered origin.
 
     Reference periods are not publication dates, and integer origin years are not
-    timestamps. A historical predictor may only be called deployable at an origin
-    when an explicit forecast-origin date is supplied, both statistical and
-    geography/concordance evidence were available no later than that date, and the
-    claimed first-availability dates have nonblank source provenance.
+    timestamps. A historical predictor may only be called deployable when its as-of
+    date follows a predeclared rolling-origin rule, both statistical and geography
+    evidence were available by that date, and the claimed first-availability dates
+    have nonblank source provenance.
     """
     require_columns(
         panel,
@@ -46,6 +95,7 @@ def apply_forecast_availability_gate(
             concordance_available_column,
             predictor_provenance_column,
             concordance_provenance_column,
+            origin_registration_column,
         },
         source_name="forecast availability panel",
     )
@@ -58,13 +108,17 @@ def apply_forecast_availability_gate(
     origin = pd.to_datetime(out[origin_column], errors="coerce")
     predictor_available = pd.to_datetime(out[predictor_available_column], errors="coerce")
     concordance_available = pd.to_datetime(out[concordance_available_column], errors="coerce")
-    if origin.isna().any():
-        raise SourceSchemaError(f"{origin_column} must contain valid forecast-origin dates")
     if predictor_available.isna().any():
         raise SourceSchemaError(f"{predictor_available_column} must be known for every forecast row")
     if concordance_available.isna().any():
         raise SourceSchemaError(f"{concordance_available_column} must be known for every forecast row")
 
+    out[origin_registration_column] = _validate_forecast_origin_registration(
+        out,
+        origin_column=origin_column,
+        registration_column=origin_registration_column,
+    )
+    out["forecast_origin_registration_verified"] = True
     out[predictor_provenance_column] = _require_availability_provenance(
         out, predictor_provenance_column
     )
@@ -78,6 +132,7 @@ def apply_forecast_availability_gate(
         out["predictor_available_at_origin"]
         & out["concordance_available_at_origin"]
         & out["availability_provenance_verified"]
+        & out["forecast_origin_registration_verified"]
     )
     out["availability_exclusion_reason"] = ""
     out.loc[~out["predictor_available_at_origin"], "availability_exclusion_reason"] = (
@@ -92,16 +147,23 @@ def apply_forecast_availability_gate(
 
 
 def point_in_time_forecast_sample(panel: pd.DataFrame) -> pd.DataFrame:
-    """Return only rows whose required predictor evidence existed at the origin."""
+    """Return only rows whose required evidence existed at a registered origin."""
     require_columns(
         panel,
-        {"point_in_time_available", "availability_provenance_verified"},
+        {
+            "point_in_time_available",
+            "availability_provenance_verified",
+            "forecast_origin_registration_verified",
+        },
         source_name="forecast availability panel",
     )
     eligible = panel["point_in_time_available"]
     provenance = panel["availability_provenance_verified"]
+    origin_registration = panel["forecast_origin_registration_verified"]
     if not pd.api.types.is_bool_dtype(eligible.dtype):
         raise SourceSchemaError("point_in_time_available must be boolean")
     if not pd.api.types.is_bool_dtype(provenance.dtype) or not provenance.all():
         raise SourceSchemaError("Point-in-time sample requires verified availability provenance")
+    if not pd.api.types.is_bool_dtype(origin_registration.dtype) or not origin_registration.all():
+        raise SourceSchemaError("Point-in-time sample requires verified forecast-origin registration")
     return panel.loc[eligible].copy().reset_index(drop=True)

--- a/tests/test_forecast_availability.py
+++ b/tests/test_forecast_availability.py
@@ -15,10 +15,17 @@ def _panel() -> pd.DataFrame:
             "period_start": [2000, 2000],
             "period_end": [2005, 2005],
             "forecast_origin_date": ["2000-01-01", "2000-01-01"],
+            "forecast_origin_registration": ["annual January 1 as-of", "annual January 1 as-of"],
             "predictor_available_date": ["1999-12-01", "2000-06-01"],
             "concordance_available_date": ["1999-11-01", "1999-11-01"],
-            "predictor_availability_source": ["official statistical release", "official statistical release"],
-            "concordance_availability_source": ["official geography release", "official geography release"],
+            "predictor_availability_source": [
+                "official statistical release",
+                "official statistical release",
+            ],
+            "concordance_availability_source": [
+                "official geography release",
+                "official geography release",
+            ],
         }
     )
 
@@ -29,6 +36,7 @@ def test_availability_gate_blocks_post_origin_predictor() -> None:
     assert not bool(result.loc[1, "point_in_time_available"])
     assert result.loc[1, "availability_exclusion_reason"] == "predictor_not_available_at_origin"
     assert result["availability_provenance_verified"].all()
+    assert result["forecast_origin_registration_verified"].all()
 
 
 def test_availability_gate_blocks_post_origin_concordance() -> None:
@@ -59,6 +67,34 @@ def test_availability_gate_requires_concordance_provenance() -> None:
         apply_forecast_availability_gate(frame)
 
 
+def test_availability_gate_requires_origin_registration() -> None:
+    frame = _panel().iloc[[0]].copy()
+    frame["forecast_origin_registration"] = " "
+    with pytest.raises(SourceSchemaError, match="predeclared forecast-origin rule"):
+        apply_forecast_availability_gate(frame)
+
+
+def test_forecast_origin_date_must_match_declared_origin_year() -> None:
+    frame = _panel().iloc[[0]].copy()
+    frame["forecast_origin_date"] = "2001-01-01"
+    with pytest.raises(SourceSchemaError, match="year declared by period_start"):
+        apply_forecast_availability_gate(frame)
+
+
+def test_rolling_origins_must_use_one_calendar_rule() -> None:
+    first = _panel().iloc[[0]].copy()
+    second = _panel().iloc[[0]].copy()
+    second["city_id"] = "C"
+    second["period_start"] = 2005
+    second["period_end"] = 2010
+    second["forecast_origin_date"] = "2005-06-30"
+    second["predictor_available_date"] = "2004-12-01"
+    second["concordance_available_date"] = "2004-11-01"
+    frame = pd.concat([first, second], ignore_index=True)
+    with pytest.raises(SourceSchemaError, match="one registered month-day rule"):
+        apply_forecast_availability_gate(frame)
+
+
 def test_integer_period_start_is_not_used_as_timestamp() -> None:
     frame = _panel().iloc[[0]].drop(columns=["forecast_origin_date"])
     with pytest.raises(SourceSchemaError, match="forecast_origin_date"):
@@ -81,4 +117,11 @@ def test_point_in_time_sample_rejects_unverified_provenance_flag() -> None:
     result = apply_forecast_availability_gate(_panel())
     result["availability_provenance_verified"] = False
     with pytest.raises(SourceSchemaError, match="verified availability provenance"):
+        point_in_time_forecast_sample(result)
+
+
+def test_point_in_time_sample_rejects_unverified_origin_registration() -> None:
+    result = apply_forecast_availability_gate(_panel())
+    result["forecast_origin_registration_verified"] = False
+    with pytest.raises(SourceSchemaError, match="verified forecast-origin registration"):
         point_in_time_forecast_sample(result)


### PR DESCRIPTION
Closes an ex-post timing-choice gap in point-in-time forecast evaluation. Availability dates were source-backed, but `forecast_origin_date` itself could still be chosen arbitrarily within an origin year. The generic availability gate now requires a nonblank `forecast_origin_registration`, verifies that each as-of date falls in its declared `period_start` year, resolves to one date per origin year, and follows one month-day rule across rolling origins. It emits `forecast_origin_registration_verified`, includes that flag in point-in-time eligibility, and the point-in-time sample fails closed if registration is absent or unverified. Regression tests cover blank registration, year mismatch, inconsistent calendar cutoffs, and downstream registration enforcement. Documentation updated.