### PR TITLE
Preserve origin risk-set denominator for forecast coverage

### DIFF
--- a/docs/forecast-origin-risk-set-coverage.md
+++ b/docs/forecast-origin-risk-set-coverage.md
@@ -1,0 +1,27 @@
+# Forecast origin risk-set coverage policy
+
+## Problem
+
+A forecast evaluation can use an origin-defined threshold and still reintroduce survivorship bias if a city is admitted to the evaluation panel only when its future endpoint exists. The scoring sample then conditions on future observability even though the scientific risk set should be fixed using information available at the forecast origin.
+
+`build_forecast_intervals` currently produces an observed-outcome scoring panel: it requires lag, origin, outcome-start, and outcome-end observations. That is appropriate for computing forecast error on rows with observable outcomes, but it is not by itself a valid denominator for claims about the origin population of cities.
+
+## Locked rule
+
+For coverage, attrition, survivorship, and representativeness statements, define the forecast risk set using only information available at the origin:
+
+- the city exists at the lag year required to construct the predictor;
+- the city exists at the forecast origin; and
+- any origin-side eligibility rule is evaluated without using future population or future observation status.
+
+After that risk set is fixed, classify future outcome observability separately. Missing future endpoints and disallowed future outcome types remain in the risk-set denominator.
+
+`src/urban_growth/forecast_coverage.py` implements this separation. `origin_risk_set_outcome_coverage` returns both the city-origin risk-set rows and an origin-level coverage summary. `observed_outcome_scoring_keys` identifies the subset that can actually be scored without erasing the denominator.
+
+## Interpretation
+
+A low or differential `observed_outcome_share` is adverse evidence about forecast-evaluation representativeness. It must not be hidden by reporting only the observed scoring sample.
+
+No universal acceptable coverage threshold is imposed here. A source-specific or registered analysis may define one before looking at results. Until then, headline claims must report the origin risk-set denominator, observed-outcome numerator, and exclusions rather than treating observed rows as the full cohort.
+
+Changing a future population value, adding a future entrant, or removing a future endpoint must never change whether a city belonged to the origin risk set.

--- a/src/urban_growth/forecast_coverage.py
+++ b/src/urban_growth/forecast_coverage.py
@@ -1,0 +1,130 @@
+"""Origin-defined forecast risk-set coverage diagnostics.
+
+Forecast scoring necessarily uses observed outcomes, but the population of cities
+eligible at a forecast origin must not be defined by whether a future outcome is
+observed. This module preserves the origin risk-set denominator and makes future
+outcome observability an explicit, separately auditable property.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
+
+
+def origin_risk_set_outcome_coverage(
+    city_year_panel: pd.DataFrame,
+    origins: list[int],
+    *,
+    lookback_years: int = 5,
+    horizon_years: int = 5,
+    outcome_gap_years: int = 0,
+    allowed_outcome_types: set[str] | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Return row-level and origin-level future-outcome coverage for an origin risk set.
+
+    Risk-set membership uses only lag/origin information. Future endpoint presence
+    and allowed outcome type are measured after membership is fixed. Cities with
+    missing or disallowed future outcomes therefore remain in the denominator.
+    """
+    required = {"city_id", "year", "population", "observation_type"}
+    require_columns(city_year_panel, required, source_name="forecast coverage source")
+    reject_duplicate_keys(
+        city_year_panel, ["city_id", "year"], source_name="forecast coverage source"
+    )
+    if lookback_years <= 0 or horizon_years <= 0 or outcome_gap_years < 0:
+        raise SourceSchemaError("Forecast lookback/horizon must be positive and gap non-negative")
+    if not origins or any(not isinstance(year, int) for year in origins):
+        raise SourceSchemaError("Forecast origins must be a non-empty list of integer years")
+    allowed = {"estimate"} if allowed_outcome_types is None else allowed_outcome_types
+    if not allowed:
+        raise SourceSchemaError("At least one outcome observation type must be allowed")
+
+    source = city_year_panel.set_index(["city_id", "year"])
+    city_ids = source.index.get_level_values("city_id").unique()
+    frames: list[pd.DataFrame] = []
+    for origin in sorted(set(origins)):
+        lag_year = origin - lookback_years
+        outcome_start_year = origin + outcome_gap_years
+        outcome_end_year = outcome_start_year + horizon_years
+        keys = pd.MultiIndex.from_product(
+            [city_ids, [lag_year, origin, outcome_start_year, outcome_end_year]],
+            names=["city_id", "year"],
+        )
+        wide = source.reindex(keys).reset_index().pivot(index="city_id", columns="year")
+
+        lag_population = wide[("population", lag_year)]
+        origin_population = wide[("population", origin)]
+        predictor_eligible = lag_population.notna() & origin_population.notna()
+        risk = wide.loc[predictor_eligible].copy()
+        if risk.empty:
+            continue
+
+        outcome_start_population = risk[("population", outcome_start_year)]
+        outcome_end_population = risk[("population", outcome_end_year)]
+        outcome_start_type = risk[("observation_type", outcome_start_year)]
+        outcome_end_type = risk[("observation_type", outcome_end_year)]
+        outcome_values_present = outcome_start_population.notna() & outcome_end_population.notna()
+        outcome_types_allowed = outcome_start_type.isin(allowed) & outcome_end_type.isin(allowed)
+        outcome_observed = outcome_values_present & outcome_types_allowed
+
+        rows = pd.DataFrame(index=risk.index)
+        rows["origin"] = origin
+        rows["lag_year"] = lag_year
+        rows["outcome_start_year"] = outcome_start_year
+        rows["outcome_end_year"] = outcome_end_year
+        rows["origin_risk_set_member"] = True
+        rows["outcome_values_present"] = outcome_values_present
+        rows["outcome_types_allowed"] = outcome_types_allowed
+        rows["outcome_observed"] = outcome_observed
+        rows["outcome_coverage_exclusion_reason"] = ""
+        rows.loc[~outcome_values_present, "outcome_coverage_exclusion_reason"] = (
+            "missing_future_outcome_value"
+        )
+        rows.loc[
+            outcome_values_present & ~outcome_types_allowed,
+            "outcome_coverage_exclusion_reason",
+        ] = "future_outcome_type_not_allowed"
+        frames.append(rows.reset_index())
+
+    if not frames:
+        raise SourceSchemaError("No origin risk-set members have complete lag/origin predictors")
+
+    row_level = pd.concat(frames, ignore_index=True).sort_values(["origin", "city_id"])
+    summary = (
+        row_level.groupby("origin", as_index=False)
+        .agg(
+            origin_risk_set_rows=("city_id", "size"),
+            observed_outcome_rows=("outcome_observed", "sum"),
+            missing_outcome_rows=("outcome_observed", lambda values: int((~values).sum())),
+        )
+        .sort_values("origin")
+        .reset_index(drop=True)
+    )
+    summary["observed_outcome_share"] = (
+        summary["observed_outcome_rows"] / summary["origin_risk_set_rows"]
+    )
+    summary["coverage_denominator_rule"] = "lag_and_origin_predictors_only"
+    summary["future_outcome_used_for_membership"] = False
+    return row_level.reset_index(drop=True), summary
+
+
+def observed_outcome_scoring_keys(coverage_rows: pd.DataFrame) -> pd.DataFrame:
+    """Return observed city-origin keys without discarding the auditable denominator."""
+    require_columns(
+        coverage_rows,
+        {"city_id", "origin", "origin_risk_set_member", "outcome_observed"},
+        source_name="forecast coverage rows",
+    )
+    if not pd.api.types.is_bool_dtype(coverage_rows["origin_risk_set_member"].dtype):
+        raise SourceSchemaError("origin_risk_set_member must be boolean")
+    if not pd.api.types.is_bool_dtype(coverage_rows["outcome_observed"].dtype):
+        raise SourceSchemaError("outcome_observed must be boolean")
+    if not coverage_rows["origin_risk_set_member"].all():
+        raise SourceSchemaError("Coverage table must contain origin risk-set members only")
+    return (
+        coverage_rows.loc[coverage_rows["outcome_observed"], ["city_id", "origin"]]
+        .drop_duplicates()
+        .reset_index(drop=True)
+    )

--- a/src/urban_growth/forecast_coverage.py
+++ b/src/urban_growth/forecast_coverage.py
@@ -48,8 +48,9 @@ def origin_risk_set_outcome_coverage(
         lag_year = origin - lookback_years
         outcome_start_year = origin + outcome_gap_years
         outcome_end_year = outcome_start_year + horizon_years
+        required_years = sorted({lag_year, origin, outcome_start_year, outcome_end_year})
         keys = pd.MultiIndex.from_product(
-            [city_ids, [lag_year, origin, outcome_start_year, outcome_end_year]],
+            [city_ids, required_years],
             names=["city_id", "year"],
         )
         wide = source.reindex(keys).reset_index().pivot(index="city_id", columns="year")

--- a/tests/test_forecast_coverage.py
+++ b/tests/test_forecast_coverage.py
@@ -1,0 +1,62 @@
+import pandas as pd
+
+from urban_growth.forecast_coverage import (
+    observed_outcome_scoring_keys,
+    origin_risk_set_outcome_coverage,
+)
+
+
+def _panel() -> pd.DataFrame:
+    rows = []
+    for city_id, populations in {
+        "A": {1995: 40_000, 2000: 50_000, 2005: 60_000},
+        "B": {1995: 30_000, 2000: 45_000},
+        "C": {1995: 20_000, 2000: 25_000, 2005: 27_000},
+    }.items():
+        for year, population in populations.items():
+            rows.append(
+                {
+                    "city_id": city_id,
+                    "year": year,
+                    "population": population,
+                    "observation_type": "estimate",
+                }
+            )
+    frame = pd.DataFrame(rows)
+    frame.loc[
+        (frame["city_id"] == "C") & frame["year"].eq(2005),
+        "observation_type",
+    ] = "projection"
+    return frame
+
+
+def test_future_missing_city_remains_in_origin_risk_set_denominator() -> None:
+    rows, summary = origin_risk_set_outcome_coverage(_panel(), [2000])
+    assert set(rows["city_id"]) == {"A", "B", "C"}
+    b = rows.loc[rows["city_id"].eq("B")].iloc[0]
+    assert not bool(b["outcome_observed"])
+    assert b["outcome_coverage_exclusion_reason"] == "missing_future_outcome_value"
+    assert summary.loc[0, "origin_risk_set_rows"] == 3
+    assert summary.loc[0, "observed_outcome_rows"] == 1
+    assert summary.loc[0, "missing_outcome_rows"] == 2
+    assert not bool(summary.loc[0, "future_outcome_used_for_membership"])
+
+
+def test_disallowed_future_type_stays_in_denominator_but_not_scoring_keys() -> None:
+    rows, _ = origin_risk_set_outcome_coverage(_panel(), [2000])
+    c = rows.loc[rows["city_id"].eq("C")].iloc[0]
+    assert bool(c["outcome_values_present"])
+    assert not bool(c["outcome_types_allowed"])
+    assert c["outcome_coverage_exclusion_reason"] == "future_outcome_type_not_allowed"
+    scoring = observed_outcome_scoring_keys(rows)
+    assert scoring.to_dict("records") == [{"city_id": "A", "origin": 2000}]
+
+
+def test_future_population_change_cannot_change_origin_risk_set_membership() -> None:
+    original_rows, _ = origin_risk_set_outcome_coverage(_panel(), [2000])
+    changed = _panel()
+    changed.loc[(changed["city_id"] == "A") & changed["year"].eq(2005), "population"] = 1
+    changed_rows, _ = origin_risk_set_outcome_coverage(changed, [2000])
+    assert original_rows[["city_id", "origin_risk_set_member"]].equals(
+        changed_rows[["city_id", "origin_risk_set_member"]]
+    )


### PR DESCRIPTION
Closes a survivorship/attrition visibility gap in forecast evaluation. The existing forecast interval builder emits only rows with complete future outcomes, which is appropriate for scoring but can silently condition the evaluation sample on future observability. This PR adds an origin-defined coverage audit that fixes risk-set membership using lag/origin predictor information only, keeps missing/disallowed future outcomes in the denominator, reports observed-outcome coverage by origin, and provides observed scoring keys without erasing the auditable denominator. Regression tests verify that missing future endpoints, disallowed future types, and changes to future population cannot alter origin risk-set membership. Documentation locks the interpretation: observed-outcome scoring samples must not be treated as the full origin cohort without reporting risk-set coverage.