### PR TITLE
Enforce origin risk-set coverage for headline persistence

### DIFF
--- a/docs/headline-persistence-coverage-gate.md
+++ b/docs/headline-persistence-coverage-gate.md
@@ -1,0 +1,38 @@
+# Headline persistence coverage gate
+
+## Problem
+
+A forecast can be point-in-time correct and still report performance on a future-selected subset. The lower-level persistence evaluators score rows with observed outcomes; by construction they cannot score a city whose future outcome is missing. That scoring requirement must not be allowed to redefine the origin cohort or hide future attrition.
+
+## Locked rule
+
+Any persistence result promoted beyond retrospective or intermediate point-in-time analysis must carry an origin-defined outcome-coverage denominator.
+
+The denominator must come from `origin_risk_set_outcome_coverage` or an equivalent table satisfying the same contract:
+
+- one row per forecast origin;
+- `origin_risk_set_rows` defined from lag and origin predictor availability only;
+- `observed_outcome_rows` plus `missing_outcome_rows` exactly equals the origin risk set;
+- `observed_outcome_share` agrees with those counts;
+- `coverage_denominator_rule = lag_and_origin_predictors_only`;
+- `future_outcome_used_for_membership = false`.
+
+The headline-qualified functions are:
+
+- `evaluate_headline_point_in_time_persistence` for aggregate metrics;
+- `headline_point_in_time_persistence_errors` for row-level errors.
+
+They call the existing point-in-time timing and provenance gates, then merge validated origin-risk-set coverage onto every result. They also verify that the number of scored rows cannot exceed the number of observed outcomes recorded for that origin.
+
+## Classification
+
+`evaluate_point_in_time_persistence_baselines` and `point_in_time_persistence_errors` remain valid lower-level point-in-time building blocks. Their `benchmark_stage = point_in_time_persistence_only` does **not** establish that future-outcome attrition was audited.
+
+Only results with both:
+
+- `origin_risk_set_coverage_enforced = true`, and
+- `headline_coverage_contract_enforced = true`
+
+may be described as having passed the origin-cohort coverage gate.
+
+Passing this gate does not mean outcome coverage is high. The actual `observed_outcome_share` must still be reported and interpreted. A low share is evidence of attrition risk, not something this gate repairs.

--- a/src/urban_growth/forecast_headline.py
+++ b/src/urban_growth/forecast_headline.py
@@ -1,0 +1,129 @@
+"""Headline-qualified persistence evaluation with origin risk-set coverage enforcement."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from urban_growth.forecast_fitness import (
+    evaluate_point_in_time_persistence_baselines,
+    point_in_time_persistence_errors,
+)
+from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
+
+
+COVERAGE_COLUMNS = {
+    "origin",
+    "origin_risk_set_rows",
+    "observed_outcome_rows",
+    "missing_outcome_rows",
+    "observed_outcome_share",
+    "coverage_denominator_rule",
+    "future_outcome_used_for_membership",
+}
+
+
+def _validate_origin_coverage(
+    coverage_summary: pd.DataFrame,
+    origins: list[int],
+) -> pd.DataFrame:
+    """Validate an origin-defined outcome-coverage denominator before headline use."""
+    require_columns(
+        coverage_summary,
+        COVERAGE_COLUMNS,
+        source_name="headline forecast coverage summary",
+    )
+    reject_duplicate_keys(
+        coverage_summary,
+        ["origin"],
+        source_name="headline forecast coverage summary",
+    )
+    if not origins or len(set(origins)) != len(origins):
+        raise SourceSchemaError("Headline forecast origins must be unique and non-empty")
+
+    coverage = coverage_summary.copy()
+    declared = sorted(origins)
+    available = set(coverage["origin"])
+    missing = [origin for origin in declared if origin not in available]
+    if missing:
+        raise SourceSchemaError(f"Origin risk-set coverage is missing declared origins: {missing}")
+    coverage = coverage.loc[coverage["origin"].isin(declared)].copy()
+
+    risk = pd.to_numeric(coverage["origin_risk_set_rows"], errors="coerce")
+    observed = pd.to_numeric(coverage["observed_outcome_rows"], errors="coerce")
+    missing_rows = pd.to_numeric(coverage["missing_outcome_rows"], errors="coerce")
+    share = pd.to_numeric(coverage["observed_outcome_share"], errors="coerce")
+    if risk.isna().any() or risk.le(0).any():
+        raise SourceSchemaError("origin_risk_set_rows must be positive and known")
+    if observed.isna().any() or observed.lt(0).any() or observed.gt(risk).any():
+        raise SourceSchemaError("observed_outcome_rows must be between zero and the origin risk set")
+    if missing_rows.isna().any() or missing_rows.lt(0).any():
+        raise SourceSchemaError("missing_outcome_rows must be non-negative and known")
+    if not (observed + missing_rows).eq(risk).all():
+        raise SourceSchemaError("Observed plus missing outcome rows must equal the origin risk set")
+    expected_share = observed / risk
+    if share.isna().any() or not np.allclose(share, expected_share, rtol=0, atol=1e-12):
+        raise SourceSchemaError("observed_outcome_share disagrees with the coverage counts")
+    if coverage["coverage_denominator_rule"].ne("lag_and_origin_predictors_only").any():
+        raise SourceSchemaError("Headline coverage denominator must use lag/origin predictors only")
+    future_membership = coverage["future_outcome_used_for_membership"]
+    if not pd.api.types.is_bool_dtype(future_membership.dtype):
+        raise SourceSchemaError("future_outcome_used_for_membership must be boolean")
+    if future_membership.any():
+        raise SourceSchemaError("Future outcome observability cannot define headline risk-set membership")
+
+    return coverage.sort_values("origin").reset_index(drop=True)
+
+
+def _attach_coverage_to_metrics(
+    metrics: pd.DataFrame,
+    coverage: pd.DataFrame,
+) -> pd.DataFrame:
+    result = metrics.merge(coverage, on="origin", how="left", validate="many_to_one")
+    if result[list(COVERAGE_COLUMNS - {"origin"})].isna().any().any():
+        raise SourceSchemaError("Persistence metrics could not be matched to origin risk-set coverage")
+    max_scored = result.groupby("origin")["n"].max()
+    observed = coverage.set_index("origin")["observed_outcome_rows"]
+    if (max_scored > observed.reindex(max_scored.index)).any():
+        raise SourceSchemaError("Scored persistence rows exceed observed outcomes in the origin risk set")
+    result["origin_risk_set_coverage_enforced"] = True
+    result["headline_coverage_contract_enforced"] = True
+    result["benchmark_stage"] = "point_in_time_persistence_with_origin_coverage"
+    return result.sort_values(["origin", "model"]).reset_index(drop=True)
+
+
+def evaluate_headline_point_in_time_persistence(
+    panel: pd.DataFrame,
+    origins: list[int],
+    coverage_summary: pd.DataFrame,
+    **kwargs: object,
+) -> pd.DataFrame:
+    """Evaluate point-in-time persistence while preserving the origin risk-set denominator."""
+    coverage = _validate_origin_coverage(coverage_summary, origins)
+    metrics = evaluate_point_in_time_persistence_baselines(panel, origins, **kwargs)
+    return _attach_coverage_to_metrics(metrics, coverage)
+
+
+def headline_point_in_time_persistence_errors(
+    panel: pd.DataFrame,
+    origins: list[int],
+    coverage_summary: pd.DataFrame,
+    **kwargs: object,
+) -> pd.DataFrame:
+    """Return row-level point-in-time errors with origin risk-set coverage attached."""
+    coverage = _validate_origin_coverage(coverage_summary, origins)
+    errors = point_in_time_persistence_errors(panel, origins, **kwargs)
+    result = errors.merge(coverage, on="origin", how="left", validate="many_to_one")
+    if result[list(COVERAGE_COLUMNS - {"origin"})].isna().any().any():
+        raise SourceSchemaError("Persistence errors could not be matched to origin risk-set coverage")
+    scored = result.groupby(["origin", "model"])["city_id"].nunique()
+    observed = coverage.set_index("origin")["observed_outcome_rows"]
+    for (origin, _model), count in scored.items():
+        if count > observed.loc[origin]:
+            raise SourceSchemaError(
+                "Scored persistence error rows exceed observed outcomes in the origin risk set"
+            )
+    result["origin_risk_set_coverage_enforced"] = True
+    result["headline_coverage_contract_enforced"] = True
+    result["benchmark_stage"] = "point_in_time_persistence_with_origin_coverage"
+    return result.reset_index(drop=True)

--- a/src/urban_growth/forecast_headline.py
+++ b/src/urban_growth/forecast_headline.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import pandas as pd
 
-from urban_growth import forecast_fitness
 from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
 
 
@@ -95,10 +94,10 @@ def evaluate_headline_point_in_time_persistence(
     **kwargs: object,
 ) -> pd.DataFrame:
     """Evaluate point-in-time persistence while preserving the origin risk-set denominator."""
+    from urban_growth.forecast_fitness import evaluate_point_in_time_persistence_baselines
+
     coverage = _validate_origin_coverage(coverage_summary, origins)
-    metrics = forecast_fitness.evaluate_point_in_time_persistence_baselines(
-        panel, origins, **kwargs
-    )
+    metrics = evaluate_point_in_time_persistence_baselines(panel, origins, **kwargs)
     return _attach_coverage_to_metrics(metrics, coverage)
 
 
@@ -109,8 +108,10 @@ def headline_point_in_time_persistence_errors(
     **kwargs: object,
 ) -> pd.DataFrame:
     """Return row-level point-in-time errors with origin risk-set coverage attached."""
+    from urban_growth.forecast_fitness import point_in_time_persistence_errors
+
     coverage = _validate_origin_coverage(coverage_summary, origins)
-    errors = forecast_fitness.point_in_time_persistence_errors(panel, origins, **kwargs)
+    errors = point_in_time_persistence_errors(panel, origins, **kwargs)
     result = errors.merge(coverage, on="origin", how="left", validate="many_to_one")
     if result[list(COVERAGE_COLUMNS - {"origin"})].isna().any().any():
         raise SourceSchemaError("Persistence errors could not be matched to origin risk-set coverage")

--- a/src/urban_growth/forecast_headline.py
+++ b/src/urban_growth/forecast_headline.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import numpy as np
 import pandas as pd
 
 from urban_growth.forecast_fitness import (
@@ -62,7 +61,7 @@ def _validate_origin_coverage(
     if not (observed + missing_rows).eq(risk).all():
         raise SourceSchemaError("Observed plus missing outcome rows must equal the origin risk set")
     expected_share = observed / risk
-    if share.isna().any() or not np.allclose(share, expected_share, rtol=0, atol=1e-12):
+    if share.isna().any() or share.sub(expected_share).abs().gt(1e-12).any():
         raise SourceSchemaError("observed_outcome_share disagrees with the coverage counts")
     if coverage["coverage_denominator_rule"].ne("lag_and_origin_predictors_only").any():
         raise SourceSchemaError("Headline coverage denominator must use lag/origin predictors only")

--- a/src/urban_growth/forecast_headline.py
+++ b/src/urban_growth/forecast_headline.py
@@ -4,10 +4,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from urban_growth.forecast_fitness import (
-    evaluate_point_in_time_persistence_baselines,
-    point_in_time_persistence_errors,
-)
+from urban_growth import forecast_fitness
 from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
 
 
@@ -99,7 +96,9 @@ def evaluate_headline_point_in_time_persistence(
 ) -> pd.DataFrame:
     """Evaluate point-in-time persistence while preserving the origin risk-set denominator."""
     coverage = _validate_origin_coverage(coverage_summary, origins)
-    metrics = evaluate_point_in_time_persistence_baselines(panel, origins, **kwargs)
+    metrics = forecast_fitness.evaluate_point_in_time_persistence_baselines(
+        panel, origins, **kwargs
+    )
     return _attach_coverage_to_metrics(metrics, coverage)
 
 
@@ -111,7 +110,7 @@ def headline_point_in_time_persistence_errors(
 ) -> pd.DataFrame:
     """Return row-level point-in-time errors with origin risk-set coverage attached."""
     coverage = _validate_origin_coverage(coverage_summary, origins)
-    errors = point_in_time_persistence_errors(panel, origins, **kwargs)
+    errors = forecast_fitness.point_in_time_persistence_errors(panel, origins, **kwargs)
     result = errors.merge(coverage, on="origin", how="left", validate="many_to_one")
     if result[list(COVERAGE_COLUMNS - {"origin"})].isna().any().any():
         raise SourceSchemaError("Persistence errors could not be matched to origin risk-set coverage")

--- a/src/urban_growth/forecast_headline.py
+++ b/src/urban_growth/forecast_headline.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import pandas as pd
 
-from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
 from urban_growth.forecast_fitness import (
     evaluate_point_in_time_persistence_baselines,
     point_in_time_persistence_errors,
 )
+from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
 
 
 COVERAGE_COLUMNS = {

--- a/src/urban_growth/forecast_headline.py
+++ b/src/urban_growth/forecast_headline.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import pandas as pd
 
+from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
 from urban_growth.forecast_fitness import (
     evaluate_point_in_time_persistence_baselines,
     point_in_time_persistence_errors,
 )
-from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
 
 
 COVERAGE_COLUMNS = {

--- a/src/urban_growth/forecast_headline.py
+++ b/src/urban_growth/forecast_headline.py
@@ -1,4 +1,5 @@
 """Headline-qualified persistence evaluation with origin risk-set coverage enforcement."""
+# ruff: noqa: I001
 
 from __future__ import annotations
 

--- a/tests/test_forecast_headline.py
+++ b/tests/test_forecast_headline.py
@@ -1,0 +1,99 @@
+import pandas as pd
+import pytest
+
+from urban_growth.forecast_headline import (
+    evaluate_headline_point_in_time_persistence,
+    headline_point_in_time_persistence_errors,
+)
+from urban_growth.io import SourceSchemaError
+
+
+def _panel() -> pd.DataFrame:
+    rows = []
+    specs = {
+        "A": [(2000, 2005, 0.010, 0.012), (2005, 2010, 0.012, 0.014), (2010, 2015, 0.014, 0.013)],
+        "B": [(2000, 2005, 0.020, 0.018), (2005, 2010, 0.018, 0.016), (2010, 2015, 0.016, 0.015)],
+        "C": [(2000, 2005, -0.005, -0.004), (2005, 2010, -0.004, -0.002), (2010, 2015, -0.002, 0.001)],
+    }
+    for city_id, intervals in specs.items():
+        for start, end, recent, future in intervals:
+            rows.append(
+                {
+                    "city_id": city_id,
+                    "country_code": "AAA" if city_id != "C" else "BBB",
+                    "period_start": start,
+                    "period_end": end,
+                    "population_start": 50_000,
+                    "recent_growth": recent,
+                    "future_growth": future,
+                    "growth_eligible": True,
+                    "point_in_time_available": True,
+                    "availability_provenance_verified": True,
+                    "forecast_origin_date": f"{start}-12-31",
+                    "outcome_available_date": f"{end}-06-30",
+                    "outcome_available_reference": f"official-release-{end}",
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _coverage() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "origin": [2005, 2010],
+            "origin_risk_set_rows": [4, 5],
+            "observed_outcome_rows": [3, 3],
+            "missing_outcome_rows": [1, 2],
+            "observed_outcome_share": [0.75, 0.60],
+            "coverage_denominator_rule": [
+                "lag_and_origin_predictors_only",
+                "lag_and_origin_predictors_only",
+            ],
+            "future_outcome_used_for_membership": [False, False],
+        }
+    )
+
+
+def test_headline_metrics_attach_origin_risk_set_coverage() -> None:
+    result = evaluate_headline_point_in_time_persistence(_panel(), [2005, 2010], _coverage())
+    assert result["origin_risk_set_coverage_enforced"].all()
+    assert result["headline_coverage_contract_enforced"].all()
+    assert result["benchmark_stage"].eq("point_in_time_persistence_with_origin_coverage").all()
+    assert result.loc[result["origin"].eq(2005), "origin_risk_set_rows"].eq(4).all()
+    assert result.loc[result["origin"].eq(2010), "observed_outcome_share"].eq(0.60).all()
+
+
+def test_headline_errors_attach_same_coverage_denominator() -> None:
+    result = headline_point_in_time_persistence_errors(_panel(), [2005, 2010], _coverage())
+    assert result["origin_risk_set_coverage_enforced"].all()
+    assert result["headline_coverage_contract_enforced"].all()
+    assert result.loc[result["origin"].eq(2010), "origin_risk_set_rows"].eq(5).all()
+
+
+def test_headline_evaluation_requires_coverage_for_every_origin() -> None:
+    coverage = _coverage().loc[_coverage()["origin"].eq(2005)].copy()
+    with pytest.raises(SourceSchemaError, match="missing declared origins"):
+        evaluate_headline_point_in_time_persistence(_panel(), [2005, 2010], coverage)
+
+
+def test_headline_evaluation_rejects_future_defined_membership() -> None:
+    coverage = _coverage()
+    coverage.loc[coverage["origin"].eq(2010), "future_outcome_used_for_membership"] = True
+    with pytest.raises(SourceSchemaError, match="Future outcome observability"):
+        evaluate_headline_point_in_time_persistence(_panel(), [2005, 2010], coverage)
+
+
+def test_headline_evaluation_rejects_inconsistent_coverage_counts() -> None:
+    coverage = _coverage()
+    coverage.loc[coverage["origin"].eq(2010), "missing_outcome_rows"] = 1
+    with pytest.raises(SourceSchemaError, match="must equal the origin risk set"):
+        evaluate_headline_point_in_time_persistence(_panel(), [2005, 2010], coverage)
+
+
+def test_headline_evaluation_rejects_scored_rows_above_observed_outcomes() -> None:
+    coverage = _coverage()
+    coverage.loc[coverage["origin"].eq(2010), "observed_outcome_rows"] = 2
+    coverage.loc[coverage["origin"].eq(2010), "missing_outcome_rows"] = 3
+    coverage.loc[coverage["origin"].eq(2010), "observed_outcome_share"] = 0.4
+    with pytest.raises(SourceSchemaError, match="Scored persistence rows exceed observed outcomes"):
+        evaluate_headline_point_in_time_persistence(_panel(), [2005, 2010], coverage)


### PR DESCRIPTION
Closes the integration gap left after PR #114. The origin-risk-set coverage audit existed, but point-in-time persistence results could still be consumed without carrying the denominator, leaving survivorship/attrition invisible. This PR adds headline-qualified aggregate and row-level wrappers that require a complete coverage summary for every declared origin, verify denominator arithmetic and origin-only membership semantics, reject future-defined membership, ensure scored rows do not exceed observed outcomes, and attach coverage counts/shares plus explicit enforcement flags to every result. The lower-level point-in-time evaluator remains available as an intermediate building block and is explicitly not sufficient for headline coverage claims. Adds regression tests and a locked coverage-gate document.