### PR TITLE
Require registered minimum outcome coverage for headline persistence

### DIFF
--- a/docs/headline-persistence-coverage-gate.md
+++ b/docs/headline-persistence-coverage-gate.md
@@ -4,9 +4,11 @@
 
 A forecast can be point-in-time correct and still report performance on a future-selected subset. The lower-level persistence evaluators score rows with observed outcomes; by construction they cannot score a city whose future outcome is missing. That scoring requirement must not be allowed to redefine the origin cohort or hide future attrition.
 
+A second distinction is also required: **coverage audited** is not the same as **coverage adequate for headline use**. Reporting a 40% observed-outcome share does not by itself justify promoting the resulting forecast score as a headline result.
+
 ## Locked rule
 
-Any persistence result promoted beyond retrospective or intermediate point-in-time analysis must carry an origin-defined outcome-coverage denominator.
+Any persistence result promoted beyond retrospective or intermediate point-in-time analysis must carry an origin-defined outcome-coverage denominator **and must pass a registered minimum observed-outcome share for every declared forecast origin**.
 
 The denominator must come from `origin_risk_set_outcome_coverage` or an equivalent table satisfying the same contract:
 
@@ -24,15 +26,35 @@ The headline-qualified functions are:
 
 They call the existing point-in-time timing and provenance gates, then merge validated origin-risk-set coverage onto every result. They also verify that the number of scored rows cannot exceed the number of observed outcomes recorded for that origin.
 
+## Registered minimum coverage policy
+
+The repository does **not** define a universal acceptable coverage percentage. The appropriate minimum may depend on source design, geography, cohort, and the planned claim. Hard-coding an unsupported default would replace one hidden assumption with another.
+
+Instead, every headline call must explicitly provide:
+
+- `minimum_observed_outcome_share`: a numeric threshold in `(0, 1]`;
+- `coverage_policy_reference`: a nonblank reference identifying the locked analysis rule, specification, or source-specific policy that set the threshold.
+
+Every declared origin must meet or exceed the registered minimum. If any origin falls below it, the headline-qualified evaluator fails closed. Lower-level point-in-time results can still be produced and reported as diagnostics, together with the adverse coverage evidence.
+
+Headline outputs record:
+
+- `minimum_observed_outcome_share`;
+- `coverage_policy_reference`;
+- `coverage_policy_passed = true`;
+- `headline_coverage_minimum_enforced = true`.
+
+Changing the minimum after examining forecast performance is a specification change and must not be presented as if it were the original headline rule.
+
 ## Classification
 
-`evaluate_point_in_time_persistence_baselines` and `point_in_time_persistence_errors` remain valid lower-level point-in-time building blocks. Their `benchmark_stage = point_in_time_persistence_only` does **not** establish that future-outcome attrition was audited.
+`evaluate_point_in_time_persistence_baselines` and `point_in_time_persistence_errors` remain valid lower-level point-in-time building blocks. Their `benchmark_stage = point_in_time_persistence_only` does **not** establish that future-outcome attrition was audited or adequate.
 
-Only results with both:
+Only results with all of the following may be described as having passed the headline origin-cohort coverage gate:
 
-- `origin_risk_set_coverage_enforced = true`, and
-- `headline_coverage_contract_enforced = true`
+- `origin_risk_set_coverage_enforced = true`;
+- `headline_coverage_contract_enforced = true`;
+- `headline_coverage_minimum_enforced = true`;
+- `coverage_policy_passed = true`.
 
-may be described as having passed the origin-cohort coverage gate.
-
-Passing this gate does not mean outcome coverage is high. The actual `observed_outcome_share` must still be reported and interpreted. A low share is evidence of attrition risk, not something this gate repairs.
+The actual `observed_outcome_share` must still be reported. Passing the registered minimum does not make missing outcomes irrelevant; it only establishes that the result met the prespecified minimum evidence standard for headline use.

--- a/src/urban_growth/forecast_headline.py
+++ b/src/urban_growth/forecast_headline.py
@@ -71,12 +71,58 @@ def _validate_origin_coverage(
     return coverage.sort_values("origin").reset_index(drop=True)
 
 
+def _apply_registered_coverage_policy(
+    coverage: pd.DataFrame,
+    *,
+    minimum_observed_outcome_share: float,
+    coverage_policy_reference: str,
+) -> pd.DataFrame:
+    """Require a preregistered minimum observed-outcome share for headline qualification."""
+    try:
+        minimum = float(minimum_observed_outcome_share)
+    except (TypeError, ValueError) as exc:
+        raise SourceSchemaError("minimum_observed_outcome_share must be numeric") from exc
+    if not 0 < minimum <= 1:
+        raise SourceSchemaError("minimum_observed_outcome_share must be in (0, 1]")
+    reference = str(coverage_policy_reference).strip()
+    if not reference:
+        raise SourceSchemaError("coverage_policy_reference must document the registered coverage rule")
+
+    result = coverage.copy()
+    result["minimum_observed_outcome_share"] = minimum
+    result["coverage_policy_reference"] = reference
+    result["coverage_policy_passed"] = result["observed_outcome_share"].ge(minimum)
+    failed = result.loc[~result["coverage_policy_passed"], "origin"].tolist()
+    if failed:
+        raise SourceSchemaError(
+            "Observed-outcome coverage is below the registered headline minimum for origins: "
+            f"{failed}"
+        )
+    return result
+
+
+def _headline_coverage(
+    coverage_summary: pd.DataFrame,
+    origins: list[int],
+    *,
+    minimum_observed_outcome_share: float,
+    coverage_policy_reference: str,
+) -> pd.DataFrame:
+    coverage = _validate_origin_coverage(coverage_summary, origins)
+    return _apply_registered_coverage_policy(
+        coverage,
+        minimum_observed_outcome_share=minimum_observed_outcome_share,
+        coverage_policy_reference=coverage_policy_reference,
+    )
+
+
 def _attach_coverage_to_metrics(
     metrics: pd.DataFrame,
     coverage: pd.DataFrame,
 ) -> pd.DataFrame:
     result = metrics.merge(coverage, on="origin", how="left", validate="many_to_one")
-    if result[list(COVERAGE_COLUMNS - {"origin"})].isna().any().any():
+    required_attached = COVERAGE_COLUMNS - {"origin"}
+    if result[list(required_attached)].isna().any().any():
         raise SourceSchemaError("Persistence metrics could not be matched to origin risk-set coverage")
     max_scored = result.groupby("origin")["n"].max()
     observed = coverage.set_index("origin")["observed_outcome_rows"]
@@ -84,6 +130,7 @@ def _attach_coverage_to_metrics(
         raise SourceSchemaError("Scored persistence rows exceed observed outcomes in the origin risk set")
     result["origin_risk_set_coverage_enforced"] = True
     result["headline_coverage_contract_enforced"] = True
+    result["headline_coverage_minimum_enforced"] = True
     result["benchmark_stage"] = "point_in_time_persistence_with_origin_coverage"
     return result.sort_values(["origin", "model"]).reset_index(drop=True)
 
@@ -92,12 +139,20 @@ def evaluate_headline_point_in_time_persistence(
     panel: pd.DataFrame,
     origins: list[int],
     coverage_summary: pd.DataFrame,
+    *,
+    minimum_observed_outcome_share: float,
+    coverage_policy_reference: str,
     **kwargs: object,
 ) -> pd.DataFrame:
-    """Evaluate point-in-time persistence while preserving the origin risk-set denominator."""
+    """Evaluate point-in-time persistence only when registered origin coverage passes."""
     from urban_growth.forecast_fitness import evaluate_point_in_time_persistence_baselines
 
-    coverage = _validate_origin_coverage(coverage_summary, origins)
+    coverage = _headline_coverage(
+        coverage_summary,
+        origins,
+        minimum_observed_outcome_share=minimum_observed_outcome_share,
+        coverage_policy_reference=coverage_policy_reference,
+    )
     metrics = evaluate_point_in_time_persistence_baselines(panel, origins, **kwargs)
     return _attach_coverage_to_metrics(metrics, coverage)
 
@@ -106,15 +161,24 @@ def headline_point_in_time_persistence_errors(
     panel: pd.DataFrame,
     origins: list[int],
     coverage_summary: pd.DataFrame,
+    *,
+    minimum_observed_outcome_share: float,
+    coverage_policy_reference: str,
     **kwargs: object,
 ) -> pd.DataFrame:
-    """Return row-level point-in-time errors with origin risk-set coverage attached."""
+    """Return row-level errors only when registered origin coverage passes."""
     from urban_growth.forecast_fitness import point_in_time_persistence_errors
 
-    coverage = _validate_origin_coverage(coverage_summary, origins)
+    coverage = _headline_coverage(
+        coverage_summary,
+        origins,
+        minimum_observed_outcome_share=minimum_observed_outcome_share,
+        coverage_policy_reference=coverage_policy_reference,
+    )
     errors = point_in_time_persistence_errors(panel, origins, **kwargs)
     result = errors.merge(coverage, on="origin", how="left", validate="many_to_one")
-    if result[list(COVERAGE_COLUMNS - {"origin"})].isna().any().any():
+    required_attached = COVERAGE_COLUMNS - {"origin"}
+    if result[list(required_attached)].isna().any().any():
         raise SourceSchemaError("Persistence errors could not be matched to origin risk-set coverage")
     scored = result.groupby(["origin", "model"])["city_id"].nunique()
     observed = coverage.set_index("origin")["observed_outcome_rows"]
@@ -125,5 +189,6 @@ def headline_point_in_time_persistence_errors(
             )
     result["origin_risk_set_coverage_enforced"] = True
     result["headline_coverage_contract_enforced"] = True
+    result["headline_coverage_minimum_enforced"] = True
     result["benchmark_stage"] = "point_in_time_persistence_with_origin_coverage"
     return result.reset_index(drop=True)

--- a/tests/test_forecast_headline.py
+++ b/tests/test_forecast_headline.py
@@ -1,3 +1,5 @@
+# ruff: noqa: I001
+
 import pandas as pd
 import pytest
 

--- a/tests/test_forecast_headline.py
+++ b/tests/test_forecast_headline.py
@@ -8,6 +8,12 @@ from urban_growth.forecast_headline import (
 from urban_growth.io import SourceSchemaError
 
 
+POLICY_KWARGS = {
+    "minimum_observed_outcome_share": 0.60,
+    "coverage_policy_reference": "locked-test-coverage-policy",
+}
+
+
 def _panel() -> pd.DataFrame:
     rows = []
     specs = {
@@ -55,39 +61,55 @@ def _coverage() -> pd.DataFrame:
 
 
 def test_headline_metrics_attach_origin_risk_set_coverage() -> None:
-    result = evaluate_headline_point_in_time_persistence(_panel(), [2005, 2010], _coverage())
+    result = evaluate_headline_point_in_time_persistence(
+        _panel(), [2005, 2010], _coverage(), **POLICY_KWARGS
+    )
     assert result["origin_risk_set_coverage_enforced"].all()
     assert result["headline_coverage_contract_enforced"].all()
+    assert result["headline_coverage_minimum_enforced"].all()
+    assert result["coverage_policy_passed"].all()
+    assert result["minimum_observed_outcome_share"].eq(0.60).all()
+    assert result["coverage_policy_reference"].eq("locked-test-coverage-policy").all()
     assert result["benchmark_stage"].eq("point_in_time_persistence_with_origin_coverage").all()
     assert result.loc[result["origin"].eq(2005), "origin_risk_set_rows"].eq(4).all()
     assert result.loc[result["origin"].eq(2010), "observed_outcome_share"].eq(0.60).all()
 
 
 def test_headline_errors_attach_same_coverage_denominator() -> None:
-    result = headline_point_in_time_persistence_errors(_panel(), [2005, 2010], _coverage())
+    result = headline_point_in_time_persistence_errors(
+        _panel(), [2005, 2010], _coverage(), **POLICY_KWARGS
+    )
     assert result["origin_risk_set_coverage_enforced"].all()
     assert result["headline_coverage_contract_enforced"].all()
+    assert result["headline_coverage_minimum_enforced"].all()
+    assert result["coverage_policy_passed"].all()
     assert result.loc[result["origin"].eq(2010), "origin_risk_set_rows"].eq(5).all()
 
 
 def test_headline_evaluation_requires_coverage_for_every_origin() -> None:
     coverage = _coverage().loc[_coverage()["origin"].eq(2005)].copy()
     with pytest.raises(SourceSchemaError, match="missing declared origins"):
-        evaluate_headline_point_in_time_persistence(_panel(), [2005, 2010], coverage)
+        evaluate_headline_point_in_time_persistence(
+            _panel(), [2005, 2010], coverage, **POLICY_KWARGS
+        )
 
 
 def test_headline_evaluation_rejects_future_defined_membership() -> None:
     coverage = _coverage()
     coverage.loc[coverage["origin"].eq(2010), "future_outcome_used_for_membership"] = True
     with pytest.raises(SourceSchemaError, match="Future outcome observability"):
-        evaluate_headline_point_in_time_persistence(_panel(), [2005, 2010], coverage)
+        evaluate_headline_point_in_time_persistence(
+            _panel(), [2005, 2010], coverage, **POLICY_KWARGS
+        )
 
 
 def test_headline_evaluation_rejects_inconsistent_coverage_counts() -> None:
     coverage = _coverage()
     coverage.loc[coverage["origin"].eq(2010), "missing_outcome_rows"] = 1
     with pytest.raises(SourceSchemaError, match="must equal the origin risk set"):
-        evaluate_headline_point_in_time_persistence(_panel(), [2005, 2010], coverage)
+        evaluate_headline_point_in_time_persistence(
+            _panel(), [2005, 2010], coverage, **POLICY_KWARGS
+        )
 
 
 def test_headline_evaluation_rejects_scored_rows_above_observed_outcomes() -> None:
@@ -95,5 +117,40 @@ def test_headline_evaluation_rejects_scored_rows_above_observed_outcomes() -> No
     coverage.loc[coverage["origin"].eq(2010), "observed_outcome_rows"] = 2
     coverage.loc[coverage["origin"].eq(2010), "missing_outcome_rows"] = 3
     coverage.loc[coverage["origin"].eq(2010), "observed_outcome_share"] = 0.4
-    with pytest.raises(SourceSchemaError, match="Scored persistence rows exceed observed outcomes"):
-        evaluate_headline_point_in_time_persistence(_panel(), [2005, 2010], coverage)
+    with pytest.raises(SourceSchemaError, match="below the registered headline minimum"):
+        evaluate_headline_point_in_time_persistence(
+            _panel(), [2005, 2010], coverage, **POLICY_KWARGS
+        )
+
+
+def test_headline_evaluation_fails_when_registered_minimum_is_not_met() -> None:
+    with pytest.raises(SourceSchemaError, match="below the registered headline minimum"):
+        evaluate_headline_point_in_time_persistence(
+            _panel(),
+            [2005, 2010],
+            _coverage(),
+            minimum_observed_outcome_share=0.70,
+            coverage_policy_reference="locked-test-coverage-policy",
+        )
+
+
+def test_headline_evaluation_rejects_invalid_registered_minimum() -> None:
+    with pytest.raises(SourceSchemaError, match=r"must be in \(0, 1\]"):
+        evaluate_headline_point_in_time_persistence(
+            _panel(),
+            [2005, 2010],
+            _coverage(),
+            minimum_observed_outcome_share=0,
+            coverage_policy_reference="locked-test-coverage-policy",
+        )
+
+
+def test_headline_evaluation_requires_coverage_policy_reference() -> None:
+    with pytest.raises(SourceSchemaError, match="coverage_policy_reference"):
+        evaluate_headline_point_in_time_persistence(
+            _panel(),
+            [2005, 2010],
+            _coverage(),
+            minimum_observed_outcome_share=0.60,
+            coverage_policy_reference="  ",
+        )


### PR DESCRIPTION
Closes the remaining ambiguity between coverage being audited and coverage being adequate. Headline-qualified persistence now requires an explicit minimum observed-outcome share and a nonblank policy reference. Every declared origin must meet the registered minimum; otherwise the headline evaluator fails closed. The repository intentionally does not hard-code a universal percentage. Outputs record the threshold, policy reference, pass flag, and minimum-enforcement flag. Lower-level point-in-time evaluators remain available for diagnostics when coverage is inadequate. Tests and the locked coverage-gate documentation are updated accordingly.