### PR TITLE
Lock headline coverage thresholds to versioned registry

### DIFF
--- a/docs/headline-persistence-coverage-gate.md
+++ b/docs/headline-persistence-coverage-gate.md
@@ -4,11 +4,13 @@
 
 A forecast can be point-in-time correct and still report performance on a future-selected subset. The lower-level persistence evaluators score rows with observed outcomes; by construction they cannot score a city whose future outcome is missing. That scoring requirement must not be allowed to redefine the origin cohort or hide future attrition.
 
-A second distinction is also required: **coverage audited** is not the same as **coverage adequate for headline use**. Reporting a 40% observed-outcome share does not by itself justify promoting the resulting forecast score as a headline result.
+A second distinction is also required: **coverage audited** is not the same as **coverage adequate for headline use**. Reporting a low observed-outcome share does not by itself justify promoting the resulting forecast score as a headline result.
+
+A third constraint is necessary: the minimum itself cannot be a runtime tuning parameter. If an analyst can lower the cutoff after inspecting results, a nominally "registered" threshold does not prevent specification search.
 
 ## Locked rule
 
-Any persistence result promoted beyond retrospective or intermediate point-in-time analysis must carry an origin-defined outcome-coverage denominator **and must pass a registered minimum observed-outcome share for every declared forecast origin**.
+Any persistence result promoted beyond retrospective or intermediate point-in-time analysis must carry an origin-defined outcome-coverage denominator and must pass a **repository-registered minimum observed-outcome share** for every declared forecast origin.
 
 The denominator must come from `origin_risk_set_outcome_coverage` or an equivalent table satisfying the same contract:
 
@@ -24,27 +26,25 @@ The headline-qualified functions are:
 - `evaluate_headline_point_in_time_persistence` for aggregate metrics;
 - `headline_point_in_time_persistence_errors` for row-level errors.
 
-They call the existing point-in-time timing and provenance gates, then merge validated origin-risk-set coverage onto every result. They also verify that the number of scored rows cannot exceed the number of observed outcomes recorded for that origin.
+They call the existing point-in-time timing and provenance gates, merge validated origin-risk-set coverage onto every result, and verify that the number of scored rows cannot exceed the number of observed outcomes recorded for that origin.
 
-## Registered minimum coverage policy
+## Versioned coverage policy registry
 
-The repository does **not** define a universal acceptable coverage percentage. The appropriate minimum may depend on source design, geography, cohort, and the planned claim. Hard-coding an unsupported default would replace one hidden assumption with another.
+Headline callers provide only `coverage_policy_id`. They do **not** supply the numerical threshold or free-text reference at runtime.
 
-Instead, every headline call must explicitly provide:
+`src/urban_growth/coverage_policy.py` is the repository-controlled policy registry. Each entry contains:
 
-- `minimum_observed_outcome_share`: a numeric threshold in `(0, 1]`;
-- `coverage_policy_reference`: a nonblank reference identifying the locked analysis rule, specification, or source-specific policy that set the threshold.
+- a stable `policy_id`;
+- `minimum_observed_outcome_share` in `(0, 1]`;
+- a nonblank policy reference.
 
-Every declared origin must meet or exceed the registered minimum. If any origin falls below it, the headline-qualified evaluator fails closed. Lower-level point-in-time results can still be produced and reported as diagnostics, together with the adverse coverage evidence.
+Changing a threshold therefore requires a versioned repository change and review rather than a function-call adjustment. Outputs retain the policy ID, minimum, reference, and `coverage_policy_registry_enforced = true` so a result can be traced back to the exact policy in Git history.
 
-Headline outputs record:
+The production registry is deliberately empty until the project adopts a substantively justified threshold. This is fail-closed: no headline-qualified persistence result can be produced merely by inventing a cutoff during analysis. Synthetic unit tests inject test-only entries and do not establish a substantive project policy.
 
-- `minimum_observed_outcome_share`;
-- `coverage_policy_reference`;
-- `coverage_policy_passed = true`;
-- `headline_coverage_minimum_enforced = true`.
+When a real policy is adopted, it should be added through a reviewed PR with its rationale, intended source/cohort scope, and relationship to the claim being qualified.
 
-Changing the minimum after examining forecast performance is a specification change and must not be presented as if it were the original headline rule.
+Every declared origin must meet or exceed the registered minimum. If any origin falls below it, the headline-qualified evaluator fails closed. Lower-level point-in-time results can still be produced and reported as diagnostics together with the adverse coverage evidence.
 
 ## Classification
 
@@ -55,6 +55,7 @@ Only results with all of the following may be described as having passed the hea
 - `origin_risk_set_coverage_enforced = true`;
 - `headline_coverage_contract_enforced = true`;
 - `headline_coverage_minimum_enforced = true`;
+- `coverage_policy_registry_enforced = true`;
 - `coverage_policy_passed = true`.
 
-The actual `observed_outcome_share` must still be reported. Passing the registered minimum does not make missing outcomes irrelevant; it only establishes that the result met the prespecified minimum evidence standard for headline use.
+The actual `observed_outcome_share` must still be reported. Passing the registered minimum does not make missing outcomes irrelevant; it only establishes that the result met the versioned minimum evidence standard for headline use.

--- a/src/urban_growth/coverage_policy.py
+++ b/src/urban_growth/coverage_policy.py
@@ -1,0 +1,46 @@
+"""Repository-controlled registry for headline outcome-coverage policies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from urban_growth.io import SourceSchemaError
+
+
+@dataclass(frozen=True)
+class HeadlineCoveragePolicy:
+    """A versioned minimum observed-outcome coverage rule."""
+
+    policy_id: str
+    minimum_observed_outcome_share: float
+    reference: str
+
+
+# Deliberately empty until the project adopts a substantive threshold.
+# Adding or changing a policy requires a reviewed repository commit/PR.
+REGISTERED_HEADLINE_COVERAGE_POLICIES: tuple[HeadlineCoveragePolicy, ...] = ()
+
+
+def resolve_registered_coverage_policy(policy_id: str) -> HeadlineCoveragePolicy:
+    """Resolve one repository-registered coverage policy by stable ID."""
+    requested = str(policy_id).strip()
+    if not requested:
+        raise SourceSchemaError("coverage_policy_id must name a repository-registered policy")
+
+    matches = [policy for policy in REGISTERED_HEADLINE_COVERAGE_POLICIES if policy.policy_id == requested]
+    if not matches:
+        raise SourceSchemaError(
+            f"Unknown coverage_policy_id {requested!r}; add the policy to the versioned registry before headline use"
+        )
+    if len(matches) != 1:
+        raise SourceSchemaError(f"Duplicate registered coverage policy ID: {requested}")
+
+    policy = matches[0]
+    minimum = float(policy.minimum_observed_outcome_share)
+    if not 0 < minimum <= 1:
+        raise SourceSchemaError(
+            f"Registered coverage policy {requested!r} has an invalid minimum observed-outcome share"
+        )
+    if not str(policy.reference).strip():
+        raise SourceSchemaError(f"Registered coverage policy {requested!r} lacks a policy reference")
+    return policy

--- a/src/urban_growth/forecast_headline.py
+++ b/src/urban_growth/forecast_headline.py
@@ -71,26 +71,23 @@ def _validate_origin_coverage(
     return coverage.sort_values("origin").reset_index(drop=True)
 
 
-def _apply_registered_coverage_policy(
-    coverage: pd.DataFrame,
+def _headline_coverage(
+    coverage_summary: pd.DataFrame,
+    origins: list[int],
     *,
-    minimum_observed_outcome_share: float,
-    coverage_policy_reference: str,
+    coverage_policy_id: str,
 ) -> pd.DataFrame:
-    """Require a preregistered minimum observed-outcome share for headline qualification."""
-    try:
-        minimum = float(minimum_observed_outcome_share)
-    except (TypeError, ValueError) as exc:
-        raise SourceSchemaError("minimum_observed_outcome_share must be numeric") from exc
-    if not 0 < minimum <= 1:
-        raise SourceSchemaError("minimum_observed_outcome_share must be in (0, 1]")
-    reference = str(coverage_policy_reference).strip()
-    if not reference:
-        raise SourceSchemaError("coverage_policy_reference must document the registered coverage rule")
+    from urban_growth.coverage_policy import resolve_registered_coverage_policy
+
+    coverage = _validate_origin_coverage(coverage_summary, origins)
+    policy = resolve_registered_coverage_policy(coverage_policy_id)
+    minimum = float(policy.minimum_observed_outcome_share)
 
     result = coverage.copy()
+    result["coverage_policy_id"] = policy.policy_id
     result["minimum_observed_outcome_share"] = minimum
-    result["coverage_policy_reference"] = reference
+    result["coverage_policy_reference"] = str(policy.reference).strip()
+    result["coverage_policy_registry_enforced"] = True
     result["coverage_policy_passed"] = result["observed_outcome_share"].ge(minimum)
     failed = result.loc[~result["coverage_policy_passed"], "origin"].tolist()
     if failed:
@@ -99,21 +96,6 @@ def _apply_registered_coverage_policy(
             f"{failed}"
         )
     return result
-
-
-def _headline_coverage(
-    coverage_summary: pd.DataFrame,
-    origins: list[int],
-    *,
-    minimum_observed_outcome_share: float,
-    coverage_policy_reference: str,
-) -> pd.DataFrame:
-    coverage = _validate_origin_coverage(coverage_summary, origins)
-    return _apply_registered_coverage_policy(
-        coverage,
-        minimum_observed_outcome_share=minimum_observed_outcome_share,
-        coverage_policy_reference=coverage_policy_reference,
-    )
 
 
 def _attach_coverage_to_metrics(
@@ -140,18 +122,16 @@ def evaluate_headline_point_in_time_persistence(
     origins: list[int],
     coverage_summary: pd.DataFrame,
     *,
-    minimum_observed_outcome_share: float,
-    coverage_policy_reference: str,
+    coverage_policy_id: str,
     **kwargs: object,
 ) -> pd.DataFrame:
-    """Evaluate point-in-time persistence only when registered origin coverage passes."""
+    """Evaluate point-in-time persistence only under a versioned coverage policy."""
     from urban_growth.forecast_fitness import evaluate_point_in_time_persistence_baselines
 
     coverage = _headline_coverage(
         coverage_summary,
         origins,
-        minimum_observed_outcome_share=minimum_observed_outcome_share,
-        coverage_policy_reference=coverage_policy_reference,
+        coverage_policy_id=coverage_policy_id,
     )
     metrics = evaluate_point_in_time_persistence_baselines(panel, origins, **kwargs)
     return _attach_coverage_to_metrics(metrics, coverage)
@@ -162,18 +142,16 @@ def headline_point_in_time_persistence_errors(
     origins: list[int],
     coverage_summary: pd.DataFrame,
     *,
-    minimum_observed_outcome_share: float,
-    coverage_policy_reference: str,
+    coverage_policy_id: str,
     **kwargs: object,
 ) -> pd.DataFrame:
-    """Return row-level errors only when registered origin coverage passes."""
+    """Return row-level errors only under a versioned coverage policy."""
     from urban_growth.forecast_fitness import point_in_time_persistence_errors
 
     coverage = _headline_coverage(
         coverage_summary,
         origins,
-        minimum_observed_outcome_share=minimum_observed_outcome_share,
-        coverage_policy_reference=coverage_policy_reference,
+        coverage_policy_id=coverage_policy_id,
     )
     errors = point_in_time_persistence_errors(panel, origins, **kwargs)
     result = errors.merge(coverage, on="origin", how="left", validate="many_to_one")

--- a/tests/test_forecast_headline.py
+++ b/tests/test_forecast_headline.py
@@ -3,6 +3,8 @@
 import pandas as pd
 import pytest
 
+from urban_growth import coverage_policy
+from urban_growth.coverage_policy import HeadlineCoveragePolicy
 from urban_growth.forecast_headline import (
     evaluate_headline_point_in_time_persistence,
     headline_point_in_time_persistence_errors,
@@ -10,10 +12,22 @@ from urban_growth.forecast_headline import (
 from urban_growth.io import SourceSchemaError
 
 
-POLICY_KWARGS = {
-    "minimum_observed_outcome_share": 0.60,
-    "coverage_policy_reference": "locked-test-coverage-policy",
-}
+TEST_POLICY_ID = "synthetic-test-coverage-v1"
+
+
+@pytest.fixture(autouse=True)
+def _registered_test_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        coverage_policy,
+        "REGISTERED_HEADLINE_COVERAGE_POLICIES",
+        (
+            HeadlineCoveragePolicy(
+                policy_id=TEST_POLICY_ID,
+                minimum_observed_outcome_share=0.60,
+                reference="synthetic unit-test policy",
+            ),
+        ),
+    )
 
 
 def _panel() -> pd.DataFrame:
@@ -62,97 +76,94 @@ def _coverage() -> pd.DataFrame:
     )
 
 
-def test_headline_metrics_attach_origin_risk_set_coverage() -> None:
-    result = evaluate_headline_point_in_time_persistence(
-        _panel(), [2005, 2010], _coverage(), **POLICY_KWARGS
+def _evaluate(coverage: pd.DataFrame | None = None) -> pd.DataFrame:
+    return evaluate_headline_point_in_time_persistence(
+        _panel(),
+        [2005, 2010],
+        _coverage() if coverage is None else coverage,
+        coverage_policy_id=TEST_POLICY_ID,
     )
+
+
+def test_headline_metrics_attach_registered_policy_and_coverage() -> None:
+    result = _evaluate()
     assert result["origin_risk_set_coverage_enforced"].all()
     assert result["headline_coverage_contract_enforced"].all()
     assert result["headline_coverage_minimum_enforced"].all()
+    assert result["coverage_policy_registry_enforced"].all()
     assert result["coverage_policy_passed"].all()
+    assert result["coverage_policy_id"].eq(TEST_POLICY_ID).all()
     assert result["minimum_observed_outcome_share"].eq(0.60).all()
-    assert result["coverage_policy_reference"].eq("locked-test-coverage-policy").all()
-    assert result["benchmark_stage"].eq("point_in_time_persistence_with_origin_coverage").all()
-    assert result.loc[result["origin"].eq(2005), "origin_risk_set_rows"].eq(4).all()
-    assert result.loc[result["origin"].eq(2010), "observed_outcome_share"].eq(0.60).all()
 
 
-def test_headline_errors_attach_same_coverage_denominator() -> None:
+def test_headline_errors_attach_same_registered_policy() -> None:
     result = headline_point_in_time_persistence_errors(
-        _panel(), [2005, 2010], _coverage(), **POLICY_KWARGS
+        _panel(), [2005, 2010], _coverage(), coverage_policy_id=TEST_POLICY_ID
     )
-    assert result["origin_risk_set_coverage_enforced"].all()
-    assert result["headline_coverage_contract_enforced"].all()
-    assert result["headline_coverage_minimum_enforced"].all()
-    assert result["coverage_policy_passed"].all()
-    assert result.loc[result["origin"].eq(2010), "origin_risk_set_rows"].eq(5).all()
+    assert result["coverage_policy_registry_enforced"].all()
+    assert result["coverage_policy_id"].eq(TEST_POLICY_ID).all()
+
+
+def test_unknown_runtime_policy_id_fails_closed() -> None:
+    with pytest.raises(SourceSchemaError, match="Unknown coverage_policy_id"):
+        evaluate_headline_point_in_time_persistence(
+            _panel(), [2005, 2010], _coverage(), coverage_policy_id="lower-cutoff-after-results"
+        )
+
+
+def test_empty_production_registry_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(coverage_policy, "REGISTERED_HEADLINE_COVERAGE_POLICIES", ())
+    with pytest.raises(SourceSchemaError, match="Unknown coverage_policy_id"):
+        _evaluate()
 
 
 def test_headline_evaluation_requires_coverage_for_every_origin() -> None:
     coverage = _coverage().loc[_coverage()["origin"].eq(2005)].copy()
     with pytest.raises(SourceSchemaError, match="missing declared origins"):
-        evaluate_headline_point_in_time_persistence(
-            _panel(), [2005, 2010], coverage, **POLICY_KWARGS
-        )
+        _evaluate(coverage)
 
 
 def test_headline_evaluation_rejects_future_defined_membership() -> None:
     coverage = _coverage()
     coverage.loc[coverage["origin"].eq(2010), "future_outcome_used_for_membership"] = True
     with pytest.raises(SourceSchemaError, match="Future outcome observability"):
-        evaluate_headline_point_in_time_persistence(
-            _panel(), [2005, 2010], coverage, **POLICY_KWARGS
-        )
+        _evaluate(coverage)
 
 
 def test_headline_evaluation_rejects_inconsistent_coverage_counts() -> None:
     coverage = _coverage()
     coverage.loc[coverage["origin"].eq(2010), "missing_outcome_rows"] = 1
     with pytest.raises(SourceSchemaError, match="must equal the origin risk set"):
-        evaluate_headline_point_in_time_persistence(
-            _panel(), [2005, 2010], coverage, **POLICY_KWARGS
-        )
+        _evaluate(coverage)
 
 
-def test_headline_evaluation_rejects_scored_rows_above_observed_outcomes() -> None:
-    coverage = _coverage()
-    coverage.loc[coverage["origin"].eq(2010), "observed_outcome_rows"] = 2
-    coverage.loc[coverage["origin"].eq(2010), "missing_outcome_rows"] = 3
-    coverage.loc[coverage["origin"].eq(2010), "observed_outcome_share"] = 0.4
+def test_registered_minimum_fails_when_not_met(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        coverage_policy,
+        "REGISTERED_HEADLINE_COVERAGE_POLICIES",
+        (
+            HeadlineCoveragePolicy(
+                policy_id=TEST_POLICY_ID,
+                minimum_observed_outcome_share=0.70,
+                reference="synthetic stricter policy",
+            ),
+        ),
+    )
     with pytest.raises(SourceSchemaError, match="below the registered headline minimum"):
-        evaluate_headline_point_in_time_persistence(
-            _panel(), [2005, 2010], coverage, **POLICY_KWARGS
-        )
+        _evaluate()
 
 
-def test_headline_evaluation_fails_when_registered_minimum_is_not_met() -> None:
-    with pytest.raises(SourceSchemaError, match="below the registered headline minimum"):
-        evaluate_headline_point_in_time_persistence(
-            _panel(),
-            [2005, 2010],
-            _coverage(),
-            minimum_observed_outcome_share=0.70,
-            coverage_policy_reference="locked-test-coverage-policy",
-        )
-
-
-def test_headline_evaluation_rejects_invalid_registered_minimum() -> None:
-    with pytest.raises(SourceSchemaError, match=r"must be in \(0, 1\]"):
-        evaluate_headline_point_in_time_persistence(
-            _panel(),
-            [2005, 2010],
-            _coverage(),
-            minimum_observed_outcome_share=0,
-            coverage_policy_reference="locked-test-coverage-policy",
-        )
-
-
-def test_headline_evaluation_requires_coverage_policy_reference() -> None:
-    with pytest.raises(SourceSchemaError, match="coverage_policy_reference"):
-        evaluate_headline_point_in_time_persistence(
-            _panel(),
-            [2005, 2010],
-            _coverage(),
-            minimum_observed_outcome_share=0.60,
-            coverage_policy_reference="  ",
-        )
+def test_invalid_registered_policy_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        coverage_policy,
+        "REGISTERED_HEADLINE_COVERAGE_POLICIES",
+        (
+            HeadlineCoveragePolicy(
+                policy_id=TEST_POLICY_ID,
+                minimum_observed_outcome_share=0,
+                reference="invalid synthetic policy",
+            ),
+        ),
+    )
+    with pytest.raises(SourceSchemaError, match="invalid minimum"):
+        _evaluate()


### PR DESCRIPTION
Closes the remaining post-hoc tuning path in the headline coverage gate. PR #116 required a minimum observed-outcome share, but callers could still supply that minimum directly at runtime. This PR moves headline coverage thresholds into a repository-controlled versioned registry and changes headline evaluators to accept only a stable coverage_policy_id. The production registry is deliberately empty until a substantively justified threshold is adopted, so headline qualification fails closed rather than inventing a default. Outputs record the resolved policy ID, minimum, reference, and registry-enforcement flag. Tests inject synthetic test-only policies and verify unknown IDs, empty production registry, invalid policies, and below-threshold coverage fail closed. Documentation now treats any threshold change as a reviewed specification change in Git history.