### PR TITLE
Enforce forecast-origin registration in persistence evaluation

### DIFF
--- a/docs/point-in-time-persistence-gate.md
+++ b/docs/point-in-time-persistence-gate.md
@@ -1,17 +1,20 @@
 # Point-in-time persistence evaluation gate
 
-A persistence benchmark can be out-of-sample in reference-year terms while still using evidence that was not actually available at the forecast origin. Point-in-time evaluation therefore distinguishes test-row predictor availability from training-outcome availability.
+A persistence benchmark can be out-of-sample in reference-year terms while still using evidence that was not actually available at the forecast origin. Point-in-time evaluation therefore distinguishes test-row predictor availability, the registered forecast-origin rule, and training-outcome availability.
 
 Deployable persistence evaluation requires all of the following:
 
 - the source-specific City Data Fitness eligibility flag (normally `growth_eligible`);
 - `point_in_time_available = true` for eligible forecast rows, produced from explicit predictor and concordance availability dates with verified availability provenance;
+- `forecast_origin_registration_verified = true` for every row entering the point-in-time persistence path, establishing that the as-of dates passed the registered rolling-origin calendar rule;
 - an explicit `outcome_available_date` for every candidate training row; and
 - a nonblank `outcome_available_reference` identifying the evidence supporting that first-availability date.
 
+The downstream persistence evaluator must not trust `point_in_time_available` by itself. That boolean can be copied, reconstructed, or supplied by a caller after the original availability gate. `point_in_time_fitness_gated_forecast_panel` therefore independently requires the origin-registration verification flag as well as the availability-provenance flag. Missing, nonboolean, or false origin-registration verification fails closed. Aggregate and row-level point-in-time outputs record `forecast_origin_registration_gate_enforced = true`.
+
 For each forecast origin, `evaluate_point_in_time_persistence_baselines` and `point_in_time_persistence_errors` resolve that origin's explicit `forecast_origin_date` and retain only historical rows whose outcomes were published on or before that date. A training interval whose reference period ended by the origin but whose statistical release occurred later is not valid training evidence for that origin. The same historical interval can become eligible training evidence at a later origin once its release date has passed.
 
-The deployable path reports both `candidate_training_rows` and `available_training_rows`, sets `training_outcome_availability_enforced = true`, and sets `training_outcome_provenance_enforced = true`. Missing release dates, missing or blank outcome-release provenance, ambiguous forecast-origin dates, or fewer than two origins with published training outcomes fail closed.
+The deployable path reports both `candidate_training_rows` and `available_training_rows`, sets `training_outcome_availability_enforced = true`, `training_outcome_provenance_enforced = true`, and `forecast_origin_registration_gate_enforced = true`. Missing release dates, missing or blank outcome-release provenance, unverified origin registration, ambiguous forecast-origin dates, or fewer than two origins with published training outcomes fail closed.
 
 Reference years, enumeration dates, endpoint years, current download dates, or analyst-entered assumptions are not sufficient provenance for `outcome_available_date`. The reference must point to the release notice, archived publication, metadata record, or equivalent evidence establishing when the outcome became observable.
 

--- a/src/urban_growth/forecast_fitness.py
+++ b/src/urban_growth/forecast_fitness.py
@@ -92,31 +92,45 @@ def point_in_time_fitness_gated_forecast_panel(
     eligibility_column: str = "growth_eligible",
     availability_column: str = "point_in_time_available",
     provenance_column: str = "availability_provenance_verified",
+    origin_registration_column: str = "forecast_origin_registration_verified",
 ) -> pd.DataFrame:
-    """Return rows passing fitness plus an auditable point-in-time availability gate."""
+    """Return rows passing fitness plus auditable point-in-time and origin-rule gates."""
     require_columns(
         panel,
-        {availability_column, provenance_column},
+        {availability_column, provenance_column, origin_registration_column},
         source_name="point-in-time forecast panel",
     )
     availability = panel[availability_column]
     provenance = panel[provenance_column]
+    origin_registration = panel[origin_registration_column]
     if not pd.api.types.is_bool_dtype(availability.dtype):
         raise SourceSchemaError(f"{availability_column} must be boolean")
     if not pd.api.types.is_bool_dtype(provenance.dtype):
         raise SourceSchemaError(f"{provenance_column} must be boolean")
+    if not pd.api.types.is_bool_dtype(origin_registration.dtype):
+        raise SourceSchemaError(f"{origin_registration_column} must be boolean")
     if not provenance.all():
         raise SourceSchemaError(
             "Point-in-time persistence requires verified availability provenance for every row"
         )
+    if not origin_registration.all():
+        raise SourceSchemaError(
+            "Point-in-time persistence requires verified forecast-origin registration for every row"
+        )
     gated = fitness_gated_forecast_panel(panel, eligibility_column=eligibility_column)
-    result = gated.loc[gated[availability_column] & gated[provenance_column]].copy()
+    result = gated.loc[
+        gated[availability_column]
+        & gated[provenance_column]
+        & gated[origin_registration_column]
+    ].copy()
     if result.empty:
-        raise SourceSchemaError("No forecast rows pass both fitness and point-in-time gates")
+        raise SourceSchemaError("No forecast rows pass fitness and point-in-time gates")
     result["forecast_availability_gate"] = availability_column
     result["forecast_availability_gate_passed"] = True
     result["forecast_availability_provenance_gate"] = provenance_column
     result["forecast_availability_provenance_gate_passed"] = True
+    result["forecast_origin_registration_gate"] = origin_registration_column
+    result["forecast_origin_registration_gate_passed"] = True
     return result.reset_index(drop=True)
 
 
@@ -256,6 +270,7 @@ def evaluate_point_in_time_persistence_baselines(
     eligibility_column: str = "growth_eligible",
     availability_column: str = "point_in_time_available",
     provenance_column: str = "availability_provenance_verified",
+    origin_registration_column: str = "forecast_origin_registration_verified",
     forecast_origin_date_column: str = "forecast_origin_date",
     outcome_available_column: str = "outcome_available_date",
     outcome_available_reference_column: str = "outcome_available_reference",
@@ -267,6 +282,7 @@ def evaluate_point_in_time_persistence_baselines(
         eligibility_column=eligibility_column,
         availability_column=availability_column,
         provenance_column=provenance_column,
+        origin_registration_column=origin_registration_column,
     )
     horizon = _validate_single_horizon(gated)
     declared = _validate_declared_origins(gated, origins)
@@ -307,6 +323,8 @@ def evaluate_point_in_time_persistence_baselines(
     result["availability_gate_enforced"] = True
     result["availability_provenance_gate"] = provenance_column
     result["availability_provenance_gate_enforced"] = True
+    result["forecast_origin_registration_gate"] = origin_registration_column
+    result["forecast_origin_registration_gate_enforced"] = True
     result["training_outcome_availability_column"] = outcome_available_column
     result["training_outcome_provenance_column"] = outcome_available_reference_column
     result["benchmark_stage"] = "point_in_time_persistence_only"
@@ -343,6 +361,7 @@ def point_in_time_persistence_errors(
     eligibility_column: str = "growth_eligible",
     availability_column: str = "point_in_time_available",
     provenance_column: str = "availability_provenance_verified",
+    origin_registration_column: str = "forecast_origin_registration_verified",
     forecast_origin_date_column: str = "forecast_origin_date",
     outcome_available_column: str = "outcome_available_date",
     outcome_available_reference_column: str = "outcome_available_reference",
@@ -354,6 +373,7 @@ def point_in_time_persistence_errors(
         eligibility_column=eligibility_column,
         availability_column=availability_column,
         provenance_column=provenance_column,
+        origin_registration_column=origin_registration_column,
     )
     horizon = _validate_single_horizon(gated)
     declared = _validate_declared_origins(gated, origins)
@@ -392,6 +412,8 @@ def point_in_time_persistence_errors(
     result["availability_gate_enforced"] = True
     result["availability_provenance_gate"] = provenance_column
     result["availability_provenance_gate_enforced"] = True
+    result["forecast_origin_registration_gate"] = origin_registration_column
+    result["forecast_origin_registration_gate_enforced"] = True
     result["training_outcome_availability_column"] = outcome_available_column
     result["training_outcome_provenance_column"] = outcome_available_reference_column
     result["benchmark_stage"] = "point_in_time_persistence_only"

--- a/tests/test_forecast_fitness.py
+++ b/tests/test_forecast_fitness.py
@@ -33,6 +33,7 @@ def forecast_panel() -> pd.DataFrame:
                     "growth_eligible": True,
                     "point_in_time_available": True,
                     "availability_provenance_verified": True,
+                    "forecast_origin_registration_verified": True,
                     "forecast_origin_date": f"{start}-12-31",
                     "outcome_available_date": f"{end}-06-30",
                     "outcome_available_reference": f"official-release-{end}",
@@ -72,6 +73,19 @@ def test_point_in_time_gate_requires_verified_provenance() -> None:
         point_in_time_fitness_gated_forecast_panel(panel)
 
 
+def test_point_in_time_gate_requires_origin_registration_column() -> None:
+    panel = forecast_panel().drop(columns="forecast_origin_registration_verified")
+    with pytest.raises(SourceSchemaError, match="forecast_origin_registration_verified"):
+        point_in_time_fitness_gated_forecast_panel(panel)
+
+
+def test_point_in_time_gate_rejects_unverified_origin_registration() -> None:
+    panel = forecast_panel()
+    panel.loc[0, "forecast_origin_registration_verified"] = False
+    with pytest.raises(SourceSchemaError, match="verified forecast-origin registration"):
+        point_in_time_fitness_gated_forecast_panel(panel)
+
+
 def test_point_in_time_gate_excludes_late_rows_after_fitness_gate() -> None:
     panel = forecast_panel()
     panel.loc[
@@ -83,6 +97,7 @@ def test_point_in_time_gate_excludes_late_rows_after_fitness_gate() -> None:
     assert not ((result["city_id"] == "C") & (result["period_start"] == 2010)).any()
     assert result["forecast_availability_gate_passed"].all()
     assert result["forecast_availability_provenance_gate_passed"].all()
+    assert result["forecast_origin_registration_gate_passed"].all()
 
 
 def test_persistence_oos_requires_multiple_usable_origins() -> None:
@@ -120,6 +135,7 @@ def test_point_in_time_persistence_cannot_score_late_test_rows() -> None:
     assert result["fitness_gate_enforced"].all()
     assert result["availability_gate_enforced"].all()
     assert result["availability_provenance_gate_enforced"].all()
+    assert result["forecast_origin_registration_gate_enforced"].all()
     assert result["training_outcome_availability_enforced"].all()
     assert result["training_outcome_provenance_enforced"].all()
     assert result["benchmark_stage"].eq("point_in_time_persistence_only").all()
@@ -174,5 +190,6 @@ def test_point_in_time_errors_cannot_reintroduce_late_rows() -> None:
     assert excluded.empty
     assert errors["availability_gate_enforced"].all()
     assert errors["availability_provenance_gate_enforced"].all()
+    assert errors["forecast_origin_registration_gate_enforced"].all()
     assert errors["training_outcome_availability_enforced"].all()
     assert errors["training_outcome_provenance_enforced"].all()

--- a/tests/test_forecast_headline.py
+++ b/tests/test_forecast_headline.py
@@ -51,6 +51,7 @@ def _panel() -> pd.DataFrame:
                     "growth_eligible": True,
                     "point_in_time_available": True,
                     "availability_provenance_verified": True,
+                    "forecast_origin_registration_verified": True,
                     "forecast_origin_date": f"{start}-12-31",
                     "outcome_available_date": f"{end}-06-30",
                     "outcome_available_reference": f"official-release-{end}",
@@ -94,6 +95,7 @@ def test_headline_metrics_attach_registered_policy_and_coverage() -> None:
     assert result["coverage_policy_passed"].all()
     assert result["coverage_policy_id"].eq(TEST_POLICY_ID).all()
     assert result["minimum_observed_outcome_share"].eq(0.60).all()
+    assert result["forecast_origin_registration_gate_enforced"].all()
 
 
 def test_headline_errors_attach_same_registered_policy() -> None:
@@ -102,6 +104,16 @@ def test_headline_errors_attach_same_registered_policy() -> None:
     )
     assert result["coverage_policy_registry_enforced"].all()
     assert result["coverage_policy_id"].eq(TEST_POLICY_ID).all()
+    assert result["forecast_origin_registration_gate_enforced"].all()
+
+
+def test_headline_rejects_unverified_origin_registration() -> None:
+    panel = _panel()
+    panel.loc[0, "forecast_origin_registration_verified"] = False
+    with pytest.raises(SourceSchemaError, match="verified forecast-origin registration"):
+        evaluate_headline_point_in_time_persistence(
+            panel, [2005, 2010], _coverage(), coverage_policy_id=TEST_POLICY_ID
+        )
 
 
 def test_unknown_runtime_policy_id_fails_closed() -> None:


### PR DESCRIPTION
Closes a downstream bypass left after the forecast-origin registration rule was introduced. The availability constructor verifies `forecast_origin_registration_verified`, but `point_in_time_fitness_gated_forecast_panel` previously trusted only `point_in_time_available` and availability provenance. A caller could therefore construct a panel with a true availability boolean and bypass the registered origin-calendar rule. This PR requires the origin-registration verification flag independently in the persistence gate, propagates it through aggregate and row-level point-in-time outputs, adds fail-closed tests for missing/false registration, updates headline fixtures, and documents that `point_in_time_available` is not sufficient by itself.