### PR TITLE
Use current-origin availability for persistence training rows

### DIFF
--- a/docs/point-in-time-persistence-gate.md
+++ b/docs/point-in-time-persistence-gate.md
@@ -1,21 +1,33 @@
 # Point-in-time persistence evaluation gate
 
-A persistence benchmark can be out-of-sample in reference-year terms while still using evidence that was not actually available at the forecast origin. Point-in-time evaluation therefore distinguishes test-row predictor availability, the registered forecast-origin rule, and training-outcome availability.
+A persistence benchmark can be out-of-sample in reference-year terms while still using evidence that was not actually available at the forecast origin. Point-in-time evaluation therefore distinguishes test-row deployability at its own origin from training-row availability at the current evaluation origin.
 
 Deployable persistence evaluation requires all of the following:
 
 - the source-specific City Data Fitness eligibility flag (normally `growth_eligible`);
-- `point_in_time_available = true` for eligible forecast rows, produced from explicit predictor and concordance availability dates with verified availability provenance;
-- `forecast_origin_registration_verified = true` for every row entering the point-in-time persistence path, establishing that the as-of dates passed the registered rolling-origin calendar rule;
-- an explicit `outcome_available_date` for every candidate training row; and
-- a nonblank `outcome_available_reference` identifying the evidence supporting that first-availability date.
+- `point_in_time_available = true` for test rows at the origin being scored;
+- verified predictor and concordance availability provenance;
+- `forecast_origin_registration_verified = true` for every row entering the point-in-time persistence path;
+- explicit predictor, concordance, and outcome availability dates for candidate training rows; and
+- nonblank provenance supporting those availability dates.
 
-The downstream persistence evaluator must not trust `point_in_time_available` by itself. That boolean can be copied, reconstructed, or supplied by a caller after the original availability gate. `point_in_time_fitness_gated_forecast_panel` therefore independently requires the origin-registration verification flag as well as the availability-provenance flag. Missing, nonboolean, or false origin-registration verification fails closed. Aggregate and row-level point-in-time outputs record `forecast_origin_registration_gate_enforced = true`.
+## Test rows versus training rows
 
-For each forecast origin, `evaluate_point_in_time_persistence_baselines` and `point_in_time_persistence_errors` resolve that origin's explicit `forecast_origin_date` and retain only historical rows whose outcomes were published on or before that date. A training interval whose reference period ended by the origin but whose statistical release occurred later is not valid training evidence for that origin. The same historical interval can become eligible training evidence at a later origin once its release date has passed.
+The test sample for origin `t` is evaluated exactly as-of its own registered forecast date. A test row whose predictor or concordance was not available at that date cannot be scored at `t`.
 
-The deployable path reports both `candidate_training_rows` and `available_training_rows`, sets `training_outcome_availability_enforced = true`, `training_outcome_provenance_enforced = true`, and `forecast_origin_registration_gate_enforced = true`. Missing release dates, missing or blank outcome-release provenance, unverified origin registration, ambiguous forecast-origin dates, or fewer than two origins with published training outcomes fail closed.
+Historical training rows use a different rule. They are **not** required to have been deployable at their own earlier forecast origin. For each current evaluation origin, a historical row may enter training if all evidence needed by the persistence benchmark is available by the current origin's as-of date:
 
-Reference years, enumeration dates, endpoint years, current download dates, or analyst-entered assumptions are not sufficient provenance for `outcome_available_date`. The reference must point to the release notice, archived publication, metadata record, or equivalent evidence establishing when the outcome became observable.
+- the row's reference interval ended by the current origin;
+- `predictor_available_date <= current forecast_origin_date`;
+- `concordance_available_date <= current forecast_origin_date`; and
+- `outcome_available_date <= current forecast_origin_date`.
+
+This matters because a row can legitimately be unavailable in real time at, for example, its 2000 origin but become fully observable before a 2010 forecast. Permanently excluding it because `point_in_time_available` was false in 2000 would understate the information set available in 2010 and could distort comparisons across models or origins.
+
+The training gate therefore evaluates availability **as of the current origin**, not the historical row's own origin. The implementation reports `training_uses_current_origin_as_of = true`, along with `training_predictor_availability_enforced`, `training_concordance_availability_enforced`, and `training_outcome_availability_enforced`.
+
+The downstream evaluator still independently requires verified origin registration and availability provenance; it does not trust a caller-supplied `point_in_time_available` boolean as sufficient evidence.
+
+Reference years, enumeration dates, endpoint years, current download dates, or analyst-entered assumptions are not sufficient provenance for availability dates. Evidence should point to the relevant statistical release, archived publication, geography release, metadata record, or equivalent source establishing when the information became observable.
 
 The original `evaluate_fitness_gated_persistence_baselines` remains available for retrospective sensitivity analysis and must not by itself be described as real-time or deployable-at-origin performance.

--- a/src/urban_growth/forecast_fitness.py
+++ b/src/urban_growth/forecast_fitness.py
@@ -18,32 +18,28 @@ PERSISTENCE_BASELINE_MODELS = {
 
 
 def _attach_forecast_horizon(panel: pd.DataFrame) -> pd.DataFrame:
-    """Attach the target horizon without counting any pre-outcome gap as forecast time."""
     out = panel.copy()
     period_end = pd.to_numeric(out["period_end"], errors="coerce")
     period_start = pd.to_numeric(out["period_start"], errors="coerce")
-
     derived: pd.Series | None = None
     if "outcome_start_year" in out.columns:
-        outcome_start = pd.to_numeric(out["outcome_start_year"], errors="coerce")
-        derived = period_end - outcome_start
+        derived = period_end - pd.to_numeric(out["outcome_start_year"], errors="coerce")
     elif "outcome_gap_years" in out.columns:
-        outcome_gap = pd.to_numeric(out["outcome_gap_years"], errors="coerce")
-        derived = period_end - (period_start + outcome_gap)
+        gap = pd.to_numeric(out["outcome_gap_years"], errors="coerce")
+        derived = period_end - (period_start + gap)
     elif "forecast_horizon_years" not in out.columns:
         derived = period_end - period_start
-
-    explicit: pd.Series | None = None
-    if "forecast_horizon_years" in out.columns:
-        explicit = pd.to_numeric(out["forecast_horizon_years"], errors="coerce")
-
+    explicit = (
+        pd.to_numeric(out["forecast_horizon_years"], errors="coerce")
+        if "forecast_horizon_years" in out.columns
+        else None
+    )
     if explicit is not None and derived is not None:
         mismatch = explicit.notna() & derived.notna() & explicit.ne(derived)
         if mismatch.any():
             raise SourceSchemaError(
                 "Explicit forecast_horizon_years disagrees with the declared outcome interval"
             )
-
     horizon = explicit if explicit is not None else derived
     if horizon is None or horizon.isna().any() or horizon.le(0).any():
         raise SourceSchemaError("forecast_horizon_years must be positive and known for every row")
@@ -56,7 +52,6 @@ def fitness_gated_forecast_panel(
     *,
     eligibility_column: str = "growth_eligible",
 ) -> pd.DataFrame:
-    """Return only explicitly eligible forecast rows."""
     require_columns(
         panel,
         {
@@ -94,7 +89,6 @@ def point_in_time_fitness_gated_forecast_panel(
     provenance_column: str = "availability_provenance_verified",
     origin_registration_column: str = "forecast_origin_registration_verified",
 ) -> pd.DataFrame:
-    """Return rows passing fitness plus auditable point-in-time and origin-rule gates."""
     require_columns(
         panel,
         {availability_column, provenance_column, origin_registration_column},
@@ -159,9 +153,7 @@ def _validate_multi_origin_oos(panel: pd.DataFrame, origins: list[int]) -> list[
     declared = _validate_declared_origins(panel, origins)
     usable = []
     for origin in declared:
-        has_train = panel["period_end"].le(origin).any()
-        has_test = panel["period_start"].eq(origin).any()
-        if has_train and has_test:
+        if panel["period_end"].le(origin).any() and panel["period_start"].eq(origin).any():
             usable.append(origin)
     if len(usable) < 2:
         raise SourceSchemaError(
@@ -171,48 +163,99 @@ def _validate_multi_origin_oos(panel: pd.DataFrame, origins: list[int]) -> list[
     return usable
 
 
+def _nonblank_strings(panel: pd.DataFrame, column: str) -> pd.Series:
+    values = panel[column].astype("string").str.strip()
+    if values.isna().any() or values.eq("").any():
+        raise SourceSchemaError(f"{column} must provide provenance for every availability date")
+    return values
+
+
+def _point_in_time_evidence_panel(
+    panel: pd.DataFrame,
+    *,
+    eligibility_column: str,
+    availability_column: str,
+    provenance_column: str,
+    origin_registration_column: str,
+    predictor_available_column: str,
+    concordance_available_column: str,
+    predictor_reference_column: str,
+    concordance_reference_column: str,
+    outcome_available_column: str,
+    outcome_available_reference_column: str,
+) -> pd.DataFrame:
+    required = {
+        availability_column,
+        provenance_column,
+        origin_registration_column,
+        predictor_available_column,
+        concordance_available_column,
+        predictor_reference_column,
+        concordance_reference_column,
+        outcome_available_column,
+        outcome_available_reference_column,
+    }
+    require_columns(panel, required, source_name="point-in-time persistence evidence panel")
+    for column in (availability_column, provenance_column, origin_registration_column):
+        if not pd.api.types.is_bool_dtype(panel[column].dtype):
+            raise SourceSchemaError(f"{column} must be boolean")
+    if not panel[provenance_column].all():
+        raise SourceSchemaError(
+            "Point-in-time persistence requires verified availability provenance for every row"
+        )
+    if not panel[origin_registration_column].all():
+        raise SourceSchemaError(
+            "Point-in-time persistence requires verified forecast-origin registration for every row"
+        )
+    _nonblank_strings(panel, predictor_reference_column)
+    _nonblank_strings(panel, concordance_reference_column)
+    _nonblank_strings(panel, outcome_available_reference_column)
+    for column in (
+        predictor_available_column,
+        concordance_available_column,
+        outcome_available_column,
+    ):
+        if pd.to_datetime(panel[column], errors="coerce").isna().any():
+            raise SourceSchemaError(f"{column} must be known for every point-in-time forecast row")
+    return fitness_gated_forecast_panel(panel, eligibility_column=eligibility_column)
+
+
 def _origin_specific_point_in_time_panel(
     panel: pd.DataFrame,
     origin: int,
     *,
+    availability_column: str,
     forecast_origin_date_column: str,
+    predictor_available_column: str,
+    concordance_available_column: str,
     outcome_available_column: str,
-    outcome_available_reference_column: str,
 ) -> tuple[pd.DataFrame, int, int]:
-    """Return one origin's test rows plus only auditable, published training outcomes."""
-    require_columns(
-        panel,
-        {
-            forecast_origin_date_column,
-            outcome_available_column,
-            outcome_available_reference_column,
-        },
-        source_name="point-in-time persistence panel",
-    )
-    references = panel[outcome_available_reference_column].fillna("").astype(str).str.strip()
-    if references.eq("").any():
-        raise SourceSchemaError(
-            f"{outcome_available_reference_column} must provide provenance for every outcome release date"
-        )
-    test = panel.loc[panel["period_start"].eq(origin)].copy()
-    if test.empty:
+    test_all = panel.loc[panel["period_start"].eq(origin)].copy()
+    if test_all.empty:
         raise SourceSchemaError(f"Point-in-time panel lacks test rows for origin {origin}")
-    origin_dates = pd.to_datetime(test[forecast_origin_date_column], errors="coerce")
+    origin_dates = pd.to_datetime(test_all[forecast_origin_date_column], errors="coerce")
     if origin_dates.isna().any() or origin_dates.nunique() != 1:
         raise SourceSchemaError(
             f"{forecast_origin_date_column} must resolve to one valid date per forecast origin"
         )
     as_of = origin_dates.iloc[0]
+    test = test_all.loc[test_all[availability_column]].copy()
+    if test.empty:
+        raise SourceSchemaError(f"No test rows were available at forecast origin {origin}")
+
+    predictor_available = pd.to_datetime(panel[predictor_available_column], errors="coerce")
+    concordance_available = pd.to_datetime(panel[concordance_available_column], errors="coerce")
     outcome_available = pd.to_datetime(panel[outcome_available_column], errors="coerce")
-    if outcome_available.isna().any():
-        raise SourceSchemaError(
-            f"{outcome_available_column} must be known for every point-in-time forecast row"
-        )
     candidate_train = panel["period_end"].le(origin)
-    available_train = candidate_train & outcome_available.le(as_of)
+    available_train = (
+        candidate_train
+        & predictor_available.le(as_of)
+        & concordance_available.le(as_of)
+        & outcome_available.le(as_of)
+    )
     train = panel.loc[available_train].copy()
     if train.empty:
-        raise SourceSchemaError(f"No training outcomes were published by forecast origin {origin}")
+        raise SourceSchemaError(f"No training evidence was available by forecast origin {origin}")
     combined = pd.concat([train, test], ignore_index=True)
     reject_duplicate_keys(
         combined,
@@ -252,7 +295,6 @@ def evaluate_fitness_gated_persistence_baselines(
     eligibility_column: str = "growth_eligible",
     outcome_column: str = "future_growth",
 ) -> pd.DataFrame:
-    """Evaluate retrospective persistence baselines on fitness-eligible rows only."""
     gated = fitness_gated_forecast_panel(panel, eligibility_column=eligibility_column)
     return _evaluate_persistence_baselines(
         gated,
@@ -261,6 +303,96 @@ def evaluate_fitness_gated_persistence_baselines(
         outcome_column=outcome_column,
         benchmark_stage="retrospective_persistence_only",
     )
+
+
+def _evaluate_point_in_time(
+    panel: pd.DataFrame,
+    origins: list[int],
+    *,
+    row_errors: bool,
+    eligibility_column: str,
+    availability_column: str,
+    provenance_column: str,
+    origin_registration_column: str,
+    forecast_origin_date_column: str,
+    predictor_available_column: str,
+    concordance_available_column: str,
+    predictor_reference_column: str,
+    concordance_reference_column: str,
+    outcome_available_column: str,
+    outcome_available_reference_column: str,
+    outcome_column: str,
+) -> pd.DataFrame:
+    gated = _point_in_time_evidence_panel(
+        panel,
+        eligibility_column=eligibility_column,
+        availability_column=availability_column,
+        provenance_column=provenance_column,
+        origin_registration_column=origin_registration_column,
+        predictor_available_column=predictor_available_column,
+        concordance_available_column=concordance_available_column,
+        predictor_reference_column=predictor_reference_column,
+        concordance_reference_column=concordance_reference_column,
+        outcome_available_column=outcome_available_column,
+        outcome_available_reference_column=outcome_available_reference_column,
+    )
+    horizon = _validate_single_horizon(gated)
+    declared = _validate_declared_origins(gated, origins)
+    frames: list[pd.DataFrame] = []
+    for origin in declared:
+        try:
+            origin_panel, candidate_train_n, available_train_n = _origin_specific_point_in_time_panel(
+                gated,
+                origin,
+                availability_column=availability_column,
+                forecast_origin_date_column=forecast_origin_date_column,
+                predictor_available_column=predictor_available_column,
+                concordance_available_column=concordance_available_column,
+                outcome_available_column=outcome_available_column,
+            )
+        except SourceSchemaError as exc:
+            if "No training evidence was available" in str(exc) or "No test rows were available" in str(exc):
+                continue
+            raise
+        scorer = rolling_baseline_errors if row_errors else evaluate_rolling_baselines
+        scored = scorer(origin_panel, [origin], outcome_column=outcome_column)
+        scored = scored.loc[scored["model"].isin(PERSISTENCE_BASELINE_MODELS)].copy()
+        if scored.empty:
+            continue
+        scored["candidate_training_rows"] = candidate_train_n
+        scored["available_training_rows"] = available_train_n
+        scored["training_predictor_availability_enforced"] = True
+        scored["training_concordance_availability_enforced"] = True
+        scored["training_outcome_availability_enforced"] = True
+        scored["training_availability_provenance_enforced"] = True
+        scored["training_uses_current_origin_as_of"] = True
+        frames.append(scored)
+    if len(frames) < 2:
+        raise SourceSchemaError(
+            "Point-in-time persistence requires at least two origins with available training evidence and test rows"
+        )
+    result = pd.concat(frames, ignore_index=True)
+    if not row_errors and (
+        "persistence" not in set(result["model"]) or "zero_growth" not in set(result["model"])
+    ):
+        raise SourceSchemaError("Required persistence-stage baselines were not produced")
+    result["fitness_gate"] = eligibility_column
+    result["fitness_gate_enforced"] = True
+    result["availability_gate"] = availability_column
+    result["availability_gate_enforced"] = True
+    result["availability_provenance_gate"] = provenance_column
+    result["availability_provenance_gate_enforced"] = True
+    result["forecast_origin_registration_gate"] = origin_registration_column
+    result["forecast_origin_registration_gate_enforced"] = True
+    result["training_predictor_availability_column"] = predictor_available_column
+    result["training_concordance_availability_column"] = concordance_available_column
+    result["training_outcome_availability_column"] = outcome_available_column
+    result["training_outcome_provenance_column"] = outcome_available_reference_column
+    result["benchmark_stage"] = "point_in_time_persistence_only"
+    result["forecast_horizon_years"] = horizon
+    if row_errors:
+        return result.reset_index(drop=True)
+    return result.sort_values(["origin", "model"]).reset_index(drop=True)
 
 
 def evaluate_point_in_time_persistence_baselines(
@@ -272,64 +404,31 @@ def evaluate_point_in_time_persistence_baselines(
     provenance_column: str = "availability_provenance_verified",
     origin_registration_column: str = "forecast_origin_registration_verified",
     forecast_origin_date_column: str = "forecast_origin_date",
+    predictor_available_column: str = "predictor_available_date",
+    concordance_available_column: str = "concordance_available_date",
+    predictor_reference_column: str = "predictor_availability_source",
+    concordance_reference_column: str = "concordance_availability_source",
     outcome_available_column: str = "outcome_available_date",
     outcome_available_reference_column: str = "outcome_available_reference",
     outcome_column: str = "future_growth",
 ) -> pd.DataFrame:
-    """Evaluate deployable persistence baselines with auditable timing gates."""
-    gated = point_in_time_fitness_gated_forecast_panel(
+    return _evaluate_point_in_time(
         panel,
+        origins,
+        row_errors=False,
         eligibility_column=eligibility_column,
         availability_column=availability_column,
         provenance_column=provenance_column,
         origin_registration_column=origin_registration_column,
+        forecast_origin_date_column=forecast_origin_date_column,
+        predictor_available_column=predictor_available_column,
+        concordance_available_column=concordance_available_column,
+        predictor_reference_column=predictor_reference_column,
+        concordance_reference_column=concordance_reference_column,
+        outcome_available_column=outcome_available_column,
+        outcome_available_reference_column=outcome_available_reference_column,
+        outcome_column=outcome_column,
     )
-    horizon = _validate_single_horizon(gated)
-    declared = _validate_declared_origins(gated, origins)
-    frames: list[pd.DataFrame] = []
-    for origin in declared:
-        try:
-            origin_panel, candidate_train_n, available_train_n = _origin_specific_point_in_time_panel(
-                gated,
-                origin,
-                forecast_origin_date_column=forecast_origin_date_column,
-                outcome_available_column=outcome_available_column,
-                outcome_available_reference_column=outcome_available_reference_column,
-            )
-        except SourceSchemaError as exc:
-            if "No training outcomes were published" in str(exc):
-                continue
-            raise
-        scored = evaluate_rolling_baselines(origin_panel, [origin], outcome_column=outcome_column)
-        scored = scored.loc[scored["model"].isin(PERSISTENCE_BASELINE_MODELS)].copy()
-        if scored.empty:
-            continue
-        scored["candidate_training_rows"] = candidate_train_n
-        scored["available_training_rows"] = available_train_n
-        scored["training_outcome_availability_enforced"] = True
-        scored["training_outcome_provenance_enforced"] = True
-        frames.append(scored)
-    if len(frames) < 2:
-        raise SourceSchemaError(
-            "Point-in-time persistence benchmark requires at least two origins with published "
-            "training outcomes and eligible test rows"
-        )
-    result = pd.concat(frames, ignore_index=True)
-    if "persistence" not in set(result["model"]) or "zero_growth" not in set(result["model"]):
-        raise SourceSchemaError("Required persistence-stage baselines were not produced")
-    result["fitness_gate"] = eligibility_column
-    result["fitness_gate_enforced"] = True
-    result["availability_gate"] = availability_column
-    result["availability_gate_enforced"] = True
-    result["availability_provenance_gate"] = provenance_column
-    result["availability_provenance_gate_enforced"] = True
-    result["forecast_origin_registration_gate"] = origin_registration_column
-    result["forecast_origin_registration_gate_enforced"] = True
-    result["training_outcome_availability_column"] = outcome_available_column
-    result["training_outcome_provenance_column"] = outcome_available_reference_column
-    result["benchmark_stage"] = "point_in_time_persistence_only"
-    result["forecast_horizon_years"] = horizon
-    return result.sort_values(["origin", "model"]).reset_index(drop=True)
 
 
 def fitness_gated_persistence_errors(
@@ -339,7 +438,6 @@ def fitness_gated_persistence_errors(
     eligibility_column: str = "growth_eligible",
     outcome_column: str = "future_growth",
 ) -> pd.DataFrame:
-    """Return retrospective row-level errors for the fitness-gated baseline ladder."""
     gated = fitness_gated_forecast_panel(panel, eligibility_column=eligibility_column)
     horizon = _validate_single_horizon(gated)
     usable_origins = _validate_multi_origin_oos(gated, origins)
@@ -363,59 +461,28 @@ def point_in_time_persistence_errors(
     provenance_column: str = "availability_provenance_verified",
     origin_registration_column: str = "forecast_origin_registration_verified",
     forecast_origin_date_column: str = "forecast_origin_date",
+    predictor_available_column: str = "predictor_available_date",
+    concordance_available_column: str = "concordance_available_date",
+    predictor_reference_column: str = "predictor_availability_source",
+    concordance_reference_column: str = "concordance_availability_source",
     outcome_available_column: str = "outcome_available_date",
     outcome_available_reference_column: str = "outcome_available_reference",
     outcome_column: str = "future_growth",
 ) -> pd.DataFrame:
-    """Return row-level errors after auditable predictor and training-outcome timing gates."""
-    gated = point_in_time_fitness_gated_forecast_panel(
+    return _evaluate_point_in_time(
         panel,
+        origins,
+        row_errors=True,
         eligibility_column=eligibility_column,
         availability_column=availability_column,
         provenance_column=provenance_column,
         origin_registration_column=origin_registration_column,
+        forecast_origin_date_column=forecast_origin_date_column,
+        predictor_available_column=predictor_available_column,
+        concordance_available_column=concordance_available_column,
+        predictor_reference_column=predictor_reference_column,
+        concordance_reference_column=concordance_reference_column,
+        outcome_available_column=outcome_available_column,
+        outcome_available_reference_column=outcome_available_reference_column,
+        outcome_column=outcome_column,
     )
-    horizon = _validate_single_horizon(gated)
-    declared = _validate_declared_origins(gated, origins)
-    frames: list[pd.DataFrame] = []
-    for origin in declared:
-        try:
-            origin_panel, candidate_train_n, available_train_n = _origin_specific_point_in_time_panel(
-                gated,
-                origin,
-                forecast_origin_date_column=forecast_origin_date_column,
-                outcome_available_column=outcome_available_column,
-                outcome_available_reference_column=outcome_available_reference_column,
-            )
-        except SourceSchemaError as exc:
-            if "No training outcomes were published" in str(exc):
-                continue
-            raise
-        scored = rolling_baseline_errors(origin_panel, [origin], outcome_column=outcome_column)
-        scored = scored.loc[scored["model"].isin(PERSISTENCE_BASELINE_MODELS)].copy()
-        if scored.empty:
-            continue
-        scored["candidate_training_rows"] = candidate_train_n
-        scored["available_training_rows"] = available_train_n
-        scored["training_outcome_availability_enforced"] = True
-        scored["training_outcome_provenance_enforced"] = True
-        frames.append(scored)
-    if len(frames) < 2:
-        raise SourceSchemaError(
-            "Point-in-time persistence errors require at least two origins with published "
-            "training outcomes and eligible test rows"
-        )
-    result = pd.concat(frames, ignore_index=True)
-    result["fitness_gate"] = eligibility_column
-    result["fitness_gate_enforced"] = True
-    result["availability_gate"] = availability_column
-    result["availability_gate_enforced"] = True
-    result["availability_provenance_gate"] = provenance_column
-    result["availability_provenance_gate_enforced"] = True
-    result["forecast_origin_registration_gate"] = origin_registration_column
-    result["forecast_origin_registration_gate_enforced"] = True
-    result["training_outcome_availability_column"] = outcome_available_column
-    result["training_outcome_provenance_column"] = outcome_available_reference_column
-    result["benchmark_stage"] = "point_in_time_persistence_only"
-    result["forecast_horizon_years"] = horizon
-    return result.reset_index(drop=True)

--- a/tests/test_forecast_fitness.py
+++ b/tests/test_forecast_fitness.py
@@ -35,6 +35,10 @@ def forecast_panel() -> pd.DataFrame:
                     "availability_provenance_verified": True,
                     "forecast_origin_registration_verified": True,
                     "forecast_origin_date": f"{start}-12-31",
+                    "predictor_available_date": f"{start}-01-01",
+                    "concordance_available_date": f"{start}-01-01",
+                    "predictor_availability_source": f"predictor-release-{start}",
+                    "concordance_availability_source": f"geography-release-{start}",
                     "outcome_available_date": f"{end}-06-30",
                     "outcome_available_reference": f"official-release-{end}",
                 }
@@ -107,10 +111,6 @@ def test_persistence_oos_requires_multiple_usable_origins() -> None:
 
 def test_persistence_oos_scores_only_fitness_eligible_test_rows() -> None:
     result = evaluate_fitness_gated_persistence_baselines(forecast_panel(), [2005, 2010])
-    assert {"zero_growth", "persistence"}.issubset(set(result["model"]))
-    assert result["fitness_gate_enforced"].all()
-    assert result["benchmark_stage"].eq("retrospective_persistence_only").all()
-    assert result["forecast_horizon_years"].eq(5.0).all()
     counts = result.pivot(index="origin", columns="model", values="n")
     assert counts.loc[2005, "persistence"] == 3
     assert counts.loc[2010, "persistence"] == 2
@@ -132,13 +132,34 @@ def test_point_in_time_persistence_cannot_score_late_test_rows() -> None:
     result = evaluate_point_in_time_persistence_baselines(panel, [2005, 2010])
     counts = result.pivot(index="origin", columns="model", values="n")
     assert counts.loc[2010, "persistence"] == 1
-    assert result["fitness_gate_enforced"].all()
-    assert result["availability_gate_enforced"].all()
-    assert result["availability_provenance_gate_enforced"].all()
-    assert result["forecast_origin_registration_gate_enforced"].all()
+    assert result["training_uses_current_origin_as_of"].all()
+    assert result["training_predictor_availability_enforced"].all()
+    assert result["training_concordance_availability_enforced"].all()
     assert result["training_outcome_availability_enforced"].all()
-    assert result["training_outcome_provenance_enforced"].all()
-    assert result["benchmark_stage"].eq("point_in_time_persistence_only").all()
+
+
+def test_later_origin_training_can_use_row_unavailable_at_its_own_origin() -> None:
+    panel = forecast_panel()
+    mask = panel["period_start"].eq(2000)
+    panel.loc[mask, "point_in_time_available"] = False
+    panel.loc[mask, "predictor_available_date"] = "2001-01-01"
+    panel.loc[mask, "concordance_available_date"] = "2001-01-01"
+    result = evaluate_point_in_time_persistence_baselines(panel, [2005, 2010])
+    at_2010 = result.loc[result["origin"].eq(2010)]
+    assert at_2010["candidate_training_rows"].eq(6).all()
+    assert at_2010["available_training_rows"].eq(6).all()
+    assert at_2010["training_uses_current_origin_as_of"].all()
+
+
+def test_training_row_stays_excluded_until_predictor_is_available() -> None:
+    panel = forecast_panel()
+    mask = panel["period_start"].eq(2000)
+    panel.loc[mask, "point_in_time_available"] = False
+    panel.loc[mask, "predictor_available_date"] = "2011-01-01"
+    result = evaluate_point_in_time_persistence_baselines(panel, [2005, 2010])
+    at_2010 = result.loc[result["origin"].eq(2010)]
+    assert at_2010["candidate_training_rows"].eq(6).all()
+    assert at_2010["available_training_rows"].eq(3).all()
 
 
 def test_point_in_time_persistence_excludes_unpublished_training_outcomes() -> None:
@@ -148,8 +169,18 @@ def test_point_in_time_persistence_excludes_unpublished_training_outcomes() -> N
     at_2010 = result.loc[result["origin"].eq(2010)]
     assert at_2010["candidate_training_rows"].eq(6).all()
     assert at_2010["available_training_rows"].eq(3).all()
-    assert at_2010["training_outcome_availability_enforced"].all()
-    assert at_2010["training_outcome_provenance_enforced"].all()
+
+
+def test_point_in_time_persistence_requires_training_predictor_dates() -> None:
+    panel = forecast_panel().drop(columns="predictor_available_date")
+    with pytest.raises(SourceSchemaError, match="predictor_available_date"):
+        evaluate_point_in_time_persistence_baselines(panel, [2005, 2010])
+
+
+def test_point_in_time_persistence_requires_training_concordance_dates() -> None:
+    panel = forecast_panel().drop(columns="concordance_available_date")
+    with pytest.raises(SourceSchemaError, match="concordance_available_date"):
+        evaluate_point_in_time_persistence_baselines(panel, [2005, 2010])
 
 
 def test_point_in_time_persistence_requires_outcome_release_dates() -> None:
@@ -158,16 +189,10 @@ def test_point_in_time_persistence_requires_outcome_release_dates() -> None:
         evaluate_point_in_time_persistence_baselines(panel, [2005, 2010])
 
 
-def test_point_in_time_persistence_requires_outcome_release_provenance() -> None:
-    panel = forecast_panel().drop(columns="outcome_available_reference")
-    with pytest.raises(SourceSchemaError, match="outcome_available_reference"):
-        evaluate_point_in_time_persistence_baselines(panel, [2005, 2010])
-
-
 def test_point_in_time_persistence_rejects_blank_outcome_release_provenance() -> None:
     panel = forecast_panel()
     panel.loc[0, "outcome_available_reference"] = "  "
-    with pytest.raises(SourceSchemaError, match="provenance for every outcome release date"):
+    with pytest.raises(SourceSchemaError, match="outcome_available_reference"):
         evaluate_point_in_time_persistence_baselines(panel, [2005, 2010])
 
 
@@ -175,21 +200,14 @@ def test_row_level_errors_cannot_reintroduce_ineligible_rows() -> None:
     errors = fitness_gated_persistence_errors(forecast_panel(), [2005, 2010])
     excluded = errors.loc[(errors["city_id"] == "B") & (errors["origin"] == 2010)]
     assert excluded.empty
-    assert errors["fitness_gate_enforced"].all()
-    assert errors["forecast_horizon_years"].eq(5.0).all()
 
 
-def test_point_in_time_errors_cannot_reintroduce_late_rows() -> None:
+def test_point_in_time_errors_use_same_current_origin_training_gate() -> None:
     panel = forecast_panel()
-    panel.loc[
-        (panel["city_id"] == "C") & (panel["period_start"] == 2010),
-        "point_in_time_available",
-    ] = False
+    mask = panel["period_start"].eq(2000)
+    panel.loc[mask, "point_in_time_available"] = False
+    panel.loc[mask, "predictor_available_date"] = "2001-01-01"
     errors = point_in_time_persistence_errors(panel, [2005, 2010])
-    excluded = errors.loc[(errors["city_id"] == "C") & (errors["origin"] == 2010)]
-    assert excluded.empty
-    assert errors["availability_gate_enforced"].all()
-    assert errors["availability_provenance_gate_enforced"].all()
-    assert errors["forecast_origin_registration_gate_enforced"].all()
-    assert errors["training_outcome_availability_enforced"].all()
-    assert errors["training_outcome_provenance_enforced"].all()
+    at_2010 = errors.loc[errors["origin"].eq(2010)]
+    assert at_2010["available_training_rows"].eq(6).all()
+    assert at_2010["training_uses_current_origin_as_of"].all()

--- a/tests/test_forecast_fitness.py
+++ b/tests/test_forecast_fitness.py
@@ -153,13 +153,13 @@ def test_later_origin_training_can_use_row_unavailable_at_its_own_origin() -> No
 
 def test_training_row_stays_excluded_until_predictor_is_available() -> None:
     panel = forecast_panel()
-    mask = panel["period_start"].eq(2000)
+    mask = panel["period_start"].eq(2000) & panel["city_id"].eq("A")
     panel.loc[mask, "point_in_time_available"] = False
     panel.loc[mask, "predictor_available_date"] = "2011-01-01"
     result = evaluate_point_in_time_persistence_baselines(panel, [2005, 2010])
     at_2010 = result.loc[result["origin"].eq(2010)]
     assert at_2010["candidate_training_rows"].eq(6).all()
-    assert at_2010["available_training_rows"].eq(3).all()
+    assert at_2010["available_training_rows"].eq(5).all()
 
 
 def test_point_in_time_persistence_excludes_unpublished_training_outcomes() -> None:

--- a/tests/test_forecast_headline.py
+++ b/tests/test_forecast_headline.py
@@ -53,6 +53,10 @@ def _panel() -> pd.DataFrame:
                     "availability_provenance_verified": True,
                     "forecast_origin_registration_verified": True,
                     "forecast_origin_date": f"{start}-12-31",
+                    "predictor_available_date": f"{start}-01-01",
+                    "concordance_available_date": f"{start}-01-01",
+                    "predictor_availability_source": f"predictor-release-{start}",
+                    "concordance_availability_source": f"geography-release-{start}",
                     "outcome_available_date": f"{end}-06-30",
                     "outcome_available_reference": f"official-release-{end}",
                 }
@@ -96,6 +100,7 @@ def test_headline_metrics_attach_registered_policy_and_coverage() -> None:
     assert result["coverage_policy_id"].eq(TEST_POLICY_ID).all()
     assert result["minimum_observed_outcome_share"].eq(0.60).all()
     assert result["forecast_origin_registration_gate_enforced"].all()
+    assert result["training_uses_current_origin_as_of"].all()
 
 
 def test_headline_errors_attach_same_registered_policy() -> None:
@@ -105,6 +110,7 @@ def test_headline_errors_attach_same_registered_policy() -> None:
     assert result["coverage_policy_registry_enforced"].all()
     assert result["coverage_policy_id"].eq(TEST_POLICY_ID).all()
     assert result["forecast_origin_registration_gate_enforced"].all()
+    assert result["training_uses_current_origin_as_of"].all()
 
 
 def test_headline_rejects_unverified_origin_registration() -> None:


### PR DESCRIPTION
Fixes a conservative-sample bias in point-in-time persistence evaluation. The existing path globally filtered rows by each row's own historical `point_in_time_available` before constructing later-origin training sets, so evidence unavailable at an earlier origin could never enter training even after it was published. This PR separates test-row deployability from training-row availability. Test rows still must pass their own-origin availability gate. Historical training rows are evaluated as of the current forecast origin and require predictor, concordance, and outcome availability dates to be on or before that current as-of date, with provenance present. Outputs record the current-origin training rule and separate predictor/concordance/outcome enforcement. Tests cover later admissibility, pre-release exclusion, row-level consistency, and headline propagation.