### PR TITLE
Test incremental predictive value of recent growth beyond country context

### DIFF
--- a/docs/h1-incremental-information-test.md
+++ b/docs/h1-incremental-information-test.md
@@ -1,0 +1,21 @@
+# H1 incremental information test
+
+H1 concerns whether recent city growth contains predictive information for later city growth. A raw persistence forecast and a country-context forecast are not a nested test of that proposition: raw persistence can lose to a country mean even when recent city growth still improves prediction after country context is controlled.
+
+The registered diagnostic in `src/urban_growth/h1_information.py` therefore compares two nested forecasts on identical city-origin rows at each rolling origin:
+
+1. `country_loo_only`: the leave-city-out historical country mean; and
+2. `country_loo_plus_recent_growth`: the same country baseline plus a coefficient on the city's recent growth deviation from its country's training-sample recent-growth mean.
+
+The recent-growth coefficient is estimated after country demeaning and uses only training intervals whose outcomes end by the forecast origin. The test reports the coefficient, matched row counts, MAE and RMSE for both models, and the recent-minus-country error deltas. A negative delta means recent growth improves the country-context forecast.
+
+This diagnostic does **not** retroactively redefine the preregistered universal H1. It separates two questions that were previously conflated:
+
+- whether raw persistence is the best standalone forecast; and
+- whether recent city growth adds predictive information conditional on country context.
+
+The second question is the direct incremental-information test. Universal H1 support would still require the declared consistency conditions across origins and relevant geographic strata. A mixed sign across origins is adverse evidence even if the pooled average improves.
+
+For WUP 2025, the runner uses the empirical-lineage correction in `wup_lineage.py`. The default observed/reference-estimate path therefore ends at the 2015 origin with a 2020 endpoint. The 2020-to-2025 interval is a CRISP projection sensitivity and is not part of this observed-outcome H1 diagnostic.
+
+The WUP result remains retrospective revised-history evidence with changing city definitions. It is not vintage-correct and is not headline-eligible for a deployable forecasting claim.

--- a/scripts/run_wup_h1_incremental.py
+++ b/scripts/run_wup_h1_incremental.py
@@ -1,5 +1,4 @@
 """Evaluate whether recent city growth adds information beyond country context in WUP."""
-# ruff: noqa: I001
 
 from __future__ import annotations
 

--- a/scripts/run_wup_h1_incremental.py
+++ b/scripts/run_wup_h1_incremental.py
@@ -1,0 +1,59 @@
+"""Evaluate whether recent city growth adds information beyond country context in WUP."""
+# ruff: noqa: I001
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from urban_growth.adapters.wup import (
+    read_f21_city_population,
+    read_f25_city_land_area,
+    read_f30_built_up_area_per_capita,
+    read_f34_population_density,
+)
+from urban_growth.forecast import build_forecast_intervals
+from urban_growth.h1_information import evaluate_country_adjusted_recent_growth_information
+from urban_growth.wup_lineage import classify_wup_city_population_lineage
+from urban_growth.wup_panel import build_wup_city_year_panel
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--raw-dir", type=Path, default=Path("data/raw"))
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("outputs/wup_h1_incremental_recent_growth_by_origin.csv"),
+    )
+    args = parser.parse_args()
+
+    raw = args.raw_dir
+    population = classify_wup_city_population_lineage(
+        read_f21_city_population(raw / "WUP2025-F21-DEGURBA-Cities_Pop.xlsx")
+    )
+    area = read_f25_city_land_area(raw / "WUP2025-F25-DEGURBA-Cities_AREA_km2.xlsx")
+    built = read_f30_built_up_area_per_capita(
+        raw / "WUP2025-F30-DEGURBA-Cities_BU_m2_per_capita.xlsx"
+    )
+    density = read_f34_population_density(
+        raw / "WUP2025-F34-DEGURBA-Cities_Pop_density.xlsx"
+    )
+    city_year = build_wup_city_year_panel(population, area, built, density)
+    intervals = build_forecast_intervals(city_year, list(range(1980, 2025, 5)))
+    result = evaluate_country_adjusted_recent_growth_information(
+        intervals,
+        list(range(1985, 2025, 5)),
+    )
+    result["outcome_lineage"] = "WUP_reference_estimate_only"
+    result["headline_eligible"] = False
+    result["headline_limitation"] = (
+        "retrospective WUP revised-history test; changing city definitions and no vintage-correct data"
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    result.to_csv(args.output, index=False)
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/urban_growth/h1_information.py
+++ b/src/urban_growth/h1_information.py
@@ -1,5 +1,4 @@
 """Tests of whether recent city growth adds information beyond country context."""
-# ruff: noqa: I001
 
 from __future__ import annotations
 

--- a/src/urban_growth/h1_information.py
+++ b/src/urban_growth/h1_information.py
@@ -1,0 +1,137 @@
+"""Tests of whether recent city growth adds information beyond country context."""
+# ruff: noqa: I001
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from urban_growth.forecast import baseline_predictions, rolling_origin_splits, score_forecast
+from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
+
+
+def evaluate_country_adjusted_recent_growth_information(
+    panel: pd.DataFrame,
+    origins: list[int],
+    *,
+    outcome_column: str = "future_growth",
+) -> pd.DataFrame:
+    """Compare country context alone with country context plus recent city growth.
+
+    The comparison is nested and matched by construction. For each rolling origin,
+    the recent-growth coefficient is estimated only from training rows whose outcomes
+    end by the forecast origin. Country means are removed before estimating the
+    coefficient. Both models are then scored on the identical test rows.
+
+    Negative MAE/RMSE deltas mean recent growth improves the country-context forecast.
+    """
+    require_columns(
+        panel,
+        {
+            "city_id",
+            "country_code",
+            "period_start",
+            "period_end",
+            "recent_growth",
+            outcome_column,
+        },
+        source_name="H1 recent-growth information panel",
+    )
+    reject_duplicate_keys(
+        panel,
+        ["city_id", "period_start", "period_end"],
+        source_name="H1 recent-growth information panel",
+    )
+    if not origins or len(set(origins)) != len(origins):
+        raise SourceSchemaError("H1 forecast origins must be unique and non-empty")
+
+    rows: list[dict[str, object]] = []
+    for origin, train_index, test_index in rolling_origin_splits(panel, sorted(origins)):
+        candidate_train = panel.loc[train_index].copy()
+        candidate_test = panel.loc[test_index].copy()
+        needed = ["city_id", "country_code", "recent_growth", outcome_column]
+        train = candidate_train.dropna(subset=needed).copy()
+        test = candidate_test.dropna(subset=needed).copy()
+        train = train.loc[
+            np.isfinite(train[["recent_growth", outcome_column]]).all(axis=1)
+        ]
+        test = test.loc[
+            np.isfinite(test[["recent_growth", outcome_column]]).all(axis=1)
+        ]
+        if train.empty or test.empty:
+            continue
+
+        baseline = baseline_predictions(train, test, outcome_column=outcome_column)
+        country_only = baseline["country_mean_leave_city_out"]
+        matched = pd.DataFrame(
+            {
+                "actual": test[outcome_column],
+                "recent_growth": test["recent_growth"],
+                "country_only": country_only,
+            },
+            index=test.index,
+        ).dropna()
+        if matched.empty:
+            continue
+
+        fit = train[["country_code", outcome_column, "recent_growth"]].copy()
+        group_means = fit.groupby("country_code")[[outcome_column, "recent_growth"]].transform(
+            "mean"
+        )
+        demeaned = fit[[outcome_column, "recent_growth"]] - group_means
+        x = demeaned[["recent_growth"]].to_numpy()
+        y = demeaned[outcome_column].to_numpy()
+        beta, *_ = np.linalg.lstsq(x, y, rcond=None)
+        beta_recent = float(beta[0])
+
+        country_recent_means = fit.groupby("country_code")["recent_growth"].mean()
+        global_recent_mean = float(fit["recent_growth"].mean())
+        matched["country_recent_mean"] = (
+            test.loc[matched.index, "country_code"]
+            .map(country_recent_means)
+            .fillna(global_recent_mean)
+        )
+        matched["country_plus_recent"] = matched["country_only"] + beta_recent * (
+            matched["recent_growth"] - matched["country_recent_mean"]
+        )
+
+        country_metrics = score_forecast(matched["actual"], matched["country_only"])
+        recent_metrics = score_forecast(matched["actual"], matched["country_plus_recent"])
+        if country_metrics.n != recent_metrics.n:
+            raise SourceSchemaError("H1 nested models were not scored on identical rows")
+
+        mae_delta = recent_metrics.mae - country_metrics.mae
+        rmse_delta = recent_metrics.rmse - country_metrics.rmse
+        rows.append(
+            {
+                "origin": origin,
+                "n": recent_metrics.n,
+                "candidate_train_n": len(candidate_train),
+                "matched_train_n": len(train),
+                "candidate_test_n": len(candidate_test),
+                "matched_test_n": recent_metrics.n,
+                "recent_growth_beta_within_country": beta_recent,
+                "country_only_mae": country_metrics.mae,
+                "country_plus_recent_mae": recent_metrics.mae,
+                "mae_delta_recent_minus_country": mae_delta,
+                "mae_improvement_fraction": (
+                    -mae_delta / country_metrics.mae if country_metrics.mae > 0 else np.nan
+                ),
+                "country_only_rmse": country_metrics.rmse,
+                "country_plus_recent_rmse": recent_metrics.rmse,
+                "rmse_delta_recent_minus_country": rmse_delta,
+                "rmse_improvement_fraction": (
+                    -rmse_delta / country_metrics.rmse if country_metrics.rmse > 0 else np.nan
+                ),
+                "recent_growth_improves_mae": bool(mae_delta < 0),
+                "recent_growth_improves_rmse": bool(rmse_delta < 0),
+                "recent_growth_improves_both": bool(mae_delta < 0 and rmse_delta < 0),
+                "comparison": "country_loo_only_vs_country_loo_plus_recent_growth",
+                "training_precedes_origin": True,
+                "test_rows_identical_across_nested_models": True,
+            }
+        )
+
+    if not rows:
+        raise SourceSchemaError("No H1 incremental recent-growth evaluations were produced")
+    return pd.DataFrame(rows).sort_values("origin").reset_index(drop=True)

--- a/tests/test_h1_information.py
+++ b/tests/test_h1_information.py
@@ -1,0 +1,58 @@
+import pandas as pd
+import pytest
+
+from urban_growth.h1_information import evaluate_country_adjusted_recent_growth_information
+from urban_growth.io import SourceSchemaError
+
+
+def _panel() -> pd.DataFrame:
+    rows = []
+    for origin in [2000, 2005, 2010]:
+        for city_id, country, recent, future in [
+            (1, "A", 0.01 + (origin - 2000) / 1000, 0.012 + (origin - 2000) / 1000),
+            (2, "A", 0.03 + (origin - 2000) / 1000, 0.028 + (origin - 2000) / 1000),
+            (3, "B", -0.01, -0.008),
+            (4, "B", 0.01, 0.012),
+        ]:
+            rows.append(
+                {
+                    "city_id": city_id,
+                    "country_code": country,
+                    "period_start": origin,
+                    "period_end": origin + 5,
+                    "recent_growth": recent,
+                    "future_growth": future,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def test_incremental_recent_growth_scores_nested_models_on_same_rows() -> None:
+    result = evaluate_country_adjusted_recent_growth_information(_panel(), [2005, 2010])
+    assert result["origin"].tolist() == [2005, 2010]
+    assert result["n"].tolist() == [4, 4]
+    assert result["test_rows_identical_across_nested_models"].all()
+    assert result["training_precedes_origin"].all()
+    assert result["comparison"].eq(
+        "country_loo_only_vs_country_loo_plus_recent_growth"
+    ).all()
+
+
+def test_incremental_recent_growth_can_show_predictive_gain() -> None:
+    result = evaluate_country_adjusted_recent_growth_information(_panel(), [2005, 2010])
+    assert result["recent_growth_beta_within_country"].gt(0).all()
+    assert result["recent_growth_improves_mae"].all()
+    assert result["recent_growth_improves_rmse"].all()
+    assert result["mae_delta_recent_minus_country"].lt(0).all()
+    assert result["rmse_delta_recent_minus_country"].lt(0).all()
+
+
+def test_incremental_recent_growth_rejects_duplicate_city_intervals() -> None:
+    panel = pd.concat([_panel(), _panel().iloc[[0]]], ignore_index=True)
+    with pytest.raises(SourceSchemaError, match="duplicate"):
+        evaluate_country_adjusted_recent_growth_information(panel, [2005, 2010])
+
+
+def test_incremental_recent_growth_requires_unique_origins() -> None:
+    with pytest.raises(SourceSchemaError, match="unique and non-empty"):
+        evaluate_country_adjusted_recent_growth_information(_panel(), [2005, 2005])


### PR DESCRIPTION
Implements the direct nested-information test implied by H1. For each rolling origin, the new evaluator compares a leave-city-out country-context forecast against the same country forecast plus the city's recent-growth deviation, with the recent-growth coefficient estimated only from prior outcomes after country demeaning. Both models are scored on identical test rows. Outputs report by-origin MAE/RMSE deltas, improvement fractions, and the within-country recent-growth coefficient. A dedicated WUP runner uses the corrected empirical-lineage classification, so the observed/reference-estimate diagnostic ends at 2015->2020 and excludes the CRISP 2025 endpoint. This does not retroactively redefine universal H1; it separates raw-persistence performance from whether recent growth adds information conditional on country context.