### PR TITLE
Downgrade GHSL persistence to construction-sensitive robustness evidence

### DIFF
--- a/docs/ghsl-construction-lineage-audit.md
+++ b/docs/ghsl-construction-lineage-audit.md
@@ -1,0 +1,63 @@
+# GHSL construction-lineage red-team audit
+
+## Finding
+
+The fixed-boundary GHSL persistence result is **not an independent replication of city-growth persistence**. It is a construction-sensitive robustness result produced from a modeled spatial population surface inside a future-defined 2025 footprint.
+
+This distinction is separate from the already documented boundary look-ahead and future-survivor problems.
+
+## Why the population series is not direct city enumeration
+
+The GHS-POP family distributes census or administrative-unit population to grid cells using GHSL built-up information. For the historical 1975–2020 epochs, population totals ultimately originate in census/administrative data, but the population assigned to a particular urban-centre footprint is a modeled spatial allocation rather than a direct enumeration of that footprint.
+
+Official JRC references:
+
+- GHS-POP R2023A dataset page: https://data.jrc.ec.europa.eu/dataset/2ff68a52-5b5b-4a22-8f40-c41da8332cfe
+- GHS-BUILT-S R2023A dataset page: https://data.jrc.ec.europa.eu/dataset/9f06f36f-4b11-47ec-abb0-4f8b7b1d72ea
+- GHSL WUP population methodology: https://human-settlement.emergency.copernicus.eu/ghs_wup_pop_r2025a.php
+
+The built-up series used to inform spatial allocation is itself multitemporal modeled data. JRC describes GHS-BUILT-S as spatial-temporal interpolation of a limited set of observed satellite-image collections. That creates a plausible mechanical channel through which local population histories can be smoother than direct locality counts even when higher-level population totals are census anchored.
+
+## Evidence already inside this repository
+
+The repository's matched fixed-versus-dynamic GHSL sensitivity provides direct evidence that construction choices materially affect apparent persistence:
+
+- fixed-2025-footprint persistence MAE: 0.758 percentage points;
+- dynamic-footprint persistence MAE: 1.274 percentage points;
+- fixed-2025-footprint persistence RMSE: 1.334 percentage points;
+- dynamic-footprint persistence RMSE: 2.268 percentage points;
+- 2020 within-country recent/future correlation: 0.764 fixed versus 0.532 dynamic.
+
+Holding the footprint fixed therefore makes the same source family substantially smoother and persistence substantially stronger. This does not prove that population disaggregation is the cause, but it demonstrates that the strength of the persistence signal is sensitive to the source-construction package.
+
+## What can and cannot be concluded
+
+Allowed interpretation:
+
+> Within the retrospective GHSL modeled population surface, recent growth remains highly predictive when population is measured repeatedly inside the same 2025 urban-centre footprint.
+
+Not allowed:
+
+- GHSL independently confirms the real-world magnitude of city-growth persistence;
+- GHSL validates the WUP persistence coefficient;
+- the fixed-boundary result identifies how much persistence is demographic rather than induced by spatial allocation or footprint construction;
+- stronger fixed-footprint persistence proves changing boundaries caused the WUP/GHSL disagreement.
+
+The construction-artifact hypothesis and the true-demographic-persistence hypothesis are observationally entangled in this source.
+
+## Required falsification test
+
+The preferred falsification is an external direct-count benchmark, not another transformation of GHSL. For national census systems with direct locality/place counts and defensible concordances:
+
+1. define the origin cohort before concordance exclusions;
+2. estimate recent-to-future growth persistence from direct counts;
+3. where possible, aggregate GHSL population to comparable locality footprints and periods;
+4. compare coefficients, forecast-error deltas, sign-reversal rates, and growth curvature on the matched locality-period sample;
+5. stratify by census recency and concordance quality;
+6. treat a materially stronger GHSL persistence signal than the direct-count signal as evidence consistent with construction smoothing.
+
+Until that test exists, GHSL is a sensitivity layer rather than independent confirmation of H1.
+
+## Claim status
+
+This audit does not invalidate the registered GHSL numerical outputs. It changes their evidentiary role. The existing outputs remain reproducible retrospective diagnostics, but they cannot upgrade a persistence claim beyond what direct-count or vintage-correct evidence supports.

--- a/docs/ghsl-fixed-fitness-persistence.md
+++ b/docs/ghsl-fixed-fitness-persistence.md
@@ -4,6 +4,8 @@
 
 The GHSL R2024A v1.2 thematic stream is the first repository source with enough multi-origin coverage and an internally stable geographic unit to exercise the fitness-gated persistence benchmark. It is admitted only as a **retrospective stable-footprint sensitivity**, not as headline or deployable-at-origin evidence.
 
+It is also **not an independent replication of real-world city-growth persistence**. Historical population inside each footprint is a modeled spatial allocation of census/administrative population using GHSL built-up information. The built-up time series is itself modeled from multitemporal satellite observations. This construction lineage can smooth local histories and is observationally entangled with genuine demographic persistence. See `docs/ghsl-construction-lineage-audit.md`.
+
 ## Why this source can enter the persistence benchmark
 
 Every historical GHSL thematic statistic is calculated inside the same 2025 urban-centre footprint. The repository has already reconciled the fixed thematic and multi-temporal streams at their documented common 2025 epoch, requiring one-to-one identifier/country agreement, exact area agreement, and population agreement within publisher rounding precision.
@@ -32,7 +34,15 @@ For that reason the source-specific adapter forcibly sets:
 - `boundary_information_leakage = true`;
 - `benchmark_interpretation = retrospective_stable_footprint_sensitivity`.
 
-The runner repeats these labels on every metrics/error output. A good persistence result here would establish that the persistence signal survives a stable-footprint definition. It would **not** establish a deployable historical forecast or remove survivorship concerns.
+The runner repeats these labels on every metrics/error output. A good persistence result here establishes only that persistence survives **within the GHSL fixed-footprint modeled population surface**. It does not establish a deployable historical forecast, an independent demographic replication, or the real-world magnitude of persistence.
+
+## Construction-lineage threat
+
+GHSL population grids distribute census or administrative-unit population across space using built-up information. For a fixed urban-centre footprint, the resulting historical population is therefore not a direct census enumeration of that footprint. JRC also documents the built-up surface series as a spatial-temporal interpolation of a limited set of observed satellite-image collections.
+
+The repository's own matched fixed-versus-dynamic comparison already demonstrates that construction choices materially change the apparent persistence signal: fixed footprints are substantially smoother and persistence is materially stronger than on matched dynamic-footprint rows. That is evidence of **construction sensitivity**, not proof that either footprint recovers the latent demographic process more accurately.
+
+The required falsification is an external direct-count comparison using national census locality/place histories and defensible concordances. Until then, GHSL cannot upgrade H1 beyond the support available from direct-count or vintage-correct sources.
 
 ## Remaining selection problem
 
@@ -52,4 +62,4 @@ The script rebuilds both streams, validates their 2025 reconciliation, construct
 
 ## Next evidence requirement
 
-After this sensitivity path, the next headline-capable persistence result still requires a source with multiple historical origins whose geographic identity can be established without future-boundary information and whose threshold/survivorship exposure is acceptable for the intended claim. National census locality concordances remain the preferred route for that test.
+After this sensitivity path, the next headline-capable persistence result still requires a source with multiple historical origins whose geographic identity can be established without future-boundary information and whose threshold/survivorship exposure is acceptable for the intended claim. National census locality concordances remain the preferred route for that test, and now serve a second purpose: testing whether GHSL persistence is materially stronger than persistence in direct locality counts on matched places and periods.


### PR DESCRIPTION
Implements the next red-team finding on GHSL lineage. The fixed-boundary result remains numerically valid but is explicitly reclassified as construction-sensitive robustness evidence rather than an independent replication of real-world city persistence. The new audit documents that GHSL historical population inside urban-centre footprints is a modeled spatial allocation of census/admin population using built-up information, while the built-up series is itself multitemporal modeled/interpolated data. The repo's own matched fixed-vs-dynamic result is reframed as evidence that construction choices materially change smoothness and apparent persistence. The audit defines the required falsification against direct national census locality counts. Issue #124 tracks that empirical comparison. No numerical output or registered hash is changed.