### PR TITLE
Preserve U.S. Census origin cohort before concordance exclusions

### DIFF
--- a/docs/us-census-threshold-pilot.md
+++ b/docs/us-census-threshold-pilot.md
@@ -8,10 +8,12 @@ does not replace the Mexico, Brazil, South Africa, or Ghana pilots. U.S. place
 identifiers and Census relationship files make this a comparatively favorable test of
 the implementation rather than a demanding test of international harmonization.
 
-The first registered interval is 2010–2020. The origin cohort contains places with
-25,000–100,000 residents in 2010. Cohort membership is defined **only** from the 2010
-origin population. The 2020 population is retained as an outcome and cannot add a
-future entrant, remove a later decliner, or otherwise redefine the origin risk set.
+The first registered interval is 2010–2020. The origin denominator contains **every**
+2010 place with 25,000–100,000 residents before any relationship, overlap, or endpoint
+filter is applied. Cohort membership is defined only from the 2010 origin population.
+The 2020 population is an outcome and cannot add a future entrant, remove a later
+decliner, or otherwise redefine the origin risk set.
+
 A place crosses the WUP observation threshold when its directly enumerated population
 is below 50,000 in 2010 and at least 50,000 in 2020. Crossing is interval-censored in
 the open interval `(2010, 2020)`; the code does not invent a point crossing year.
@@ -20,44 +22,75 @@ the open interval `(2010, 2020)`; the code does not invent a point crossing year
 
 | Input | Official field | Role |
 |---|---|---|
-| 2010 Decennial Census SF1 place population | `P001001` | Origin population |
-| 2020 Decennial Census PL 94-171 place population | `P1_001N` | Endpoint population |
-| 2020-place to 2010-place national relationship file | Place GEOIDs, endpoint land areas, intersection land area | Comparable-geography screen |
+| 2010 Decennial Census SF1 place population | `P001001` | Origin population and denominator membership |
+| 2020 Decennial Census PL 94-171 place population | `P1_001N` | Endpoint outcome |
+| 2020-place to 2010-place national relationship file | Place GEOIDs, endpoint land areas, intersection land area | Post-membership concordance classification |
 
 Population is retrieved for the 50 states and District of Columbia. Puerto Rico is
 outside this initial U.S. pilot. The relationship file is the official pipe-delimited
 national file at
 `https://www2.census.gov/geo/docs/maps-data/data/rel2020/place/tab20_place20_place10_natl.txt`.
 
+## Origin denominator before concordance
+
+`urban_growth.adapters.us_census.build_us_place_origin_denominator` is the canonical
+U.S. pilot denominator constructor. It first fixes the 25,000–100,000 cohort from 2010
+population, then attaches relationship evidence and endpoint population.
+
+Every origin place remains represented with:
+
+- `cohort_defined_at_origin = true`;
+- `cohort_population_basis = population_origin`;
+- `cohort_uses_endpoint_population = false`;
+- `concordance_resolved`;
+- `endpoint_population_observed`;
+- `analysis_eligible`;
+- a controlled `concordance_exclusion_reason` when unresolved.
+
+This prevents non-one-to-one relationships, boundary changes, missing relationship
+evidence, or missing endpoint data from silently disappearing before coverage is
+measured. The analysis cohort is a subset of this denominator; it is not the
+denominator itself.
+
+`us_place_concordance_coverage` reports both count and origin-population coverage for
+resolved concordances and final analysis eligibility. No production minimum coverage
+threshold is registered yet. Coverage must be reported before any threshold-crossing
+result is promoted.
+
 ## Comparable-geography rule
 
-A repeated GEOID alone is not treated as proof of stable geography. The registered
-cohort keeps only relationships that are one-to-one in both directions and whose
-intersection land area is at least 99.5% of both the 2010 and 2020 place land areas.
-A changed GEOID can enter as an `official_crosswalk` when it passes those same rules.
-All other relationships are excluded rather than interpreted as demographic change.
+A repeated GEOID alone is not treated as proof of stable geography. A place is resolved
+only when its relationship is one-to-one in both directions and its intersection land
+area is at least 99.5% of both the 2010 and 2020 place land areas. A changed GEOID can
+enter as an `official_crosswalk` when it passes those same rules.
 
-This land-overlap rule is a conservative feasibility screen. It is not proof that
+Places that fail these rules remain in the origin denominator with
+`geography_status = unresolved`; they are excluded only from the resolved analysis
+sample. This distinction is essential because geography instability may correlate with
+growth and threshold crossing.
+
+The land-overlap rule is a conservative feasibility screen. It is not proof that
 population was enumerated on perfectly identical geography, and the retained overlap
-ratios remain in the output for sensitivity analysis.
+ratios remain in the resolved output for sensitivity analysis.
 
 ## Origin-defined cohort rule
 
-`urban_growth.census_threshold.origin_defined_threshold_cohort` is the canonical
-constructor for the threshold-study risk set. It first validates comparable geography
-and complete endpoints, then applies the declared population bounds to
-`population_origin` only. It records `cohort_population_basis = population_origin`,
-`cohort_defined_at_origin = true`, and `cohort_uses_endpoint_population = false`.
+`urban_growth.census_threshold.origin_defined_threshold_cohort` remains the generic
+constructor for already comparable boundary cohorts. For the U.S. pilot, however,
+comparability cannot be allowed to define the denominator. The adapter-specific
+`build_us_place_origin_denominator` therefore precedes the generic resolved-cohort
+logic.
 
-This means a locality with 20,000 people at origin and 70,000 at the endpoint remains
-outside a 25,000–100,000 origin cohort, while a locality with 80,000 at origin and
-30,000 at the endpoint remains inside. Endpoint growth, threshold crossing, and later
-survival therefore cannot determine sample membership.
+A locality with 20,000 people at origin and 70,000 at the endpoint remains outside a
+25,000–100,000 origin cohort, while a locality with 80,000 at origin and 30,000 at the
+endpoint remains inside the denominator even if its geography later proves unresolved.
+Endpoint growth, threshold crossing, concordance success, and later survival therefore
+cannot determine denominator membership.
 
 ## City Data Fitness gate
 
-The registered cohort is passed through `urban_growth.census_fitness` before any
-headline analysis. The adapter translates the existing boundary evidence into the
+Only the resolved analysis cohort is passed through `urban_growth.census_fitness` before
+headline analysis. The adapter translates the accepted boundary evidence into the
 common City Data Fitness vocabulary and then calls the repository-wide evaluator.
 
 For this pilot:
@@ -73,9 +106,9 @@ For this pilot:
 - the headline sample is written separately and can only be produced through the
   common `headline_eligible` gate.
 
-This fitness decision is specific to the registered 50,000-threshold analysis. It must
-not be generalized to arbitrary U.S. place level comparisons, spatial models, or
-samples outside the 25,000–100,000 origin range.
+The `low` truncation/survivorship label does not override the new concordance-coverage
+report. If unresolved places are material, the headline interpretation must remain
+qualified even when resolved rows pass row-level fitness checks.
 
 ## Acquisition and execution
 
@@ -91,18 +124,30 @@ uv run --locked python scripts/run_us_census_threshold_pilot.py
 The acquisition script saves untouched API responses and the official relationship
 file under `data/raw/`. Those inputs must be inventoried in `data/manifest.csv` with
 their retrieval date, exact URL, and SHA-256 hash before an empirical result is
-registered. The fitness-annotated cohort, strict headline sample, and summary are
-written under `outputs/` and remain outside Git.
+registered.
+
+The runner writes four outputs under `outputs/`:
+
+- the complete origin-defined denominator;
+- the resolved, fitness-annotated cohort;
+- the strict headline-eligible subset;
+- the summary containing count and origin-population concordance coverage.
+
+Generated outputs remain outside Git unless explicitly registered through the result
+manifest process.
 
 ## Current status and decision rule
 
-The adapter, acquisition script, cohort builder, City Data Fitness application, and
-synthetic contract tests are implemented. The empirical run is blocked until a Census
-API key is available; no modeled or intercensal estimate will be substituted for the
-two decennial counts.
+The adapter, acquisition script, origin-first denominator, concordance coverage summary,
+resolved cohort builder, City Data Fitness application, and synthetic contract tests are
+implemented. The empirical run is blocked until a Census API key is available; no
+modeled or intercensal estimate will be substituted for the two decennial counts.
 
-The summary deliberately writes `gate_g2_satisfied = false`. Successful execution
-shows that the common threshold-audit and fitness-gating code works against an
-official, well-documented national system. It does not establish that comparable
-multiwave locality data are available in the countries central to the global claim.
-The next feasibility decision therefore remains a Mexico or Brazil pilot.
+The summary deliberately writes `gate_g2_satisfied = false` and
+`coverage_threshold_registered = false`. Successful execution shows that the common
+threshold-audit and fitness-gating code works against an official, well-documented
+national system while exposing any concordance attrition against the full origin cohort.
+It does not establish that comparable multiwave locality data are available in the
+countries central to the global claim, nor does it authorize a headline if concordance
+coverage is poor. The next feasibility decision therefore remains a Mexico or Brazil
+pilot.

--- a/scripts/run_us_census_threshold_pilot.py
+++ b/scripts/run_us_census_threshold_pilot.py
@@ -9,8 +9,10 @@ import pandas as pd
 
 from urban_growth.adapters.us_census import (
     build_us_place_boundary_cohort,
+    build_us_place_origin_denominator,
     read_2020_place_relationship,
     read_place_population_snapshot,
+    us_place_concordance_coverage,
 )
 from urban_growth.census_fitness import apply_us_census_place_fitness, us_census_headline_sample
 
@@ -18,6 +20,11 @@ from urban_growth.census_fitness import apply_us_census_place_fitness, us_census
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--raw-dir", type=Path, default=Path("data/raw"))
+    parser.add_argument(
+        "--denominator-output",
+        type=Path,
+        default=Path("outputs/us_census_threshold_origin_denominator.csv"),
+    )
     parser.add_argument(
         "--cohort-output",
         type=Path,
@@ -41,36 +48,37 @@ def main() -> None:
         args.raw_dir / "us_census_2020_place_population.json", year=2020
     )
     relationship = read_2020_place_relationship(args.raw_dir / "tab20_place20_place10_natl.txt")
+
+    denominator = build_us_place_origin_denominator(population_2010, population_2020, relationship)
+    coverage = us_place_concordance_coverage(denominator)
     raw_cohort = build_us_place_boundary_cohort(population_2010, population_2020, relationship)
     cohort = apply_us_census_place_fitness(raw_cohort)
     headline = us_census_headline_sample(raw_cohort)
-    summary = pd.DataFrame(
-        [
-            {
-                "country_code": "USA",
-                "origin_year": 2010,
-                "endpoint_year": 2020,
-                "cohort_rows": len(cohort),
-                "headline_eligible_rows": int(cohort["headline_eligible"].sum()),
-                "growth_eligible_rows": int(cohort["growth_eligible"].sum()),
-                "spatial_eligible_rows": int(cohort["spatial_eligible"].sum()),
-                "stable_geography_rows": int(cohort["geography_status"].eq("stable").sum()),
-                "official_crosswalk_rows": int(
-                    cohort["geography_status"].eq("official_crosswalk").sum()
-                ),
-                "crossed_50000_rows": int(cohort["crossed_50000"].sum()),
-                "headline_crossed_50000_rows": int(headline["crossed_50000"].sum()),
-                "origin_threshold_uncertain_rows": int(
-                    cohort["origin_threshold_band"].eq("threshold_uncertain").sum()
-                ),
-                "minimum_land_overlap": 0.995,
-                "fitness_scope": "us_census_place_2010_2020_threshold_pilot",
-                "gate_g2_satisfied": False,
-                "gate_note": "US pipeline validation does not satisfy Global South pilot gate",
-            }
-        ]
+
+    summary = coverage.assign(
+        country_code="USA",
+        origin_year=2010,
+        endpoint_year=2020,
+        resolved_cohort_rows=len(cohort),
+        headline_eligible_rows=int(cohort["headline_eligible"].sum()),
+        growth_eligible_rows=int(cohort["growth_eligible"].sum()),
+        spatial_eligible_rows=int(cohort["spatial_eligible"].sum()),
+        stable_geography_rows=int(cohort["geography_status"].eq("stable").sum()),
+        official_crosswalk_rows=int(cohort["geography_status"].eq("official_crosswalk").sum()),
+        unresolved_geography_rows=int((~denominator["concordance_resolved"]).sum()),
+        crossed_50000_rows=int(cohort["crossed_50000"].sum()),
+        headline_crossed_50000_rows=int(headline["crossed_50000"].sum()),
+        origin_threshold_uncertain_rows=int(
+            cohort["origin_threshold_band"].eq("threshold_uncertain").sum()
+        ),
+        minimum_land_overlap=0.995,
+        fitness_scope="us_census_place_2010_2020_threshold_pilot",
+        gate_g2_satisfied=False,
+        gate_note="US pipeline validation does not satisfy Global South pilot gate",
     )
+
     for path, frame in [
+        (args.denominator_output, denominator),
         (args.cohort_output, cohort),
         (args.headline_output, headline),
         (args.summary_output, summary),

--- a/scripts/run_us_census_threshold_pilot.py
+++ b/scripts/run_us_census_threshold_pilot.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-import pandas as pd
-
 from urban_growth.adapters.us_census import (
     build_us_place_boundary_cohort,
     build_us_place_origin_denominator,

--- a/src/urban_growth/adapters/us_census.py
+++ b/src/urban_growth/adapters/us_census.py
@@ -61,24 +61,11 @@ def read_2020_place_relationship(path: Path) -> pd.DataFrame:
     return frame
 
 
-def build_us_place_boundary_cohort(
+def _validate_us_place_inputs(
     population_2010: pd.DataFrame,
     population_2020: pd.DataFrame,
     relationship: pd.DataFrame,
-    *,
-    minimum_origin_population: int = 25_000,
-    maximum_origin_population: int = 100_000,
-    minimum_land_overlap: float = 0.995,
-) -> pd.DataFrame:
-    """Build a strict one-to-one, near-identical-land U.S. place cohort.
-
-    Land overlap is a feasibility screen, not proof of population comparability.
-    Places failing it remain excluded rather than being treated as demographic change.
-    """
-    if not 0 < minimum_land_overlap <= 1:
-        raise SourceSchemaError("Minimum land overlap must be in (0, 1]")
-    if minimum_origin_population <= 0 or maximum_origin_population < minimum_origin_population:
-        raise SourceSchemaError("Origin population bounds are invalid")
+) -> None:
     for frame, label in [
         (population_2010, "2010 Census places"),
         (population_2020, "2020 Census places"),
@@ -100,46 +87,219 @@ def build_us_place_boundary_cohort(
         source_name="2020-to-2010 Census place relationship",
     )
 
-    related = relationship.dropna(subset=["GEOID_PLACE_10", "GEOID_PLACE_20"]).copy()
-    count_10 = related.groupby("GEOID_PLACE_10")["GEOID_PLACE_20"].transform("size")
-    count_20 = related.groupby("GEOID_PLACE_20")["GEOID_PLACE_10"].transform("size")
-    related["one_to_one_relationship"] = count_10.eq(1) & count_20.eq(1)
-    related["origin_land_overlap"] = related["AREALAND_PART"] / related["AREALAND_PLACE_10"]
-    related["endpoint_land_overlap"] = related["AREALAND_PART"] / related["AREALAND_PLACE_20"]
-    comparable = related.loc[
-        related["one_to_one_relationship"]
-        & related["origin_land_overlap"].ge(minimum_land_overlap)
-        & related["endpoint_land_overlap"].ge(minimum_land_overlap)
-    ].copy()
-    cohort = comparable.merge(
-        population_2010.add_suffix("_2010"),
-        left_on="GEOID_PLACE_10",
-        right_on="geoid_2010",
-        validate="one_to_one",
-    ).merge(
-        population_2020.add_suffix("_2020"),
-        left_on="GEOID_PLACE_20",
-        right_on="geoid_2020",
-        validate="one_to_one",
-    )
-    cohort = cohort.loc[
-        cohort["population_2010"].between(
+
+def build_us_place_origin_denominator(
+    population_2010: pd.DataFrame,
+    population_2020: pd.DataFrame,
+    relationship: pd.DataFrame,
+    *,
+    minimum_origin_population: int = 25_000,
+    maximum_origin_population: int = 100_000,
+    minimum_land_overlap: float = 0.995,
+) -> pd.DataFrame:
+    """Fix the 2010 population cohort before evaluating geographic concordance.
+
+    Every 2010 place inside the registered population bounds remains in the denominator.
+    Relationship quality, land overlap, and endpoint population are classified only after
+    membership is fixed. Unresolved places therefore cannot disappear before coverage is
+    measured.
+    """
+    if not 0 < minimum_land_overlap <= 1:
+        raise SourceSchemaError("Minimum land overlap must be in (0, 1]")
+    if minimum_origin_population <= 0 or maximum_origin_population < minimum_origin_population:
+        raise SourceSchemaError("Origin population bounds are invalid")
+    _validate_us_place_inputs(population_2010, population_2020, relationship)
+
+    denominator = population_2010.loc[
+        population_2010["population"].between(
             minimum_origin_population, maximum_origin_population, inclusive="both"
         )
     ].copy()
-    if cohort.empty:
-        raise SourceSchemaError("No U.S. places satisfy the threshold-pilot cohort rules")
-    cohort["settlement_id"] = "US_PLACE_2010_" + cohort["GEOID_PLACE_10"]
-    cohort["country_code"] = "USA"
-    cohort["origin_year"] = 2010
-    cohort["endpoint_year"] = 2020
-    cohort["population_origin"] = cohort["population_2010"]
-    cohort["population_endpoint"] = cohort["population_2020"]
-    cohort["geography_status"] = np.where(
-        cohort["GEOID_PLACE_10"].eq(cohort["GEOID_PLACE_20"]),
-        "stable",
-        "official_crosswalk",
+    if denominator.empty:
+        raise SourceSchemaError("No U.S. places satisfy the origin population cohort rules")
+    denominator = denominator.rename(
+        columns={"geoid": "GEOID_PLACE_10", "place_name": "place_name_2010", "population": "population_origin"}
     )
+    denominator["settlement_id"] = "US_PLACE_2010_" + denominator["GEOID_PLACE_10"]
+    denominator["country_code"] = "USA"
+    denominator["origin_year"] = 2010
+    denominator["endpoint_year"] = 2020
+    denominator["cohort_defined_at_origin"] = True
+    denominator["cohort_population_basis"] = "population_origin"
+    denominator["cohort_uses_endpoint_population"] = False
+
+    related = relationship.dropna(subset=["GEOID_PLACE_10", "GEOID_PLACE_20"]).copy()
+    related = related.drop_duplicates(subset=["GEOID_PLACE_10", "GEOID_PLACE_20"])
+    origin_counts = related.groupby("GEOID_PLACE_10")["GEOID_PLACE_20"].nunique()
+    endpoint_counts = related.groupby("GEOID_PLACE_20")["GEOID_PLACE_10"].nunique()
+    related["origin_endpoint_count"] = related["GEOID_PLACE_10"].map(origin_counts)
+    related["endpoint_origin_count"] = related["GEOID_PLACE_20"].map(endpoint_counts)
+    related["one_to_one_relationship"] = related["origin_endpoint_count"].eq(1) & related[
+        "endpoint_origin_count"
+    ].eq(1)
+    related["origin_land_overlap"] = related["AREALAND_PART"] / related["AREALAND_PLACE_10"]
+    related["endpoint_land_overlap"] = related["AREALAND_PART"] / related["AREALAND_PLACE_20"]
+
+    one_row_per_origin = related.sort_values(
+        ["GEOID_PLACE_10", "one_to_one_relationship", "origin_land_overlap", "endpoint_land_overlap"],
+        ascending=[True, False, False, False],
+        na_position="last",
+    ).drop_duplicates(subset=["GEOID_PLACE_10"], keep="first")
+    keep_relationship = [
+        "GEOID_PLACE_10",
+        "GEOID_PLACE_20",
+        "origin_endpoint_count",
+        "endpoint_origin_count",
+        "one_to_one_relationship",
+        "origin_land_overlap",
+        "endpoint_land_overlap",
+    ]
+    denominator = denominator.merge(
+        one_row_per_origin[keep_relationship],
+        on="GEOID_PLACE_10",
+        how="left",
+        validate="one_to_one",
+    )
+
+    endpoint = population_2020.rename(
+        columns={"geoid": "GEOID_PLACE_20", "place_name": "place_name_2020", "population": "population_endpoint"}
+    )
+    denominator = denominator.merge(endpoint, on="GEOID_PLACE_20", how="left", validate="many_to_one")
+
+    denominator["concordance_resolved"] = (
+        denominator["one_to_one_relationship"].fillna(False).astype(bool)
+        & denominator["origin_land_overlap"].ge(minimum_land_overlap).fillna(False)
+        & denominator["endpoint_land_overlap"].ge(minimum_land_overlap).fillna(False)
+    )
+    denominator["endpoint_population_observed"] = denominator["population_endpoint"].notna()
+    denominator["analysis_eligible"] = denominator["concordance_resolved"] & denominator[
+        "endpoint_population_observed"
+    ]
+
+    denominator["concordance_exclusion_reason"] = "eligible"
+    no_relationship = denominator["GEOID_PLACE_20"].isna()
+    multiple_endpoint = denominator["origin_endpoint_count"].fillna(0).gt(1)
+    multiple_origin = denominator["endpoint_origin_count"].fillna(0).gt(1)
+    missing_overlap = (
+        denominator["GEOID_PLACE_20"].notna()
+        & (denominator["origin_land_overlap"].isna() | denominator["endpoint_land_overlap"].isna())
+    )
+    low_origin_overlap = denominator["origin_land_overlap"].lt(minimum_land_overlap).fillna(False)
+    low_endpoint_overlap = denominator["endpoint_land_overlap"].lt(minimum_land_overlap).fillna(False)
+    missing_endpoint_population = denominator["concordance_resolved"] & ~denominator[
+        "endpoint_population_observed"
+    ]
+    denominator.loc[no_relationship, "concordance_exclusion_reason"] = "no_relationship"
+    denominator.loc[multiple_endpoint, "concordance_exclusion_reason"] = "origin_to_multiple_endpoints"
+    denominator.loc[~multiple_endpoint & multiple_origin, "concordance_exclusion_reason"] = (
+        "endpoint_from_multiple_origins"
+    )
+    denominator.loc[
+        ~(multiple_endpoint | multiple_origin) & missing_overlap,
+        "concordance_exclusion_reason",
+    ] = "missing_land_overlap"
+    denominator.loc[
+        ~(multiple_endpoint | multiple_origin | missing_overlap) & low_origin_overlap,
+        "concordance_exclusion_reason",
+    ] = "insufficient_origin_land_overlap"
+    denominator.loc[
+        ~(multiple_endpoint | multiple_origin | missing_overlap | low_origin_overlap)
+        & low_endpoint_overlap,
+        "concordance_exclusion_reason",
+    ] = "insufficient_endpoint_land_overlap"
+    denominator.loc[missing_endpoint_population, "concordance_exclusion_reason"] = (
+        "endpoint_population_missing"
+    )
+
+    denominator["geography_status"] = "unresolved"
+    stable = denominator["concordance_resolved"] & denominator["GEOID_PLACE_10"].eq(
+        denominator["GEOID_PLACE_20"]
+    )
+    denominator.loc[stable, "geography_status"] = "stable"
+    denominator.loc[denominator["concordance_resolved"] & ~stable, "geography_status"] = (
+        "official_crosswalk"
+    )
+    denominator["minimum_land_overlap_rule"] = minimum_land_overlap
+    reject_duplicate_keys(denominator, ["settlement_id"], source_name="U.S. place origin denominator")
+    return denominator.sort_values("settlement_id").reset_index(drop=True)
+
+
+def us_place_concordance_coverage(denominator: pd.DataFrame) -> pd.DataFrame:
+    """Summarize concordance coverage against the origin-defined denominator."""
+    require_columns(
+        denominator,
+        {
+            "settlement_id",
+            "population_origin",
+            "concordance_resolved",
+            "endpoint_population_observed",
+            "analysis_eligible",
+            "cohort_defined_at_origin",
+            "cohort_uses_endpoint_population",
+        },
+        source_name="U.S. place origin denominator",
+    )
+    reject_duplicate_keys(denominator, ["settlement_id"], source_name="U.S. place origin denominator")
+    if not denominator["cohort_defined_at_origin"].eq(True).all():
+        raise SourceSchemaError("U.S. denominator must be defined at origin")
+    if not denominator["cohort_uses_endpoint_population"].eq(False).all():
+        raise SourceSchemaError("U.S. denominator cannot use endpoint population for membership")
+    total_rows = len(denominator)
+    total_population = float(denominator["population_origin"].sum())
+    if total_rows == 0 or total_population <= 0:
+        raise SourceSchemaError("U.S. denominator coverage requires positive cohort support")
+
+    resolved = denominator["concordance_resolved"].astype(bool)
+    observed = denominator["endpoint_population_observed"].astype(bool)
+    eligible = denominator["analysis_eligible"].astype(bool)
+    return pd.DataFrame(
+        [
+            {
+                "origin_denominator_rows": total_rows,
+                "origin_denominator_population": total_population,
+                "concordance_resolved_rows": int(resolved.sum()),
+                "concordance_resolved_population": float(
+                    denominator.loc[resolved, "population_origin"].sum()
+                ),
+                "concordance_count_coverage": float(resolved.mean()),
+                "concordance_population_coverage": float(
+                    denominator.loc[resolved, "population_origin"].sum() / total_population
+                ),
+                "endpoint_population_observed_rows": int(observed.sum()),
+                "analysis_eligible_rows": int(eligible.sum()),
+                "analysis_eligible_count_coverage": float(eligible.mean()),
+                "analysis_eligible_population_coverage": float(
+                    denominator.loc[eligible, "population_origin"].sum() / total_population
+                ),
+                "coverage_denominator_rule": "2010_origin_population_25000_100000_before_concordance",
+                "future_outcome_used_for_membership": False,
+                "coverage_threshold_registered": False,
+            }
+        ]
+    )
+
+
+def build_us_place_boundary_cohort(
+    population_2010: pd.DataFrame,
+    population_2020: pd.DataFrame,
+    relationship: pd.DataFrame,
+    *,
+    minimum_origin_population: int = 25_000,
+    maximum_origin_population: int = 100_000,
+    minimum_land_overlap: float = 0.995,
+) -> pd.DataFrame:
+    """Build the resolved U.S. analysis cohort from an origin-defined denominator."""
+    denominator = build_us_place_origin_denominator(
+        population_2010,
+        population_2020,
+        relationship,
+        minimum_origin_population=minimum_origin_population,
+        maximum_origin_population=maximum_origin_population,
+        minimum_land_overlap=minimum_land_overlap,
+    )
+    cohort = denominator.loc[denominator["analysis_eligible"]].copy()
+    if cohort.empty:
+        raise SourceSchemaError("No U.S. places satisfy the threshold-pilot analysis rules")
     cohort["origin_population_status"] = "direct_decennial_enumeration"
     cohort["endpoint_population_status"] = "direct_decennial_enumeration"
     cohort["origin_threshold_band"] = classify_threshold_measurement_band(

--- a/tests/test_us_census_denominator.py
+++ b/tests/test_us_census_denominator.py
@@ -1,0 +1,91 @@
+import pandas as pd
+import pytest
+
+from urban_growth.adapters.us_census import (
+    build_us_place_boundary_cohort,
+    build_us_place_origin_denominator,
+    us_place_concordance_coverage,
+)
+
+
+def _population_2010() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "geoid": ["0100001", "0100002", "0100003", "0100004"],
+            "place_name": ["Stable", "Split", "Renamed", "Too Large"],
+            "population": [30_000, 40_000, 50_000, 110_000],
+        }
+    )
+
+
+def _population_2020() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "geoid": ["0100001", "0100201", "0100202", "0100300", "0100004"],
+            "place_name": ["Stable", "Split A", "Split B", "Renamed New", "Too Large"],
+            "population": [35_000, 22_000, 25_000, 60_000, 120_000],
+        }
+    )
+
+
+def _relationship() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "GEOID_PLACE_10": ["0100001", "0100002", "0100002", "0100003", "0100004"],
+            "GEOID_PLACE_20": ["0100001", "0100201", "0100202", "0100300", "0100004"],
+            "AREALAND_PLACE_10": [100.0, 100.0, 100.0, 100.0, 100.0],
+            "AREALAND_PLACE_20": [100.0, 50.0, 50.0, 100.0, 100.0],
+            "AREALAND_PART": [100.0, 50.0, 50.0, 100.0, 100.0],
+        }
+    )
+
+
+def test_origin_denominator_retains_unresolved_places() -> None:
+    result = build_us_place_origin_denominator(
+        _population_2010(), _population_2020(), _relationship()
+    )
+    assert result["GEOID_PLACE_10"].tolist() == ["0100001", "0100002", "0100003"]
+    assert result["cohort_defined_at_origin"].all()
+    assert result["cohort_uses_endpoint_population"].eq(False).all()
+
+    split = result.loc[result["GEOID_PLACE_10"].eq("0100002")].iloc[0]
+    assert not split["concordance_resolved"]
+    assert not split["analysis_eligible"]
+    assert split["concordance_exclusion_reason"] == "origin_to_multiple_endpoints"
+    assert split["geography_status"] == "unresolved"
+
+    renamed = result.loc[result["GEOID_PLACE_10"].eq("0100003")].iloc[0]
+    assert renamed["concordance_resolved"]
+    assert renamed["geography_status"] == "official_crosswalk"
+
+
+def test_origin_denominator_membership_does_not_depend_on_endpoint_population() -> None:
+    endpoint = _population_2020()
+    first = build_us_place_origin_denominator(_population_2010(), endpoint, _relationship())
+    changed = endpoint.copy()
+    changed["population"] = changed["population"] * 100
+    second = build_us_place_origin_denominator(_population_2010(), changed, _relationship())
+    assert first["settlement_id"].tolist() == second["settlement_id"].tolist()
+
+
+def test_concordance_coverage_uses_full_origin_denominator() -> None:
+    denominator = build_us_place_origin_denominator(
+        _population_2010(), _population_2020(), _relationship()
+    )
+    coverage = us_place_concordance_coverage(denominator).iloc[0]
+    assert coverage["origin_denominator_rows"] == 3
+    assert coverage["origin_denominator_population"] == 120_000
+    assert coverage["concordance_resolved_rows"] == 2
+    assert coverage["concordance_count_coverage"] == pytest.approx(2 / 3)
+    assert coverage["concordance_population_coverage"] == pytest.approx(80_000 / 120_000)
+    assert coverage["analysis_eligible_rows"] == 2
+    assert coverage["future_outcome_used_for_membership"] == False
+    assert coverage["coverage_threshold_registered"] == False
+
+
+def test_analysis_cohort_is_filtered_only_after_denominator_is_fixed() -> None:
+    cohort = build_us_place_boundary_cohort(
+        _population_2010(), _population_2020(), _relationship()
+    )
+    assert cohort["GEOID_PLACE_10"].tolist() == ["0100001", "0100003"]
+    assert cohort["population_origin"].tolist() == [30_000, 50_000]


### PR DESCRIPTION
Implements the next empirical red-team correction. The U.S. Census pilot previously filtered to one-to-one, >=99.5% overlap relationships before the 25k-100k cohort was formed, allowing unresolved or boundary-unstable origin places to disappear from the denominator. This PR adds an origin-first denominator built solely from 2010 population, then classifies concordance, endpoint observability, and analysis eligibility. Unresolved places remain auditable with exclusion reasons. New coverage output reports both count and origin-population coverage; no production threshold is invented. The resolved analysis cohort is now explicitly a subset of the fixed denominator. Synthetic tests cover unresolved retention, endpoint-population invariance, count/population coverage, and post-denominator filtering.