### PR TITLE
Add contemporaneous country baseline for WUP red-team test

### DIFF
--- a/.github/workflows/wup-contemporaneous-country.yml
+++ b/.github/workflows/wup-contemporaneous-country.yml
@@ -1,0 +1,54 @@
+name: WUP contemporaneous country diagnostic
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - redteam/contemporaneous-country-baseline
+    paths:
+      - ".github/workflows/wup-contemporaneous-country.yml"
+      - "scripts/run_wup_contemporaneous_country_baseline.py"
+      - "src/urban_growth/contemporaneous_baseline.py"
+      - "src/urban_growth/wup_lineage.py"
+      - "src/urban_growth/forecast.py"
+
+jobs:
+  contemporaneous-country:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
+        with:
+          version: "0.11.33"
+      - run: uv sync --locked
+      - name: Acquire official WUP 2025 city tables
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p data/raw
+          base="https://population.un.org/wup/assets/Download/Cities"
+          for file in \
+            WUP2025-F21-DEGURBA-Cities_Pop.xlsx \
+            WUP2025-F25-DEGURBA-Cities_AREA_km2.xlsx \
+            WUP2025-F30-DEGURBA-Cities_BU_m2_per_capita.xlsx \
+            WUP2025-F34-DEGURBA-Cities_Pop_density.xlsx
+          do
+            curl --fail --location --retry 3 --retry-delay 2 \
+              "$base/$file" --output "data/raw/$file"
+          done
+          sha256sum data/raw/WUP2025-*.xlsx | tee outputs-wup-source-sha256.txt
+      - name: Run contemporaneous country diagnostic
+        run: uv run --locked python scripts/run_wup_contemporaneous_country_baseline.py
+      - name: Print metrics
+        run: cat outputs/wup_contemporaneous_country_metrics.csv
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wup-contemporaneous-country-diagnostic
+          path: |
+            outputs/wup_contemporaneous_country_metrics.csv
+            outputs/wup_contemporaneous_country_bootstrap.csv
+            outputs/wup_contemporaneous_country_time_bootstrap.csv
+            outputs-wup-source-sha256.txt

--- a/docs/wup-contemporaneous-country-result.md
+++ b/docs/wup-contemporaneous-country-result.md
@@ -1,0 +1,72 @@
+# WUP contemporaneous-country recent-growth diagnostic
+
+## Question
+
+Does a city's own recent growth outperform the contemporaneous recent-growth state of its other same-country cities at the same forecast origin?
+
+This diagnostic addresses red-team Finding 5. The comparator is fully origin-available and leave-city-out. Singleton-country observations fall back to the contemporaneous global leave-city-out mean. It does not use future outcomes.
+
+## Empirical run
+
+- GitHub Actions run: `33571092887`
+- producing head commit: `29da2ff04463456bc716f40649c8ef4e45319b49`
+- artifact: `wup-contemporaneous-country-diagnostic`, artifact ID `9824957096`
+- artifact digest: `sha256:00bfe9530c43337871b8325fa4fc2e3fc39db8934083d4b9e38bf55af9a3612b`
+- observed/reference-estimate scoring origins: 1985–2015
+- 2020->2025 CRISP outcome excluded
+
+Source workbook SHA-256 values match the registered WUP city inputs:
+
+- F21 population: `3a96030d87aec6c1c50f658d5321067d6345e1ab936c5d2854524f972caa75c0`
+- F25 area: `1174b1d46344a14c6d92d5a85e8b852cb789cf4d67835c2ff96c1634450af25f`
+- F30 built-up area per capita: `942a9d74e66949cd8eb818fa208b9402bbd5225a1dbce7f98c3101f9904ba34f`
+- F34 density: `aff1240a0db72de6adabb5fb8a734df2d9be3159f94886c18ff61d5eaea1f0b0`
+
+## Point estimates
+
+| Origin | Persistence MAE | Contemporaneous-country MAE | Persistence minus peer MAE | Persistence RMSE | Peer RMSE | Persistence minus peer RMSE |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1985 | 1.002 pp | 1.406 pp | -0.404 pp | 1.982 pp | 2.201 pp | -0.219 pp |
+| 1990 | 1.616 pp | 1.759 pp | -0.143 pp | 2.512 pp | 2.552 pp | -0.040 pp |
+| 1995 | 1.239 pp | 1.815 pp | -0.576 pp | 2.172 pp | 2.620 pp | -0.447 pp |
+| 2000 | 1.598 pp | 1.346 pp | **+0.252 pp** | 2.741 pp | 1.944 pp | **+0.797 pp** |
+| 2005 | 0.989 pp | 1.242 pp | -0.254 pp | 1.850 pp | 1.911 pp | -0.061 pp |
+| 2010 | 1.157 pp | 1.337 pp | -0.180 pp | 2.156 pp | 2.055 pp | **+0.100 pp** |
+| 2015 | 1.356 pp | 1.690 pp | -0.334 pp | 2.304 pp | 2.493 pp | -0.189 pp |
+
+Persistence has lower MAE at six of seven origins. The exception is 2000, where contemporaneous same-country peer growth improves MAE by about 0.252 percentage points and RMSE by about 0.797 percentage points. At 2010 persistence retains the lower MAE but the contemporaneous comparator has the lower RMSE.
+
+## Country-cluster uncertainty
+
+The one-way country-cluster bootstrap uses 2,000 repetitions and seed `20260827`.
+
+| Origin | MAE difference: persistence - peer | 95% country-cluster CI | P(persistence better) |
+|---:|---:|---:|---:|
+| 1985 | -0.404 pp | [-0.503, -0.303] pp | 1.000 |
+| 1990 | -0.143 pp | [-0.427, +0.158] pp | 0.738 |
+| 1995 | -0.576 pp | [-1.080, -0.101] pp | 0.994 |
+| 2000 | +0.252 pp | [-0.132, +0.681] pp | 0.381 |
+| 2005 | -0.254 pp | [-0.339, -0.192] pp | 1.000 |
+| 2010 | -0.180 pp | [-0.281, -0.092] pp | 1.000 |
+| 2015 | -0.334 pp | [-0.484, -0.183] pp | 1.000 |
+
+The 2000 point estimate is consistent with a regime in which current country peer growth is more useful than own-city persistence, but its country-cluster MAE interval crosses zero. It is therefore evidence of period sensitivity, not a definitive estimate of a national-convergence mechanism.
+
+Across all seven observed origins, the two-way country/origin bootstrap gives an average MAE difference of -0.228 pp, 95% CI [-0.447, -0.018] pp, with probability persistence is better 0.979. Thus the new comparator does not overturn persistence as the stronger average predictor in revised-history WUP; it does reveal an important period-specific failure that the historical-mean comparator could not isolate.
+
+## Interpretation
+
+Finding 5 is confirmed as a missing instrument, but its empirical addition yields a more nuanced result than a simple national-convergence story:
+
+- own-city recent growth usually beats the contemporaneous country peer state;
+- the 2000 origin is a clear point-estimate reversal on both MAE and RMSE;
+- the 2000 MAE advantage of the peer comparator is not statistically decisive under country-cluster resampling;
+- 2010 also shows a tail-error advantage for the contemporaneous comparator despite persistence winning MAE.
+
+The correct headline remains that recent growth contains substantial city-specific predictive information beyond aggregate country context, while regime changes can make contemporaneous national/country information especially valuable.
+
+Exact output SHA-256 values:
+
+- metrics CSV: `6a45bd93a1d53019d772adb4027cc327aa965524badbd5b6afeeaf76d61b3123`
+- country-cluster bootstrap CSV: `efd77d62b64c479d0238fc561e3a9cba6e3a1fe53cecf42a0c6b972a83fa18c9`
+- country/origin bootstrap CSV: `e68bc31fc04d04acd0f54ced20bcd9027e37412da04d36df9db513cbe53b9836`

--- a/docs/wup-redteam-findings-5-8.md
+++ b/docs/wup-redteam-findings-5-8.md
@@ -1,0 +1,42 @@
+# WUP red-team findings 5–8
+
+## Finding 5 — missing contemporaneous country comparator
+
+Confirmed. The historical baseline ladder uses past realized outcomes. It did not include the origin-available cross-sectional mean of `recent_growth` among the focal city's other same-country cities at the same forecast origin.
+
+The new diagnostic in `urban_growth.contemporaneous_baseline` adds exactly that comparator. It is leave-city-out. A singleton-country city falls back to the global contemporaneous leave-city-out mean. Future outcome growth is never used in constructing the predictor.
+
+Interpretation: this comparator directly tests whether a city's own persistence signal beats the contemporaneous growth state of peer cities in the same country. It is especially relevant to distinguishing city-specific persistence from convergence toward a current national urban-growth regime.
+
+## Finding 6 — hierarchy model does not provide the required per-origin H1 test
+
+Partly superseded. The original `evaluate_rolling_hierarchy_models` remains a hierarchy-model diagnostic and should not be reinterpreted as the decisive H1 test. However, PR #122 added a separate per-origin nested diagnostic comparing leave-city-out country context with the same baseline plus recent city growth, trained only on prior outcomes. PR #123 executed that diagnostic on observed/reference-estimate WUP outcomes through 2015->2020.
+
+That newer test should be cited for the incremental-information question. The older pooled hierarchy model remains useful for specification comparison, not as the sole H1 falsification instrument.
+
+## Finding 7 — comparator drift across bootstrap outputs
+
+Confirmed. Historical outputs were not comparator-identical:
+
+- the default one-way size-bin paired/bootstrap path used `country_mean`;
+- the size-bin two-way bootstrap explicitly used `country_mean`;
+- the pooled two-way bootstrap defaulted to `country_mean_leave_city_out`.
+
+The numerical distinction is small, but the provenance distinction is real. Existing registered files keep their original semantics and hashes; they must not be described generically as one comparator. New persistence-vs-country inference should name the exact `model_b` field, with leave-city-out preferred when the estimand is a distinct country component.
+
+No historical manifest is silently rewritten by this correction.
+
+## Finding 8 — aggregation-ladder bootstrap does not refit means
+
+Confirmed. The current aggregation-ladder bootstraps operate on precomputed row-level errors. Resampling country clusters therefore changes the weighting of errors but does not recompute global, region, or subregion means inside each bootstrap draw.
+
+Those intervals are conditional-on-fitted-baselines intervals, not full refit bootstrap intervals. This matters most for region-vs-global and subregion-vs-region comparisons; leave-city-out country means are much less affected because their fitted component is local to the resampled cluster.
+
+Until a refit bootstrap is implemented, aggregation-ladder confidence intervals must be labeled `conditional_on_fitted_baselines`. Point estimates remain valid. A future refit implementation must resample whole country clusters, clone repeated clusters with unique bootstrap identifiers, recompute the aggregation means within every draw using only training rows available at each origin, then rescore the same nested aggregation comparison.
+
+## Priority
+
+1. Execute the contemporaneous-country comparator on the corrected WUP observed lineage.
+2. Treat PR #122/#123 as the per-origin H1 incremental-information result, not the older hierarchy table.
+3. Keep historical bootstrap comparator names explicit.
+4. Replace aggregation-ladder conditional intervals with refit intervals before using them for strong inferential claims.

--- a/scripts/run_wup_contemporaneous_country_baseline.py
+++ b/scripts/run_wup_contemporaneous_country_baseline.py
@@ -60,8 +60,9 @@ def main() -> None:
         read_f34_population_density(raw / "WUP2025-F34-DEGURBA-Cities_Pop_density.xlsx"),
     )
     intervals = build_forecast_intervals(city_year, OBSERVED_PANEL_ORIGINS)
-    metrics = evaluate_contemporaneous_country_baseline(intervals)
-    errors = contemporaneous_country_baseline_errors(intervals)
+    scoring = intervals.loc[intervals["period_start"].isin(OBSERVED_SCORING_ORIGINS)].copy()
+    metrics = evaluate_contemporaneous_country_baseline(scoring)
+    errors = contemporaneous_country_baseline_errors(scoring)
     bootstrap = cluster_bootstrap_paired_difference(
         errors,
         model_a="persistence",

--- a/scripts/run_wup_contemporaneous_country_baseline.py
+++ b/scripts/run_wup_contemporaneous_country_baseline.py
@@ -1,0 +1,87 @@
+"""Evaluate persistence against same-origin leave-city-out country recent growth."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from urban_growth.adapters.wup import (
+    read_f21_city_population,
+    read_f25_city_land_area,
+    read_f30_built_up_area_per_capita,
+    read_f34_population_density,
+)
+from urban_growth.contemporaneous_baseline import (
+    contemporaneous_country_baseline_errors,
+    evaluate_contemporaneous_country_baseline,
+)
+from urban_growth.forecast import (
+    build_forecast_intervals,
+    cluster_bootstrap_paired_difference,
+    two_way_cluster_bootstrap_paired_difference,
+)
+from urban_growth.wup_lineage import classify_wup_city_population_lineage
+from urban_growth.wup_panel import build_wup_city_year_panel
+
+OBSERVED_PANEL_ORIGINS = list(range(1980, 2020, 5))
+OBSERVED_SCORING_ORIGINS = list(range(1985, 2020, 5))
+PEER_MODEL = "country_contemporaneous_recent_growth_leave_city_out"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--raw-dir", type=Path, default=Path("data/raw"))
+    parser.add_argument(
+        "--metrics-output",
+        type=Path,
+        default=Path("outputs/wup_contemporaneous_country_metrics.csv"),
+    )
+    parser.add_argument(
+        "--bootstrap-output",
+        type=Path,
+        default=Path("outputs/wup_contemporaneous_country_bootstrap.csv"),
+    )
+    parser.add_argument(
+        "--country-time-bootstrap-output",
+        type=Path,
+        default=Path("outputs/wup_contemporaneous_country_time_bootstrap.csv"),
+    )
+    args = parser.parse_args()
+    raw = args.raw_dir
+    population = classify_wup_city_population_lineage(
+        read_f21_city_population(raw / "WUP2025-F21-DEGURBA-Cities_Pop.xlsx")
+    )
+    city_year = build_wup_city_year_panel(
+        population,
+        read_f25_city_land_area(raw / "WUP2025-F25-DEGURBA-Cities_AREA_km2.xlsx"),
+        read_f30_built_up_area_per_capita(
+            raw / "WUP2025-F30-DEGURBA-Cities_BU_m2_per_capita.xlsx"
+        ),
+        read_f34_population_density(raw / "WUP2025-F34-DEGURBA-Cities_Pop_density.xlsx"),
+    )
+    intervals = build_forecast_intervals(city_year, OBSERVED_PANEL_ORIGINS)
+    metrics = evaluate_contemporaneous_country_baseline(intervals)
+    errors = contemporaneous_country_baseline_errors(intervals)
+    bootstrap = cluster_bootstrap_paired_difference(
+        errors,
+        model_a="persistence",
+        model_b=PEER_MODEL,
+        group_columns=["origin"],
+    )
+    country_time = two_way_cluster_bootstrap_paired_difference(
+        errors,
+        model_a="persistence",
+        model_b=PEER_MODEL,
+    )
+    for path, frame in [
+        (args.metrics_output, metrics),
+        (args.bootstrap_output, bootstrap),
+        (args.country_time_bootstrap_output, country_time),
+    ]:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        frame.to_csv(path, index=False)
+        print(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/urban_growth/contemporaneous_baseline.py
+++ b/src/urban_growth/contemporaneous_baseline.py
@@ -1,0 +1,134 @@
+"""Origin-available contemporaneous country peer-growth diagnostics."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from urban_growth.forecast import score_forecast
+from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
+
+
+def attach_contemporaneous_country_recent_growth(
+    intervals: pd.DataFrame,
+    *,
+    growth_column: str = "recent_growth",
+) -> pd.DataFrame:
+    """Attach leave-city-out same-country recent growth at each forecast origin.
+
+    The predictor uses only other cities' recent growth measured at the same origin.
+    Singleton-country rows fall back to the contemporaneous global leave-city-out mean.
+    """
+    required = {"city_id", "country_code", "period_start", growth_column}
+    require_columns(intervals, required, source_name="forecast intervals")
+    reject_duplicate_keys(
+        intervals,
+        ["city_id", "period_start"],
+        source_name="contemporaneous country baseline intervals",
+    )
+    working = intervals.copy()
+    growth = pd.to_numeric(working[growth_column], errors="coerce")
+    if growth.isna().any() or not np.isfinite(growth).all():
+        raise SourceSchemaError("Contemporaneous country baseline requires finite recent growth")
+    working["_recent_growth"] = growth
+
+    origin_totals = working.groupby("period_start")["_recent_growth"].agg(["sum", "count"])
+    country_totals = working.groupby(["period_start", "country_code"])["_recent_growth"].agg(
+        ["sum", "count"]
+    )
+    origin_sum = working["period_start"].map(origin_totals["sum"]).to_numpy()
+    origin_count = working["period_start"].map(origin_totals["count"]).to_numpy()
+    keys = pd.MultiIndex.from_frame(working[["period_start", "country_code"]])
+    country_sum = country_totals["sum"].reindex(keys).to_numpy()
+    country_count = country_totals["count"].reindex(keys).to_numpy()
+    focal = working["_recent_growth"].to_numpy()
+
+    global_loo_count = origin_count - 1
+    if (global_loo_count <= 0).any():
+        raise SourceSchemaError("Contemporaneous baseline needs at least two cities per origin")
+    global_loo = (origin_sum - focal) / global_loo_count
+    country_loo_count = country_count - 1
+    prediction = np.divide(
+        country_sum - focal,
+        country_loo_count,
+        out=global_loo.copy(),
+        where=country_loo_count > 0,
+    )
+    working["country_contemporaneous_recent_growth_leave_city_out"] = prediction
+    working["contemporaneous_country_peer_count"] = country_loo_count
+    working["contemporaneous_country_fallback_global_loo"] = country_loo_count <= 0
+    working["contemporaneous_country_uses_future_outcome"] = False
+    working["contemporaneous_country_information_time"] = "forecast_origin"
+    return working.drop(columns="_recent_growth")
+
+
+def evaluate_contemporaneous_country_baseline(
+    intervals: pd.DataFrame,
+    *,
+    outcome_column: str = "future_growth",
+) -> pd.DataFrame:
+    """Compare persistence with the contemporaneous country peer-growth baseline by origin."""
+    working = attach_contemporaneous_country_recent_growth(intervals)
+    require_columns(
+        working,
+        {outcome_column, "recent_growth", "period_start"},
+        source_name="contemporaneous baseline evaluation",
+    )
+    rows: list[dict[str, object]] = []
+    peer = "country_contemporaneous_recent_growth_leave_city_out"
+    for origin, group in working.groupby("period_start", sort=True):
+        actual = group[outcome_column]
+        persistence = score_forecast(actual, group["recent_growth"])
+        contemporary = score_forecast(actual, group[peer])
+        if persistence.n != contemporary.n:
+            raise SourceSchemaError("Contemporaneous comparator was not scored on identical rows")
+        rows.append(
+            {
+                "origin": int(origin),
+                "n": persistence.n,
+                "persistence_mae": persistence.mae,
+                "contemporaneous_country_mae": contemporary.mae,
+                "mae_delta_persistence_minus_contemporaneous": (
+                    persistence.mae - contemporary.mae
+                ),
+                "persistence_rmse": persistence.rmse,
+                "contemporaneous_country_rmse": contemporary.rmse,
+                "rmse_delta_persistence_minus_contemporaneous": (
+                    persistence.rmse - contemporary.rmse
+                ),
+                "persistence_beats_contemporaneous_mae": persistence.mae < contemporary.mae,
+                "persistence_beats_contemporaneous_rmse": persistence.rmse < contemporary.rmse,
+                "fallback_rows": int(
+                    group["contemporaneous_country_fallback_global_loo"].sum()
+                ),
+                "comparator_information_time": "forecast_origin",
+                "comparator_leave_city_out": True,
+            }
+        )
+    if not rows:
+        raise SourceSchemaError("No contemporaneous country baseline evaluations were produced")
+    return pd.DataFrame(rows)
+
+
+def contemporaneous_country_baseline_errors(
+    intervals: pd.DataFrame,
+    *,
+    outcome_column: str = "future_growth",
+) -> pd.DataFrame:
+    """Return matched row errors for persistence and contemporaneous country peer growth."""
+    working = attach_contemporaneous_country_recent_growth(intervals)
+    peer = "country_contemporaneous_recent_growth_leave_city_out"
+    required = {"city_id", "country_code", "period_start", outcome_column, "recent_growth", peer}
+    require_columns(working, required, source_name="contemporaneous baseline errors")
+    id_columns = [c for c in ["city_id", "country_code", "city_name", "period_start"] if c in working]
+    rows = []
+    for model, column in [("persistence", "recent_growth"), ("country_contemporaneous_recent_growth_leave_city_out", peer)]:
+        frame = working[id_columns].copy()
+        frame["origin"] = working["period_start"].to_numpy()
+        frame["model"] = model
+        frame["actual"] = working[outcome_column].to_numpy()
+        frame["predicted"] = working[column].to_numpy()
+        frame["error"] = frame["predicted"] - frame["actual"]
+        frame["absolute_error"] = frame["error"].abs()
+        rows.append(frame)
+    return pd.concat(rows, ignore_index=True)

--- a/tests/test_contemporaneous_baseline.py
+++ b/tests/test_contemporaneous_baseline.py
@@ -1,0 +1,58 @@
+import pandas as pd
+import pytest
+
+from urban_growth.contemporaneous_baseline import (
+    attach_contemporaneous_country_recent_growth,
+    evaluate_contemporaneous_country_baseline,
+)
+from urban_growth.io import SourceSchemaError
+
+
+def _panel() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "city_id": [1, 2, 3, 4],
+            "country_code": ["A", "A", "B", "C"],
+            "period_start": [2000, 2000, 2000, 2000],
+            "recent_growth": [0.01, 0.03, 0.02, 0.04],
+            "future_growth": [0.02, 0.01, 0.025, 0.03],
+        }
+    )
+
+
+def test_contemporaneous_country_baseline_is_leave_city_out() -> None:
+    result = attach_contemporaneous_country_recent_growth(_panel())
+    pred = result.set_index("city_id")[
+        "country_contemporaneous_recent_growth_leave_city_out"
+    ]
+    assert pred.loc[1] == pytest.approx(0.03)
+    assert pred.loc[2] == pytest.approx(0.01)
+    # Singleton countries fall back to the global mean excluding the focal city.
+    assert pred.loc[3] == pytest.approx((0.01 + 0.03 + 0.04) / 3)
+    assert pred.loc[4] == pytest.approx((0.01 + 0.03 + 0.02) / 3)
+    assert result.set_index("city_id").loc[1, "contemporaneous_country_peer_count"] == 1
+    assert result.set_index("city_id").loc[3, "contemporaneous_country_fallback_global_loo"]
+    assert not result["contemporaneous_country_uses_future_outcome"].any()
+
+
+def test_contemporaneous_country_baseline_does_not_depend_on_future_growth() -> None:
+    original = attach_contemporaneous_country_recent_growth(_panel())
+    changed = _panel()
+    changed["future_growth"] = [9.0, -3.0, 7.0, 12.0]
+    rerun = attach_contemporaneous_country_recent_growth(changed)
+    column = "country_contemporaneous_recent_growth_leave_city_out"
+    assert rerun[column].tolist() == pytest.approx(original[column].tolist())
+
+
+def test_contemporaneous_country_evaluation_reports_same_rows() -> None:
+    result = evaluate_contemporaneous_country_baseline(_panel())
+    assert result.loc[0, "origin"] == 2000
+    assert result.loc[0, "n"] == 4
+    assert result.loc[0, "comparator_information_time"] == "forecast_origin"
+    assert bool(result.loc[0, "comparator_leave_city_out"])
+
+
+def test_contemporaneous_country_baseline_requires_two_cities_per_origin() -> None:
+    one = _panel().iloc[[0]].copy()
+    with pytest.raises(SourceSchemaError, match="at least two cities"):
+        attach_contemporaneous_country_recent_growth(one)


### PR DESCRIPTION
Implements red-team Findings 5–8 follow-up. Adds the missing origin-available leave-city-out contemporaneous same-country recent-growth comparator, a corrected-lineage WUP empirical runner and workflow, and synthetic tests proving the comparator cannot use future outcomes. Documents that Finding 6 is partly superseded by PRs #122/#123, explicitly records historical comparator drift (Finding 7), and classifies existing aggregation-ladder bootstrap intervals as conditional on fixed fitted baselines pending refit. Issue #127 tracks the full refit bootstrap replacement. Historical manifests and outputs are not silently rewritten.