### PR TITLE
Register UCDB built volume and fixed-height lineage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Register UCDB total/non-residential built volume and the underlying 2018 height snapshot on
+  fixed 2025 polygons, with fail-closed lineage and volume/surface reconciliation checks.
+
+## Unreleased
+
 - License repository software under Apache-2.0 while explicitly excluding
   third-party data from that grant.
 - Add a deny-by-default, machine-readable data-rights registry covering research,

--- a/docs/source-library.md
+++ b/docs/source-library.md
@@ -132,6 +132,31 @@ Consequences:
 
 The official v1.2 GHSL thematic archive was retrieved and registered on 2026-08-27. Its CSV uses Windows-1252 encoding and contains 11,422 unique `ID_UC_G0` records and 551 columns. The adapter reads 12 five-year epochs from 1975 through 2030 for both `GH_POP_TOT_YYYY` (inhabitants) and `GH_BUS_TOT_YYYY` (square metres). All 274,128 values across those two families are present, numeric and positive.
 
+The same registered CSV carries `GH_BUV_TOT_YYYY` and `GH_BUV_NRE_YYYY` for all 12
+epochs, plus `GH_BUH_AVG_2020`. The UCDB height field is temporally labeled 2020, but its
+source is the 2018 GHS-BUILT-H composite; the normalized adapter field is therefore
+`built_up_height_avg_m_2018`. All 274,128 total and non-residential volume values are present
+and numeric. Total volume is positive; non-residential volume may be zero and never exceeds
+total volume.
+
+**Construction fact:** the volume epochs are epoch-specific built-surface layers scaled by the
+2018 height layer. They are not multi-date observations of building height. The registered
+lineage is `ghs_built_v_surface_epoch_scaled_by_2018_height`, and the height lineage is
+`ghs_built_h_2018_snapshot_ucdb_2020_label`. Historical changes in `GH_BUV_*` therefore
+combine surface-footprint change with the spatial distribution of a fixed height field and
+cannot be interpreted as vertical growth.
+
+The requested volume/surface reconciliation confirms the implication but rejects general
+polygon-level constancy. Across the 11,422 polygons, none has an exactly constant total-volume
+to total-surface ratio over all epochs; only 267 (2.3%) are within a 1% relative-span tolerance.
+The within-polygon relative span has median 11.0%,
+25th percentile 5.5%, 75th percentile 19.3%, and 95th percentile 35.4%. The cross-polygon
+median ratio declines from 7.95 m in 1975 to 7.22 m in 2030. This variation occurs because each
+epoch's built-surface mask samples a different subset of the fixed 2018 height field: entering
+and changing built cells have different fixed heights. It is evidence that `GH_BUV_*` is a
+surface-composition construct, not evidence of observed vertical change. Child issue 03 must
+still acquire an independent multi-date height source.
+
 The thematic archive is the fixed-boundary stream: every historical statistic is calculated inside the urban centre's 2025 boundary. The separately published MTUC archive follows changing boundaries. GHSL documentation says the two streams are different and not comparable except at 2025. Therefore a trend from the thematic archive describes change within today's footprint; it is not the city's historical spatial expansion.
 
 The publisher landing page still labels the release v1.1, but the official download script and archive readme identify v1.2, state that the data were last updated on 2026-05-15, and explicitly deprecate v1.1. The catalog records that discrepancy instead of silently downgrading the acquired package.

--- a/src/urban_growth/adapters/ghsl_ucdb.py
+++ b/src/urban_growth/adapters/ghsl_ucdb.py
@@ -19,6 +19,10 @@ GHSL_MTUC_METADATA = [
     "GC_UCB_YOB _2025",
     "GC_UCB_YOD _2025",
 ]
+GHSL_BUILT_VOLUME_YEARS = tuple(range(1975, 2031, 5))
+GHSL_BUILT_VOLUME_LINEAGE = "ghs_built_v_surface_epoch_scaled_by_2018_height"
+GHSL_BUILT_VOLUME_NRES_LINEAGE = "ghs_built_v_nres_surface_epoch_scaled_by_2018_height"
+GHSL_BUILT_HEIGHT_LINEAGE = "ghs_built_h_2018_snapshot_ucdb_2020_label"
 
 
 def indicator_panel(
@@ -121,6 +125,130 @@ def fixed_2025_theme_panel(frame: pd.DataFrame) -> pd.DataFrame:
         panel, ["city_id", "year", "boundary_product"], source_name="GHS-UCDB theme"
     )
     return panel.sort_values(["city_id", "year"]).reset_index(drop=True)
+
+
+def ghsl_built_volume_panel(frame: pd.DataFrame) -> pd.DataFrame:
+    """Normalize UCDB volume epochs and its single 2018 height snapshot.
+
+    UCDB labels the height statistic ``GH_BUH_AVG_2020`` because its thematic
+    temporal coverage is 2020. The underlying GHS-BUILT-H composite is dated
+    2018, so the normalized measure names the observation vintage explicitly.
+    Volume epochs are constructed by applying that fixed height surface to each
+    epoch's built-up surface; they are not observations of vertical change.
+    """
+    required = {
+        "ID_UC_G0",
+        *GHSL_THEME_METADATA,
+        "GH_BUH_AVG_2020",
+        *(f"GH_BUV_TOT_{year}" for year in GHSL_BUILT_VOLUME_YEARS),
+        *(f"GH_BUV_NRE_{year}" for year in GHSL_BUILT_VOLUME_YEARS),
+    }
+    require_columns(frame, required, source_name="GHS-UCDB built volume R2024A v1.2")
+    total = indicator_panel(
+        frame,
+        city_id_column="ID_UC_G0",
+        metadata_columns=GHSL_THEME_METADATA,
+        indicator_pattern=r"GH_BUV_TOT_(?P<year>\d{4})",
+        value_name="built_up_volume_m3",
+        boundary_product="ucdb_fixed_2025_boundary",
+    )
+    nonresidential = indicator_panel(
+        frame,
+        city_id_column="ID_UC_G0",
+        metadata_columns=GHSL_THEME_METADATA,
+        indicator_pattern=r"GH_BUV_NRE_(?P<year>\d{4})",
+        value_name="built_up_volume_nres_m3",
+        boundary_product="ucdb_fixed_2025_boundary",
+    )
+    keys = [
+        "city_id",
+        *GHSL_THEME_METADATA,
+        "year",
+        "boundary_mode",
+        "boundary_product",
+    ]
+    panel = total.merge(nonresidential, on=keys, validate="one_to_one")
+    observed_years = tuple(sorted(panel["year"].unique()))
+    if observed_years != GHSL_BUILT_VOLUME_YEARS:
+        raise SourceSchemaError(
+            "GHS-UCDB built volume epochs disagree with registered 1975-2030 schema"
+        )
+    height = _publisher_numeric(frame["GH_BUH_AVG_2020"], column="GH_BUH_AVG_2020")
+    height_by_city = pd.Series(height.to_numpy(), index=frame["ID_UC_G0"])
+    if height_by_city.index.has_duplicates:
+        raise SourceSchemaError("GHS-UCDB built volume contains duplicate ID_UC_G0")
+    panel["built_up_height_avg_m_2018"] = panel["city_id"].map(height_by_city)
+    measures = [
+        "built_up_volume_m3",
+        "built_up_volume_nres_m3",
+        "built_up_height_avg_m_2018",
+    ]
+    for column in measures[:2]:
+        panel[column] = _publisher_numeric(panel[column], column=column)
+    if panel[measures].isna().any().any():
+        raise SourceSchemaError("GHS-UCDB built volume has missing registered measures")
+    if (panel["built_up_volume_m3"] <= 0).any():
+        raise SourceSchemaError("GHS-UCDB total built volume must be positive")
+    if (panel[["built_up_volume_nres_m3", "built_up_height_avg_m_2018"]] < 0).any().any():
+        raise SourceSchemaError("GHS-UCDB non-residential volume and height must be nonnegative")
+    if (panel["built_up_height_avg_m_2018"] == 0).any():
+        raise SourceSchemaError("GHS-UCDB average built height must be positive")
+    if (panel["built_up_volume_nres_m3"] > panel["built_up_volume_m3"]).any():
+        raise SourceSchemaError("GHS-UCDB non-residential volume exceeds total volume")
+    panel["built_up_volume_lineage"] = GHSL_BUILT_VOLUME_LINEAGE
+    panel["built_up_volume_nres_lineage"] = GHSL_BUILT_VOLUME_NRES_LINEAGE
+    panel["built_up_height_lineage"] = GHSL_BUILT_HEIGHT_LINEAGE
+    panel = panel.rename(columns={"GC_UCA_KM2_2025": "urban_centre_area_km2"})
+    reject_duplicate_keys(
+        panel, ["city_id", "year", "boundary_product"], source_name="GHS-UCDB built volume"
+    )
+    return panel.sort_values(["city_id", "year"]).reset_index(drop=True)
+
+
+def reconcile_volume_surface(
+    volume_panel: pd.DataFrame,
+    surface_panel: pd.DataFrame,
+    *,
+    relative_span_tolerance: float = 0.01,
+) -> pd.DataFrame:
+    """Measure, but do not assume, within-polygon volume/surface constancy."""
+    if relative_span_tolerance < 0:
+        raise ValueError("relative_span_tolerance must be nonnegative")
+    volume_required = {"city_id", "year", "boundary_product", "built_up_volume_m3"}
+    surface_required = {"city_id", "year", "boundary_product", "built_up_area_m2"}
+    require_columns(volume_panel, volume_required, source_name="GHS-UCDB volume panel")
+    require_columns(surface_panel, surface_required, source_name="GHS-UCDB surface panel")
+    reject_duplicate_keys(
+        volume_panel, ["city_id", "year", "boundary_product"], source_name="volume panel"
+    )
+    reject_duplicate_keys(
+        surface_panel, ["city_id", "year", "boundary_product"], source_name="surface panel"
+    )
+    joined = volume_panel[list(volume_required)].merge(
+        surface_panel[list(surface_required)],
+        on=["city_id", "year", "boundary_product"],
+        how="outer",
+        validate="one_to_one",
+        indicator=True,
+    )
+    if joined["_merge"].ne("both").any():
+        raise SourceSchemaError("GHS-UCDB volume and surface panels have different keys")
+    if (joined[["built_up_volume_m3", "built_up_area_m2"]] <= 0).any().any():
+        raise SourceSchemaError("GHS-UCDB volume/surface reconciliation requires positive values")
+    joined["volume_surface_ratio_m"] = (
+        joined["built_up_volume_m3"] / joined["built_up_area_m2"]
+    )
+    audit = joined.groupby("city_id")["volume_surface_ratio_m"].agg(
+        ratio_min_m="min", ratio_max_m="max", ratio_mean_m="mean", epoch_count="size"
+    )
+    if audit["epoch_count"].ne(len(GHSL_BUILT_VOLUME_YEARS)).any():
+        raise SourceSchemaError("GHS-UCDB reconciliation requires all registered epochs")
+    audit["relative_ratio_span"] = (
+        (audit["ratio_max_m"] - audit["ratio_min_m"]) / audit["ratio_mean_m"]
+    )
+    audit["ratio_near_constant"] = audit["relative_ratio_span"].le(relative_span_tolerance)
+    audit["construction_interpretation"] = "fixed_2018_height_sampled_by_epoch_surface"
+    return audit.reset_index()
 
 
 def reconcile_2025_streams(

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -3,9 +3,11 @@ import pytest
 
 from urban_growth.adapters.ghsl_ucdb import (
     fixed_2025_theme_panel,
+    ghsl_built_volume_panel,
     indicator_panel,
     multitemporal_boundary_panel,
     reconcile_2025_streams,
+    reconcile_volume_surface,
 )
 from urban_growth.adapters.wup import (
     city_area_panel,
@@ -67,6 +69,64 @@ def test_ghsl_fixed_theme_rejects_non_numeric_measure() -> None:
     )
     with pytest.raises(SourceSchemaError, match="non-numeric population"):
         fixed_2025_theme_panel(source)
+
+
+def _built_volume_source() -> pd.DataFrame:
+    source = {
+        "ID_UC_G0": [1],
+        "GC_UCN_MAI_2025": ["Example"],
+        "GC_CNT_GAD_2025": ["Exampleland"],
+        "GC_UCA_KM2_2025": [12],
+        "GH_BUH_AVG_2020": [7.5],
+    }
+    for offset, year in enumerate(range(1975, 2031, 5)):
+        source[f"GH_BUV_TOT_{year}"] = [1_000 + 100 * offset]
+        source[f"GH_BUV_NRE_{year}"] = [100 + 10 * offset]
+    return pd.DataFrame(source)
+
+
+def test_ghsl_built_volume_panel_registers_lineage_and_fixed_height() -> None:
+    result = ghsl_built_volume_panel(_built_volume_source())
+    assert result["year"].tolist() == list(range(1975, 2031, 5))
+    assert result["built_up_volume_m3"].iloc[0] == 1_000
+    assert result["built_up_volume_nres_m3"].iloc[-1] == 210
+    assert result["built_up_height_avg_m_2018"].unique().tolist() == [7.5]
+    assert result["boundary_mode"].unique().tolist() == ["fixed"]
+    assert result["built_up_volume_lineage"].str.contains("2018_height").all()
+    assert result["built_up_height_lineage"].str.contains("2018_snapshot").all()
+
+
+def test_ghsl_built_volume_panel_fails_closed_on_missing_epoch() -> None:
+    source = _built_volume_source().drop(columns="GH_BUV_NRE_1985")
+    with pytest.raises(SourceSchemaError, match="missing columns: GH_BUV_NRE_1985"):
+        ghsl_built_volume_panel(source)
+
+
+def test_ghsl_built_volume_panel_rejects_nonresidential_above_total() -> None:
+    source = _built_volume_source()
+    source["GH_BUV_NRE_2000"] = 10_000
+    with pytest.raises(SourceSchemaError, match="exceeds total"):
+        ghsl_built_volume_panel(source)
+
+
+def test_volume_surface_reconciliation_reports_nonconstant_ratio() -> None:
+    volume = ghsl_built_volume_panel(_built_volume_source())
+    surface = volume[["city_id", "year", "boundary_product"]].copy()
+    surface["built_up_area_m2"] = 100.0
+    audit = reconcile_volume_surface(volume, surface, relative_span_tolerance=0.01)
+    assert audit["epoch_count"].tolist() == [12]
+    assert not audit["ratio_near_constant"].iloc[0]
+    assert audit["construction_interpretation"].iloc[0] == (
+        "fixed_2018_height_sampled_by_epoch_surface"
+    )
+
+
+def test_volume_surface_reconciliation_fails_on_key_mismatch() -> None:
+    volume = ghsl_built_volume_panel(_built_volume_source())
+    surface = volume[["city_id", "year", "boundary_product"]].iloc[:-1].copy()
+    surface["built_up_area_m2"] = 100.0
+    with pytest.raises(SourceSchemaError, match="different keys"):
+        reconcile_volume_surface(volume, surface)
 
 
 def test_ghsl_2025_stream_reconciliation_allows_population_rounding() -> None:


### PR DESCRIPTION
Closes #142.

## What changed
- reads all 12 UCDB `GH_BUV_TOT_*` and `GH_BUV_NRE_*` epochs on fixed 2025 polygons
- exposes `built_up_height_avg_m_2018` from UCDB's `GH_BUH_AVG_2020` field while preserving the underlying 2018 observation date
- adds per-measure lineage metadata and fail-closed epoch, numeric, positivity, NRES≤total, duplicate-key, and reconciliation checks
- adds volume/surface reconciliation without assuming constancy
- records the construction fact and empirical reconciliation in the source library

## Validation
- `uv run --extra dev ruff check ...`
- `uv run --extra dev pytest -q` — 262 passed
- exact registered archive: 137,064 rows, 11,422 polygons, 12 epochs
- no polygon exactly constant; 267 (2.3%) within 1% relative-span tolerance; median relative span 11.0%

The raster acquisition/zonal branch was not implemented because the registered UCDB CSV already contains the required total volume, NRES volume, and average-height fields.