### PR TITLE
Add fail-closed extent × density reconciliation

### DIFF
--- a/docs/research-design.md
+++ b/docs/research-design.md
@@ -14,6 +14,23 @@ g(i,t,t+h) = [log(population(i,t+h)) - log(population(i,t))] / h
 
 Report decimal annual growth and percentage-point equivalents. Do not mix annual and five-year coefficients.
 
+## Module A: national settlement envelope
+
+F01 Cities-class change is a class-total accounting outcome, not pure in-place
+demographic growth. Conceptually it contains population change within a fixed city
+universe plus class-composition change from territory or settlements entering and
+leaving the Cities class. Within fixed polygons, the population identity is separated
+exactly into in-place density change and built-surface expansion with their interaction
+allocated symmetrically. The remaining difference from F01 may be named net
+reclassification only after a documented constant-membership F21 cross-check closes
+within the registered tolerance. Until then it is an unidentified composition residual
+that may also contain coverage, cross-border, source, and geography differences.
+
+Module A must preserve the original F01 class-total outcome and its discontinuity
+flags. Any extent-density reconciliation using a GHS-POP-based density is
+construction-sensitive sensitivity evidence under the Module C lineage rule, not an
+independent demographic validation.
+
 ## Baseline ladder
 
 Models must be evaluated in this order:

--- a/docs/research-status.md
+++ b/docs/research-status.md
@@ -225,6 +225,16 @@ component of the focal country's F01 total. The leave-city-out national comparat
 undefined for those rows. The workflow now flags them, leaves that diagnostic missing,
 and scores every baseline on the common finite sample.
 
+The extent-by-density reconciliation is therefore implemented but not yet registered
+as an empirical result. The executable uses an exact fixed-polygon surface/density
+identity and carries the national-envelope discontinuity flags, but it fails closed on
+the interpretation of the residual. Issue #136 has not yet established F21's
+constant-membership semantics or a complete fixed-polygon/F21 crosswalk; existing
+cross-border and singleton failures show that the raw residual is not identified as
+reclassification. Until that dependency closes, the output field is
+`unidentified_composition_residual`, `net_reclassification_change` is missing, and no
+expected-output manifest or empirical three-way decomposition may be registered.
+
 At the 2020 origin this removes 25 of 10,709 city rows (0.23%) but 25 of 189 countries
 (13.2%). Pooled metrics therefore move little, while equal-country metrics move more.
 The substantive ranking does not change:

--- a/scripts/run_extent_density_reconciliation.py
+++ b/scripts/run_extent_density_reconciliation.py
@@ -1,0 +1,37 @@
+"""Build the registered fixed-polygon/F01/F21 accounting reconciliation."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from urban_growth.national_envelope import extent_density_reconciliation
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixed-polygon-intervals", required=True, type=Path)
+    parser.add_argument("--national-intervals", required=True, type=Path)
+    parser.add_argument("--constant-membership-intervals", required=True, type=Path)
+    parser.add_argument(
+        "--output", type=Path, default=Path("outputs/extent_density_reconciliation.csv")
+    )
+    parser.add_argument("--relative-tolerance", type=float, default=1e-6)
+    parser.add_argument("--absolute-tolerance", type=float, default=1.0)
+    args = parser.parse_args()
+    result = extent_density_reconciliation(
+        pd.read_csv(args.fixed_polygon_intervals),
+        pd.read_csv(args.national_intervals),
+        pd.read_csv(args.constant_membership_intervals),
+        relative_tolerance=args.relative_tolerance,
+        absolute_tolerance=args.absolute_tolerance,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    result.to_csv(args.output, index=False)
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/urban_growth/national_envelope.py
+++ b/src/urban_growth/national_envelope.py
@@ -10,6 +10,176 @@ from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_co
 DEGURBA_CATEGORIES = ("city", "town_and_semi_dense", "rural")
 
 
+def extent_density_reconciliation(
+    fixed_polygon_intervals: pd.DataFrame,
+    national_intervals: pd.DataFrame,
+    constant_membership_intervals: pd.DataFrame,
+    *,
+    relative_tolerance: float = 1e-6,
+    absolute_tolerance: float = 1.0,
+) -> pd.DataFrame:
+    """Reconcile fixed-polygon extent/density change with F01 Cities change.
+
+    The two fixed-polygon terms use the symmetric two-factor (Shapley) identity,
+    so their sum is exactly the change in ``surface * density``.  The remaining
+    F01 difference is called reclassification only when an independently
+    documented constant-membership F21 universe agrees with the fixed-polygon
+    change within the registered tolerance.  Otherwise it remains an
+    unidentified composition residual.
+    """
+    fixed_required = {
+        "country_code", "polygon_id", "period_start", "period_end",
+        "built_surface_start", "built_surface_end", "density_start", "density_end",
+        "density_metric_id", "density_lineage_status",
+    }
+    national_required = {
+        "country_code", "period_start", "period_end", "city_population_start",
+        "city_population_end", "category_presence_transition",
+        "large_share_change_flag", "large_share_change_threshold",
+        "composition_discontinuity_flag", "interval_observation_status",
+    }
+    membership_required = {
+        "country_code", "period_start", "period_end", "f21_population_start",
+        "f21_population_end", "constant_membership_validated",
+        "membership_semantics_source",
+    }
+    require_columns(fixed_polygon_intervals, fixed_required, source_name="fixed-polygon intervals")
+    require_columns(national_intervals, national_required, source_name="national intervals")
+    require_columns(
+        constant_membership_intervals,
+        membership_required,
+        source_name="constant-membership intervals",
+    )
+    reject_duplicate_keys(
+        fixed_polygon_intervals,
+        ["country_code", "polygon_id", "period_start", "period_end"],
+        source_name="fixed-polygon intervals",
+    )
+    interval_key = ["country_code", "period_start", "period_end"]
+    reject_duplicate_keys(national_intervals, interval_key, source_name="national intervals")
+    reject_duplicate_keys(
+        constant_membership_intervals,
+        interval_key,
+        source_name="constant-membership intervals",
+    )
+    if relative_tolerance < 0 or absolute_tolerance < 0:
+        raise SourceSchemaError("Reconciliation tolerances must be nonnegative")
+
+    numeric_columns = [
+        "built_surface_start", "built_surface_end", "density_start", "density_end",
+    ]
+    fixed = fixed_polygon_intervals.copy()
+    for column in numeric_columns:
+        fixed[column] = pd.to_numeric(fixed[column], errors="coerce")
+    if fixed[numeric_columns].isna().any().any() or not np.isfinite(
+        fixed[numeric_columns].to_numpy(dtype=float)
+    ).all():
+        raise SourceSchemaError("Fixed-polygon extent and density values must be finite")
+    if (fixed[numeric_columns] < 0).any().any():
+        raise SourceSchemaError("Fixed-polygon extent and density values must be nonnegative")
+    for column in ("density_metric_id", "density_lineage_status"):
+        if fixed.groupby(interval_key)[column].nunique(dropna=False).gt(1).any():
+            raise SourceSchemaError(f"Each country interval must use one {column}")
+
+    surface_start = fixed["built_surface_start"]
+    surface_end = fixed["built_surface_end"]
+    density_start = fixed["density_start"]
+    density_end = fixed["density_end"]
+    fixed["fixed_population_start"] = surface_start * density_start
+    fixed["fixed_population_end"] = surface_end * density_end
+    fixed["horizontal_extent_change"] = (
+        0.5 * (density_start + density_end) * (surface_end - surface_start)
+    )
+    fixed["in_place_densification_change"] = (
+        0.5 * (surface_start + surface_end) * (density_end - density_start)
+    )
+    aggregation = {
+        "fixed_population_start": "sum", "fixed_population_end": "sum",
+        "horizontal_extent_change": "sum", "in_place_densification_change": "sum",
+        "polygon_id": "nunique", "density_metric_id": "first",
+        "density_lineage_status": "first",
+    }
+    result = fixed.groupby(interval_key, as_index=False).agg(aggregation).rename(
+        columns={"polygon_id": "polygon_count"}
+    )
+    result["fixed_polygon_population_change"] = (
+        result["fixed_population_end"] - result["fixed_population_start"]
+    )
+    result["fixed_identity_error"] = result["fixed_polygon_population_change"] - (
+        result["horizontal_extent_change"] + result["in_place_densification_change"]
+    )
+    if not np.allclose(result["fixed_identity_error"], 0, atol=1e-8, rtol=1e-10):
+        raise SourceSchemaError("Extent-density decomposition does not close")
+
+    flag_columns = [
+        "city_population_start", "city_population_end", "category_presence_transition",
+        "large_share_change_flag", "large_share_change_threshold",
+        "composition_discontinuity_flag", "interval_observation_status",
+    ]
+    result = result.merge(
+        national_intervals[interval_key + flag_columns], on=interval_key, validate="one_to_one"
+    ).merge(constant_membership_intervals, on=interval_key, validate="one_to_one")
+    for column in (
+        "city_population_start", "city_population_end", "f21_population_start",
+        "f21_population_end",
+    ):
+        result[column] = pd.to_numeric(result[column], errors="coerce")
+    check_columns = [
+        "city_population_start", "city_population_end", "f21_population_start",
+        "f21_population_end",
+    ]
+    if result[check_columns].isna().any().any() or not np.isfinite(
+        result[check_columns].to_numpy(dtype=float)
+    ).all():
+        raise SourceSchemaError("F01 and F21 reconciliation populations must be finite")
+    if (result[check_columns] < 0).any().any():
+        raise SourceSchemaError("F01 and F21 reconciliation populations must be nonnegative")
+    if not result["constant_membership_validated"].isin([True, False]).all():
+        raise SourceSchemaError("constant_membership_validated must be boolean")
+    if result.loc[result["constant_membership_validated"], "membership_semantics_source"].isna().any():
+        raise SourceSchemaError("Validated membership requires a methodology source")
+
+    result["f01_cities_population_change"] = (
+        result["city_population_end"] - result["city_population_start"]
+    )
+    result["f21_constant_membership_change"] = (
+        result["f21_population_end"] - result["f21_population_start"]
+    )
+    result["fixed_vs_f21_change_difference"] = (
+        result["fixed_polygon_population_change"] - result["f21_constant_membership_change"]
+    )
+    scale = np.maximum(
+        np.maximum(result["f21_population_start"], result["f21_population_end"]), 1.0
+    )
+    allowed_error = absolute_tolerance + relative_tolerance * scale
+    result["f21_crosscheck_within_tolerance"] = (
+        result["fixed_vs_f21_change_difference"].abs() <= allowed_error
+    )
+    result["f01_composition_residual"] = (
+        result["f01_cities_population_change"] - result["fixed_polygon_population_change"]
+    )
+    identified = (
+        result["constant_membership_validated"] & result["f21_crosscheck_within_tolerance"]
+    )
+    result["residual_interpretation"] = np.where(
+        identified, "net_reclassification", "unidentified_composition_residual"
+    )
+    result["net_reclassification_change"] = result["f01_composition_residual"].where(identified)
+    result["f01_reconciliation_error"] = result["f01_cities_population_change"] - (
+        result["horizontal_extent_change"] + result["in_place_densification_change"]
+        + result["f01_composition_residual"]
+    )
+    result["relative_tolerance"] = relative_tolerance
+    result["absolute_tolerance"] = absolute_tolerance
+    result["admissible_role"] = np.where(
+        result["density_lineage_status"].eq("clean"),
+        "accounting_decomposition", "construction_sensitive_sensitivity_only",
+    )
+    if not np.allclose(result["f01_reconciliation_error"], 0, atol=1e-8, rtol=1e-10):
+        raise SourceSchemaError("F01 reconciliation does not close")
+    return result.sort_values(interval_key).reset_index(drop=True)
+
+
 def national_envelope_intervals(
     panel: pd.DataFrame,
     *,

--- a/tests/test_national_envelope.py
+++ b/tests/test_national_envelope.py
@@ -3,11 +3,73 @@ import pytest
 
 from urban_growth.io import SourceSchemaError
 from urban_growth.national_envelope import (
+    extent_density_reconciliation,
     national_envelope_feature_registry,
     national_envelope_forecast_features,
     national_envelope_intervals,
     national_envelope_summaries,
 )
+
+
+def reconciliation_inputs(validated: bool = True):
+    fixed = pd.DataFrame([
+        {"country_code": "X", "polygon_id": "a", "period_start": 2000,
+         "period_end": 2005, "built_surface_start": 10.0, "built_surface_end": 12.0,
+         "density_start": 4.0, "density_end": 5.0,
+         "density_metric_id": "census_pop_per_built_surface",
+         "density_lineage_status": "clean"},
+        {"country_code": "X", "polygon_id": "b", "period_start": 2000,
+         "period_end": 2005, "built_surface_start": 5.0, "built_surface_end": 6.0,
+         "density_start": 2.0, "density_end": 2.0,
+         "density_metric_id": "census_pop_per_built_surface",
+         "density_lineage_status": "clean"},
+    ])
+    national = pd.DataFrame([{
+        "country_code": "X", "period_start": 2000, "period_end": 2005,
+        "city_population_start": 50.0, "city_population_end": 80.0,
+        "category_presence_transition": False, "large_share_change_flag": False,
+        "large_share_change_threshold": 0.25, "composition_discontinuity_flag": False,
+        "interval_observation_status": "retrospective_revised_estimate",
+    }])
+    membership = pd.DataFrame([{
+        "country_code": "X", "period_start": 2000, "period_end": 2005,
+        "f21_population_start": 50.0, "f21_population_end": 72.0,
+        "constant_membership_validated": validated,
+        "membership_semantics_source": "publisher-methodology" if validated else None,
+    }])
+    return fixed, national, membership
+
+
+def test_extent_density_reconciliation_is_exact_and_inherits_flags() -> None:
+    result = extent_density_reconciliation(*reconciliation_inputs()).iloc[0]
+    assert result["fixed_polygon_population_change"] == pytest.approx(22.0)
+    assert result["horizontal_extent_change"] == pytest.approx(11.0)
+    assert result["in_place_densification_change"] == pytest.approx(11.0)
+    assert result["f01_composition_residual"] == pytest.approx(8.0)
+    assert result["net_reclassification_change"] == pytest.approx(8.0)
+    assert result["residual_interpretation"] == "net_reclassification"
+    assert result["f01_reconciliation_error"] == pytest.approx(0.0)
+    assert not result["composition_discontinuity_flag"]
+
+
+def test_extent_density_reconciliation_fails_closed_on_unvalidated_membership() -> None:
+    result = extent_density_reconciliation(*reconciliation_inputs(validated=False)).iloc[0]
+    assert result["residual_interpretation"] == "unidentified_composition_residual"
+    assert pd.isna(result["net_reclassification_change"])
+
+
+def test_extent_density_reconciliation_fails_closed_when_f21_does_not_close() -> None:
+    fixed, national, membership = reconciliation_inputs()
+    membership["f21_population_end"] = 60.0
+    result = extent_density_reconciliation(fixed, national, membership).iloc[0]
+    assert not result["f21_crosscheck_within_tolerance"]
+    assert result["residual_interpretation"] == "unidentified_composition_residual"
+
+
+def test_extent_density_reconciliation_rejects_duplicate_polygons() -> None:
+    fixed, national, membership = reconciliation_inputs()
+    with pytest.raises(SourceSchemaError, match="duplicate"):
+        extent_density_reconciliation(pd.concat([fixed, fixed.iloc[[0]]]), national, membership)
 
 
 def envelope_panel() -> pd.DataFrame:


### PR DESCRIPTION
Implements the fixed-polygon extent/density accounting requested by #143 using an exact symmetric two-factor decomposition. Carries the national-envelope discontinuity flags, reconciles against F01, and cross-checks the fixed-polygon change against a documented constant-membership F21 input.

The implementation deliberately fails closed: the F01 residual is named `net_reclassification` only when membership semantics are validated and the F21 cross-check closes within tolerance. Otherwise it remains `unidentified_composition_residual`, with `net_reclassification_change` missing. This reflects the unresolved dependency in #136 and the existing cross-border/singleton failures.

Also updates Module A's design language, records the empirical blocker in research status, adds a CLI runner, and adds synthetic/fail-closed schema tests.

Validation: `274 passed`; `ruff check src scripts tests` passes.

No empirical table or expected-output manifest is committed because the required validated constant-membership F21/crosswalk input does not yet exist. Closes the implementation portion of #143; empirical acceptance remains blocked by #136.