### PR TITLE
Add border-conditioned rival-mass contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add a synthetic border-conditioned rival-mass contract that preserves the existing
+  accessibility-band totals; this is infrastructure for H5, not an empirical finding.
+
 - Pre-register the lineage-clean open-covariate density model, comparator ladder, country-cluster falsification rule, fixed failure language, and fail-closed real-run gate.
 
 - Add the registered Module C density-metric policy, lineage/role enforcement, forecast-origin gates, and downstream metric-ID attachment.

--- a/src/urban_growth/accessibility.py
+++ b/src/urban_growth/accessibility.py
@@ -9,15 +9,14 @@ from urban_growth.io import SourceSchemaError, require_columns
 TRAVEL_TIME_BANDS = ((0, 1), (1, 2), (2, 4), (4, 8))
 
 
-def mutually_exclusive_rival_mass(
+def _validate_accessibility_pairs(
     pairs: pd.DataFrame,
     *,
     nominal_vintage: int,
-    focal_column: str = "focal_city_id",
-    travel_time_column: str = "travel_time_hours",
-    rival_population_column: str = "rival_population",
-) -> pd.DataFrame:
-    """Aggregate other-centre mass into non-overlapping 0-1/1-2/2-4/4-8h bands."""
+    focal_column: str,
+    travel_time_column: str,
+    rival_population_column: str,
+) -> None:
     require_columns(
         pairs,
         {focal_column, "rival_city_id", travel_time_column, rival_population_column},
@@ -31,6 +30,24 @@ def mutually_exclusive_rival_mass(
         raise SourceSchemaError("Accessibility pairs cannot contain missing time or mass")
     if (pairs[[travel_time_column, rival_population_column]] < 0).any().any():
         raise SourceSchemaError("Travel time and rival population cannot be negative")
+
+
+def mutually_exclusive_rival_mass(
+    pairs: pd.DataFrame,
+    *,
+    nominal_vintage: int,
+    focal_column: str = "focal_city_id",
+    travel_time_column: str = "travel_time_hours",
+    rival_population_column: str = "rival_population",
+) -> pd.DataFrame:
+    """Aggregate other-centre mass into non-overlapping 0-1/1-2/2-4/4-8h bands."""
+    _validate_accessibility_pairs(
+        pairs,
+        nominal_vintage=nominal_vintage,
+        focal_column=focal_column,
+        travel_time_column=travel_time_column,
+        rival_population_column=rival_population_column,
+    )
     result = pd.DataFrame(index=pd.Index(pairs[focal_column].drop_duplicates(), name=focal_column))
     for lower, upper in TRAVEL_TIME_BANDS:
         mask = pairs[travel_time_column].ge(lower) & pairs[travel_time_column].lt(upper)
@@ -38,4 +55,88 @@ def mutually_exclusive_rival_mass(
         result[f"rival_mass_{lower}_{upper}h"] = mass.reindex(result.index, fill_value=0.0)
     result["accessibility_nominal_vintage"] = nominal_vintage
     result["band_definition"] = "mutually_exclusive_left_closed"
+    return result.reset_index()
+
+
+def border_conditioned_rival_mass(
+    pairs: pd.DataFrame,
+    city_country_lookup: pd.DataFrame,
+    *,
+    nominal_vintage: int,
+    focal_column: str = "focal_city_id",
+    travel_time_column: str = "travel_time_hours",
+    rival_population_column: str = "rival_population",
+    lookup_city_column: str = "city_id",
+    country_column: str = "country_code",
+) -> pd.DataFrame:
+    """Construct descriptive same-country and cross-border rival-mass exposures.
+
+    Country assignments must be validated upstream; no boundary geometry is interpreted here.
+    Downstream coefficient signs alone do not identify competition versus agglomeration.
+    """
+    _validate_accessibility_pairs(
+        pairs,
+        nominal_vintage=nominal_vintage,
+        focal_column=focal_column,
+        travel_time_column=travel_time_column,
+        rival_population_column=rival_population_column,
+    )
+    require_columns(
+        city_country_lookup,
+        {lookup_city_column, country_column},
+        source_name="city-country lookup",
+    )
+    if city_country_lookup[lookup_city_column].duplicated().any():
+        raise SourceSchemaError("City-country lookup must contain unique city IDs")
+    if city_country_lookup[[lookup_city_column, country_column]].isna().any().any():
+        raise SourceSchemaError("City-country lookup cannot contain missing IDs or country codes")
+
+    country_codes = city_country_lookup[country_column].astype("string")
+    if country_codes.str.strip().eq("").any():
+        raise SourceSchemaError("City-country lookup cannot contain blank country codes")
+    if country_codes.ne(country_codes.str.strip()).any():
+        raise SourceSchemaError("City-country lookup country codes cannot contain outer whitespace")
+
+    lookup = city_country_lookup[[lookup_city_column, country_column]].copy()
+    lookup[country_column] = country_codes
+    focal_lookup = lookup.rename(
+        columns={lookup_city_column: focal_column, country_column: "_focal_country_code"}
+    )
+    rival_lookup = lookup.rename(
+        columns={lookup_city_column: "rival_city_id", country_column: "_rival_country_code"}
+    )
+    input_row_count = len(pairs)
+    joined = pairs.merge(focal_lookup, on=focal_column, how="left", validate="many_to_one")
+    joined = joined.merge(rival_lookup, on="rival_city_id", how="left", validate="many_to_one")
+    if len(joined) != input_row_count:
+        raise SourceSchemaError("City-country joins changed the accessibility-pair row count")
+    if joined[["_focal_country_code", "_rival_country_code"]].isna().any().any():
+        raise SourceSchemaError("Every focal and rival city must match the city-country lookup")
+
+    base = mutually_exclusive_rival_mass(
+        joined,
+        nominal_vintage=nominal_vintage,
+        focal_column=focal_column,
+        travel_time_column=travel_time_column,
+        rival_population_column=rival_population_column,
+    )
+    result = base.set_index(focal_column)
+    same_country = joined["_focal_country_code"].eq(joined["_rival_country_code"])
+
+    for lower, upper in TRAVEL_TIME_BANDS:
+        in_band = joined[travel_time_column].ge(lower) & joined[travel_time_column].lt(upper)
+        band_column = f"rival_mass_{lower}_{upper}h"
+        for suffix, border_mask in (
+            ("same_country", same_country),
+            ("cross_border", ~same_country),
+        ):
+            mass = (
+                joined.loc[in_band & border_mask]
+                .groupby(focal_column)[rival_population_column]
+                .sum()
+            )
+            result[f"{band_column}_{suffix}"] = mass.reindex(
+                result.index, fill_value=0.0
+            )
+    result["border_definition"] = "country_code_equality"
     return result.reset_index()

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from urban_growth.accessibility import mutually_exclusive_rival_mass
+from urban_growth.accessibility import border_conditioned_rival_mass, mutually_exclusive_rival_mass
 from urban_growth.io import SourceSchemaError
 
 
@@ -32,3 +32,109 @@ def test_accessibility_rejects_historical_vintage() -> None:
     )
     with pytest.raises(SourceSchemaError, match="modern validation"):
         mutually_exclusive_rival_mass(pairs, nominal_vintage=1990)
+
+
+def test_border_conditioned_mass_splits_each_band() -> None:
+    pairs = pd.DataFrame(
+        {
+            "focal_city_id": ["a"] * 5 + ["g", "g"],
+            "rival_city_id": ["b", "c", "d", "e", "f", "a", "c"],
+            "travel_time_hours": [0.5, 1.0, 1.99, 2.0, 7.99, 0.25, 4.0],
+            "rival_population": [10, 20, 30, 40, 50, 60, 70],
+        }
+    )
+    lookup = pd.DataFrame(
+        {
+            "city_id": ["a", "b", "c", "d", "e", "f", "g"],
+            "country_code": ["AA", "AA", "BB", "AA", "BB", "AA", "BB"],
+        }
+    )
+
+    result = border_conditioned_rival_mass(pairs, lookup, nominal_vintage=2015)
+    focal_a = result.loc[result["focal_city_id"] == "a"].iloc[0]
+
+    assert focal_a["rival_mass_0_1h_same_country"] == 10
+    assert focal_a["rival_mass_0_1h_cross_border"] == 0
+    assert focal_a["rival_mass_1_2h_same_country"] == 30
+    assert focal_a["rival_mass_1_2h_cross_border"] == 20
+    assert focal_a["rival_mass_2_4h_same_country"] == 0
+    assert focal_a["rival_mass_2_4h_cross_border"] == 40
+    assert focal_a["rival_mass_4_8h_same_country"] == 50
+    assert focal_a["rival_mass_4_8h_cross_border"] == 0
+    assert focal_a["border_definition"] == "country_code_equality"
+
+    for lower, upper in ((0, 1), (1, 2), (2, 4), (4, 8)):
+        total = f"rival_mass_{lower}_{upper}h"
+        pd.testing.assert_series_equal(
+            result[f"{total}_same_country"] + result[f"{total}_cross_border"],
+            result[total],
+            check_dtype=False,
+            check_names=False,
+        )
+
+
+@pytest.mark.parametrize("invalid_code", [None, "", " AA "])
+def test_border_conditioned_mass_rejects_invalid_country_codes(invalid_code: object) -> None:
+    pairs = pd.DataFrame(
+        {
+            "focal_city_id": ["a"],
+            "rival_city_id": ["b"],
+            "travel_time_hours": [1.0],
+            "rival_population": [10],
+        }
+    )
+    lookup = pd.DataFrame(
+        {"city_id": ["a", "b"], "country_code": ["AA", invalid_code]}
+    )
+
+    with pytest.raises(SourceSchemaError, match="country code"):
+        border_conditioned_rival_mass(pairs, lookup, nominal_vintage=2015)
+
+
+def test_border_conditioned_mass_rejects_duplicate_lookup_ids() -> None:
+    pairs = pd.DataFrame(
+        {
+            "focal_city_id": ["a"],
+            "rival_city_id": ["b"],
+            "travel_time_hours": [1.0],
+            "rival_population": [10],
+        }
+    )
+    lookup = pd.DataFrame(
+        {"city_id": ["a", "b", "b"], "country_code": ["AA", "AA", "BB"]}
+    )
+
+    with pytest.raises(SourceSchemaError, match="unique city IDs"):
+        border_conditioned_rival_mass(pairs, lookup, nominal_vintage=2015)
+
+
+def test_border_conditioned_mass_rejects_unmatched_cities() -> None:
+    pairs = pd.DataFrame(
+        {
+            "focal_city_id": ["a"],
+            "rival_city_id": ["b"],
+            "travel_time_hours": [1.0],
+            "rival_population": [10],
+        }
+    )
+    lookup = pd.DataFrame({"city_id": ["a"], "country_code": ["AA"]})
+
+    with pytest.raises(SourceSchemaError, match="Every focal and rival city"):
+        border_conditioned_rival_mass(pairs, lookup, nominal_vintage=2015)
+
+
+def test_border_conditioned_mass_reuses_vintage_validation() -> None:
+    pairs = pd.DataFrame(
+        {
+            "focal_city_id": ["a"],
+            "rival_city_id": ["b"],
+            "travel_time_hours": [1.0],
+            "rival_population": [10],
+        }
+    )
+    lookup = pd.DataFrame(
+        {"city_id": ["a", "b"], "country_code": ["AA", "BB"]}
+    )
+
+    with pytest.raises(SourceSchemaError, match="modern validation"):
+        border_conditioned_rival_mass(pairs, lookup, nominal_vintage=1990)


### PR DESCRIPTION
Closes #157.

## Summary

- add a companion `border_conditioned_rival_mass` constructor without changing the existing accessibility API
- join invented city-country assignments for focal and rival cities with explicit `many_to_one` cardinality enforcement
- fail closed on duplicate lookup IDs, missing/blank country codes, unmatched cities, join expansion, and unsupported historical vintages
- preserve every unsplit accessibility-band total and add same-country/cross-border components
- document that this is descriptive H5 infrastructure, not evidence of competition, agglomeration, or any empirical border effect
- record the infrastructure-only change in the Unreleased changelog; no result or expected manifest is changed

## Validation

- `uv run --locked --extra dev pytest -q` — 289 passed
- `uv run --locked --extra dev ruff check .` — passed
- `git diff --check` — passed

## Data and evidence scope

All test assignments are invented. This PR contains no Natural Earth data or geometry and does not activate #31 or register an empirical result.