### PR TITLE
Add matched-row national-envelope forecast ladder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add a synthetic matched-row forecast contract for the additive national-envelope
+  ladder; this is evaluation infrastructure, not a new empirical finding.
+
 - Add a synthetic border-conditioned rival-mass contract that preserves the existing
   accessibility-band totals; this is infrastructure for H5, not an empirical finding.
 

--- a/src/urban_growth/forecast.py
+++ b/src/urban_growth/forecast.py
@@ -754,6 +754,172 @@ def evaluate_rolling_hierarchy_models(
     return result.sort_values(["origin", "model"]).reset_index(drop=True)
 
 
+def evaluate_rolling_national_context_models(
+    panel: pd.DataFrame,
+    origins: list[int],
+    *,
+    outcome_column: str = "future_growth",
+) -> pd.DataFrame:
+    """Evaluate the locked additive national-context ladder on identical rows.
+
+    Inputs must come from the origin-available, leave-one-city-out national-context
+    constructor. This evaluator is predictive infrastructure; it does not identify a
+    causal effect of national population or settlement composition.
+    """
+    national_scale = [
+        "log_national_population_loo_at_origin",
+        "national_population_recent_growth_loo",
+    ]
+    settlement_composition = [
+        "national_city_share_loo_at_origin",
+        "national_town_share_loo_at_origin",
+    ]
+    specifications = {
+        "country_loo_plus_recent_growth": ["recent_growth"],
+        "national_scale_additive": ["recent_growth", *national_scale],
+        "national_settlement_additive": [
+            "recent_growth", *national_scale, *settlement_composition,
+        ],
+    }
+    required = {
+        "city_id",
+        "country_code",
+        "period_start",
+        "period_end",
+        outcome_column,
+        "national_context_loo_available",
+        "national_context_leave_one_city_out",
+        "national_context_uses_future_value",
+        *[feature for features in specifications.values() for feature in features],
+    }
+    require_columns(panel, required, source_name="national-context forecast panel")
+    reject_duplicate_keys(
+        panel,
+        ["city_id", "period_start", "period_end"],
+        source_name="national-context forecast panel",
+    )
+    contract_flags = panel[
+        [
+            "national_context_loo_available",
+            "national_context_leave_one_city_out",
+            "national_context_uses_future_value",
+        ]
+    ]
+    if contract_flags.isna().any().any():
+        raise SourceSchemaError("National-context contract flags cannot be missing")
+    if not all(pd.api.types.is_bool_dtype(contract_flags[column]) for column in contract_flags):
+        raise SourceSchemaError("National-context contract flags must be boolean")
+    if not panel["national_context_leave_one_city_out"].all():
+        raise SourceSchemaError("National-context models require leave-one-city-out features")
+    if panel["national_context_uses_future_value"].any():
+        raise SourceSchemaError("National-context models cannot use future national values")
+
+    joint_columns = list(
+        dict.fromkeys(
+            ["city_id", "country_code", "period_start", "period_end", outcome_column]
+            + [feature for features in specifications.values() for feature in features]
+        )
+    )
+    rows: list[dict[str, float | int | str | bool]] = []
+    for origin, train_index, test_index in rolling_origin_splits(panel, origins):
+        candidate_train = panel.loc[train_index]
+        candidate_test = panel.loc[test_index]
+        train = candidate_train.loc[
+            candidate_train["national_context_loo_available"]
+        ].dropna(subset=joint_columns)
+        test = candidate_test.loc[
+            candidate_test["national_context_loo_available"]
+        ].dropna(subset=joint_columns)
+        model_columns = list(
+            dict.fromkeys(
+                [outcome_column]
+                + [feature for features in specifications.values() for feature in features]
+            )
+        )
+        train_numeric = train[model_columns].apply(pd.to_numeric, errors="coerce")
+        test_numeric = test[model_columns].apply(pd.to_numeric, errors="coerce")
+        train_finite = train_numeric.notna().all(axis=1) & np.isfinite(train_numeric).all(axis=1)
+        test_finite = test_numeric.notna().all(axis=1) & np.isfinite(test_numeric).all(axis=1)
+        train = train.loc[train_finite].copy()
+        test = test.loc[test_finite].copy()
+        train.loc[:, model_columns] = train_numeric.loc[train_finite]
+        test.loc[:, model_columns] = test_numeric.loc[test_finite]
+        if train.empty or test.empty:
+            continue
+
+        baseline = baseline_predictions(train, test, outcome_column=outcome_column)
+        train_countries = set(train["country_code"])
+        unseen_test_countries = len(set(test["country_code"]) - train_countries)
+        for model, features in specifications.items():
+            fit_columns = ["country_code", outcome_column, *features]
+            fit = train[fit_columns]
+            country_means = fit.groupby("country_code")[[outcome_column, *features]].mean()
+            group_means = fit.groupby("country_code")[[outcome_column, *features]].transform(
+                "mean"
+            )
+            demeaned = fit[[outcome_column, *features]] - group_means
+            beta, *_ = np.linalg.lstsq(
+                demeaned[features].to_numpy(),
+                demeaned[outcome_column].to_numpy(),
+                rcond=None,
+            )
+            global_feature_means = fit[features].mean()
+            test_feature_means = pd.DataFrame(
+                {
+                    feature: test["country_code"]
+                    .map(country_means[feature])
+                    .fillna(global_feature_means[feature])
+                    for feature in features
+                },
+                index=test.index,
+            )
+            prediction = baseline["country_mean_leave_city_out"] + (
+                test[features] - test_feature_means
+            ).to_numpy() @ beta
+            metrics = score_forecast(
+                test[outcome_column], pd.Series(prediction, index=test.index)
+            )
+            if metrics.n != len(test):
+                raise SourceSchemaError(
+                    "National-context model lost rows after joint train/test matching"
+                )
+            rows.append(
+                {
+                    "origin": origin,
+                    "model": model,
+                    "features": "|".join(features),
+                    "n": metrics.n,
+                    "mae": metrics.mae,
+                    "rmse": metrics.rmse,
+                    "median_absolute_error": metrics.median_absolute_error,
+                    "bias": metrics.bias,
+                    "directional_accuracy": metrics.directional_accuracy,
+                    "candidate_train_n": len(candidate_train),
+                    "matched_train_n": len(train),
+                    "candidate_test_n": len(candidate_test),
+                    "matched_test_n": len(test),
+                    "train_coverage": len(train) / len(candidate_train),
+                    "test_coverage": len(test) / len(candidate_test),
+                    "unseen_test_countries": unseen_test_countries,
+                    "country_mean_fallback": "global_training_mean",
+                    "national_context_leave_one_city_out": True,
+                    "national_context_uses_future_value": False,
+                    "training_rows_identical_across_models": True,
+                    "test_rows_identical_across_models": True,
+                }
+            )
+    if not rows:
+        raise SourceSchemaError("No rolling national-context evaluations were produced")
+    result = pd.DataFrame(rows)
+    for count_column in ("matched_train_n", "matched_test_n", "n"):
+        counts = result.pivot(index="origin", columns="model", values=count_column)
+        if counts.nunique(axis=1).gt(1).any():
+            raise SourceSchemaError(
+                f"National-context models do not share identical {count_column} by origin"
+            )
+    return result.sort_values(["origin", "model"]).reset_index(drop=True)
+
+
 def rolling_baseline_errors(
     panel: pd.DataFrame,
     origins: list[int],

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -15,6 +15,7 @@ from urban_growth.forecast import (
     equal_origin_forecast_metrics,
     evaluate_rolling_baselines,
     evaluate_rolling_hierarchy_models,
+    evaluate_rolling_national_context_models,
     leave_one_cluster_out_paired_difference,
     locked_origin_model_evaluation,
     matched_boundary_forecast_panels,
@@ -413,6 +414,113 @@ def test_hierarchy_models_jointly_match_feature_missingness() -> None:
     assert result["candidate_test_n"].unique().tolist() == [3]
     assert result["matched_test_n"].unique().tolist() == [2]
     assert result["n"].unique().tolist() == [2]
+
+
+def national_context_forecast_panel() -> pd.DataFrame:
+    rows = []
+    for origin in [2000, 2005]:
+        for city_id, country_code in [(1, "A"), (2, "A"), (3, "B")]:
+            rows.append(
+                {
+                    "city_id": city_id,
+                    "country_code": country_code,
+                    "period_start": origin,
+                    "period_end": origin + 5,
+                    "future_growth": 0.002 * origin + 0.01 * city_id,
+                    "recent_growth": 0.005 * city_id,
+                    "log_national_population_loo_at_origin": 10 + 0.1 * city_id,
+                    "national_population_recent_growth_loo": 0.01 + 0.001 * city_id,
+                    "national_city_share_loo_at_origin": 0.4 + 0.01 * city_id,
+                    "national_town_share_loo_at_origin": 0.3 - 0.01 * city_id,
+                    "national_rural_share_loo_at_origin": 0.3,
+                    "national_context_loo_available": True,
+                    "national_context_leave_one_city_out": True,
+                    "national_context_uses_future_value": False,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def test_national_context_models_follow_locked_additive_ladder() -> None:
+    result = evaluate_rolling_national_context_models(
+        national_context_forecast_panel(), [2005]
+    )
+
+    assert set(result["model"]) == {
+        "country_loo_plus_recent_growth",
+        "national_scale_additive",
+        "national_settlement_additive",
+    }
+    assert result["n"].unique().tolist() == [3]
+    assert result["matched_train_n"].unique().tolist() == [3]
+    assert result["matched_test_n"].unique().tolist() == [3]
+    assert result["training_rows_identical_across_models"].all()
+    assert result["test_rows_identical_across_models"].all()
+    assert not result["features"].str.contains("rural").any()
+    settlement = result.loc[result["model"] == "national_settlement_additive", "features"].item()
+    assert "national_city_share_loo_at_origin" in settlement
+    assert "national_town_share_loo_at_origin" in settlement
+
+
+def test_national_context_models_report_common_sample_coverage() -> None:
+    panel = national_context_forecast_panel()
+    panel.loc[
+        panel["period_start"].eq(2000) & panel["city_id"].eq(3),
+        "national_context_loo_available",
+    ] = False
+    panel.loc[
+        panel["period_start"].eq(2005) & panel["city_id"].eq(2),
+        "national_town_share_loo_at_origin",
+    ] = np.nan
+
+    result = evaluate_rolling_national_context_models(panel, [2005])
+
+    assert result["candidate_train_n"].unique().tolist() == [3]
+    assert result["matched_train_n"].unique().tolist() == [2]
+    assert result["candidate_test_n"].unique().tolist() == [3]
+    assert result["matched_test_n"].unique().tolist() == [2]
+    assert result["n"].unique().tolist() == [2]
+    assert result["train_coverage"].unique().tolist() == pytest.approx([2 / 3])
+    assert result["test_coverage"].unique().tolist() == pytest.approx([2 / 3])
+
+
+@pytest.mark.parametrize(
+    ("column", "value", "message"),
+    [
+        ("national_context_uses_future_value", True, "future national values"),
+        ("national_context_leave_one_city_out", False, "leave-one-city-out"),
+    ],
+)
+def test_national_context_models_reject_invalid_semantics(
+    column: str, value: bool, message: str
+) -> None:
+    panel = national_context_forecast_panel()
+    panel.loc[0, column] = value
+
+    with pytest.raises(SourceSchemaError, match=message):
+        evaluate_rolling_national_context_models(panel, [2005])
+
+
+def test_national_context_models_reject_non_boolean_contract_flags() -> None:
+    panel = national_context_forecast_panel()
+    panel["national_context_uses_future_value"] = "False"
+
+    with pytest.raises(SourceSchemaError, match="must be boolean"):
+        evaluate_rolling_national_context_models(panel, [2005])
+
+
+def test_national_context_models_report_unseen_country_fallback() -> None:
+    panel = national_context_forecast_panel()
+    unseen = panel.loc[panel["period_start"].eq(2005)].iloc[[0]].copy()
+    unseen["city_id"] = 4
+    unseen["country_code"] = "C"
+    panel = pd.concat([panel, unseen], ignore_index=True)
+
+    result = evaluate_rolling_national_context_models(panel, [2005])
+
+    assert result["unseen_test_countries"].unique().tolist() == [1]
+    assert result["country_mean_fallback"].eq("global_training_mean").all()
+    assert result["n"].unique().tolist() == [4]
 
 
 def test_row_errors_support_paired_size_comparison() -> None:


### PR DESCRIPTION
Closes #159. Advances the remaining predictive-evaluation work in #29 without closing the empirical parent issue.

## Summary

- add a separate rolling-origin evaluator for the locked national-context ladder
- compare recent growth, national scale/growth, and city/town settlement composition on one joint train/test sample
- omit rural share as the compositional reference
- require origin-available, leave-one-city-out semantics and reject future-using or malformed contract flags
- report candidate/matched coverage and an explicit global fallback for unseen test countries
- keep interactions, tuning, empirical execution, results, and manifests out of scope
- label the change as synthetic evaluation infrastructure in the changelog

## Validation

- `uv run --locked --extra dev pytest -q` — 295 passed
- `uv run --locked --extra dev ruff check .` — passed
- `git diff --check` — passed

## Evidence scope

All new tests use invented data. This PR makes no claim that national-envelope features improve forecasts and does not update any registered result.