### PR TITLE
Add fail-closed reliability provenance contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Add fail-closed population-reliability snapshot and transformation provenance contracts,
+  including deterministic lineage IDs, existing catalog/license foreign keys, exact UTC
+  capture times, revision coexistence, and evidence-to-input validation. No empirical
+  reliability evidence or country score is added.
+
 - Add a synthetic matched-row forecast contract for the additive national-envelope
   ladder; this is evaluation infrastructure, not a new empirical finding.
 

--- a/data/README.md
+++ b/data/README.md
@@ -41,3 +41,29 @@ notes
 The manifest records acquired files. It does not grant permission. Source-level legal
 decisions and attribution requirements are maintained separately in
 `data/licenses.json`; see [THIRD_PARTY_DATA.md](../THIRD_PARTY_DATA.md).
+
+## Population-reliability provenance
+
+`reliability_snapshots.csv` and `reliability_transformations.csv` extend the existing
+source, license, and file-manifest registries for the population-data reliability matrix.
+They are deliberately header-only until an open input is actually captured and a
+transformation is executed.
+
+- A snapshot identifies exact captured bytes using `source_id` plus SHA-256 and carries an
+  ISO-8601 UTC retrieval timestamp and an explicit observation period. It does not replace
+  `manifest.csv` or licensing review.
+- A transformation identifies its full Git commit, canonical parameters, exact input
+  snapshots, output hash, and UTC execution interval.
+- An evidence row fails validation unless its declared snapshot is an input to its declared
+  transformation.
+
+Legacy `manifest.csv` rows contain only retrieval dates. They may be promoted into the new
+snapshot registry only when the missing capture timestamp, observation period, and media
+metadata can be supplied from evidence; the implementation does not invent midnight
+timestamps.
+
+Validate the committed registries with:
+
+```bash
+uv run --locked --extra dev urban-growth-sources verify-reliability-provenance
+```

--- a/data/reliability_snapshots.csv
+++ b/data/reliability_snapshots.csv
@@ -1,0 +1,1 @@
+snapshot_id,source_id,source_url,retrieval_method,retrieved_at,source_release,source_observation_start,source_observation_end,local_path,sha256,media_type,license_id,redistribution_status,capture_notes

--- a/data/reliability_transformations.csv
+++ b/data/reliability_transformations.csv
@@ -1,0 +1,1 @@
+transformation_run_id,code_commit,entry_point,parameters_json,input_snapshot_ids,started_at,completed_at,output_path,output_sha256

--- a/docs/reliability-matrix-design.md
+++ b/docs/reliability-matrix-design.md
@@ -133,6 +133,15 @@ structured assertion record. A bare analyst claim is not a source artifact.
 
 An output row without a registered snapshot and transformation run fails closed.
 
+The executable contract is in `src/urban_growth/reliability_provenance.py`. The committed
+registries are `data/reliability_snapshots.csv` and
+`data/reliability_transformations.csv`. They extend `data/manifest.csv`; they do not rewrite
+its date-only historical retrieval records as fabricated timestamps. Existing manifest rows
+can be promoted only when the missing capture metadata is supplied explicitly.
+An upstream release is registered under its exact release-specific source identity; a new
+release or a changed capture receives a new checksum-derived snapshot identity and does not
+overwrite prior evidence.
+
 Implementation: [#167](https://github.com/danielastone/Global-Urban-Growth-Lab/issues/167).
 
 ## Missingness and assessment-state contract

--- a/src/urban_growth/reliability_provenance.py
+++ b/src/urban_growth/reliability_provenance.py
@@ -1,0 +1,367 @@
+"""Fail-closed provenance contracts for population-reliability evidence."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import urlparse
+
+from urban_growth.sources import SourceCatalogError, license_by_source_id, source_by_id
+
+SNAPSHOT_FIELDS = [
+    "snapshot_id",
+    "source_id",
+    "source_url",
+    "retrieval_method",
+    "retrieved_at",
+    "source_release",
+    "source_observation_start",
+    "source_observation_end",
+    "local_path",
+    "sha256",
+    "media_type",
+    "license_id",
+    "redistribution_status",
+    "capture_notes",
+]
+
+TRANSFORMATION_FIELDS = [
+    "transformation_run_id",
+    "code_commit",
+    "entry_point",
+    "parameters_json",
+    "input_snapshot_ids",
+    "started_at",
+    "completed_at",
+    "output_path",
+    "output_sha256",
+]
+
+RETRIEVAL_METHODS = {"file_download", "api_capture", "manual_evidence"}
+SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
+YEAR_PATTERN = re.compile(r"[0-9]{4}")
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _validate_sha256(value: str, *, field: str) -> None:
+    if not SHA256_PATTERN.fullmatch(value):
+        raise SourceCatalogError(f"{field} must be a lowercase 64-character SHA-256")
+
+
+def _validate_https(value: str, *, field: str) -> None:
+    parsed = urlparse(value)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise SourceCatalogError(f"{field} must be an HTTPS URL")
+
+
+def _validate_utc_timestamp(value: str, *, field: str) -> datetime:
+    if not value.endswith("Z"):
+        raise SourceCatalogError(f"{field} must be an ISO-8601 UTC timestamp ending in Z")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise SourceCatalogError(f"{field} is not a valid ISO-8601 timestamp") from error
+    if parsed.tzinfo != UTC:
+        raise SourceCatalogError(f"{field} must be UTC")
+    return parsed
+
+
+def _validate_relative_path(value: str, *, field: str) -> None:
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts or value.strip() != value or not value:
+        raise SourceCatalogError(f"{field} must be a normalized relative project path")
+
+
+def _observation_bound(value: str, *, field: str, end: bool) -> tuple[int, int, int]:
+    if YEAR_PATTERN.fullmatch(value):
+        return (int(value), 12, 31) if end else (int(value), 1, 1)
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as error:
+        raise SourceCatalogError(f"{field} must be a year or ISO-8601 date") from error
+    return parsed.year, parsed.month, parsed.day
+
+
+def snapshot_id_for(source_id: str, sha256: str) -> str:
+    """Return the immutable snapshot identity for captured bytes."""
+    if not source_id or source_id.strip() != source_id:
+        raise SourceCatalogError("source_id must be a non-empty normalized string")
+    _validate_sha256(sha256, field="sha256")
+    return f"{source_id}:{sha256}"
+
+
+def transformation_run_id_for(
+    *,
+    code_commit: str,
+    entry_point: str,
+    parameters: Mapping[str, Any],
+    input_snapshot_ids: Iterable[str],
+    output_sha256: str,
+) -> str:
+    """Hash the immutable transformation recipe and output identity."""
+    inputs = tuple(sorted(input_snapshot_ids))
+    payload = {
+        "code_commit": code_commit,
+        "entry_point": entry_point,
+        "parameters": dict(parameters),
+        "input_snapshot_ids": inputs,
+        "output_sha256": output_sha256,
+    }
+    digest = hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+    return f"transform:{digest}"
+
+
+@dataclass(frozen=True)
+class DatasetSnapshot:
+    snapshot_id: str
+    source_id: str
+    source_url: str
+    retrieval_method: str
+    retrieved_at: str
+    source_release: str
+    source_observation_start: str
+    source_observation_end: str
+    local_path: str
+    sha256: str
+    media_type: str
+    license_id: str
+    redistribution_status: str
+    capture_notes: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {field: str(getattr(self, field)) for field in SNAPSHOT_FIELDS}
+
+
+@dataclass(frozen=True)
+class TransformationRun:
+    transformation_run_id: str
+    code_commit: str
+    entry_point: str
+    parameters_json: str
+    input_snapshot_ids: str
+    started_at: str
+    completed_at: str
+    output_path: str
+    output_sha256: str
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        code_commit: str,
+        entry_point: str,
+        parameters: Mapping[str, Any],
+        input_snapshot_ids: Iterable[str],
+        started_at: str,
+        completed_at: str,
+        output_path: str,
+        output_sha256: str,
+    ) -> TransformationRun:
+        inputs = tuple(sorted(input_snapshot_ids))
+        return cls(
+            transformation_run_id=transformation_run_id_for(
+                code_commit=code_commit,
+                entry_point=entry_point,
+                parameters=parameters,
+                input_snapshot_ids=inputs,
+                output_sha256=output_sha256,
+            ),
+            code_commit=code_commit,
+            entry_point=entry_point,
+            parameters_json=_canonical_json(dict(parameters)),
+            input_snapshot_ids=_canonical_json(inputs),
+            started_at=started_at,
+            completed_at=completed_at,
+            output_path=output_path,
+            output_sha256=output_sha256,
+        )
+
+    def as_dict(self) -> dict[str, str]:
+        return {field: str(getattr(self, field)) for field in TRANSFORMATION_FIELDS}
+
+
+def snapshot_from_manifest_record(
+    record: Mapping[str, str],
+    *,
+    catalog: dict,
+    licenses: dict,
+    retrieval_method: str,
+    retrieved_at: str,
+    media_type: str,
+    source_observation_start: str = "",
+    source_observation_end: str = "",
+    capture_notes: str = "",
+) -> DatasetSnapshot:
+    """Promote a legacy file-manifest row without inventing missing capture metadata."""
+    required = {
+        "source_id",
+        "release",
+        "source_url",
+        "local_path",
+        "sha256",
+        "redistribution_allowed",
+    }
+    missing = sorted(required.difference(record))
+    if missing:
+        raise SourceCatalogError(f"Manifest record missing fields: {', '.join(missing)}")
+    source = source_by_id(catalog, record["source_id"])
+    license_record = license_by_source_id(licenses, record["source_id"])
+    if record["release"] != source["release"]:
+        raise SourceCatalogError("Manifest release does not match the registered source release")
+    return DatasetSnapshot(
+        snapshot_id=snapshot_id_for(record["source_id"], record["sha256"]),
+        source_id=record["source_id"],
+        source_url=record["source_url"],
+        retrieval_method=retrieval_method,
+        retrieved_at=retrieved_at,
+        source_release=record["release"],
+        source_observation_start=source_observation_start,
+        source_observation_end=source_observation_end,
+        local_path=record["local_path"],
+        sha256=record["sha256"],
+        media_type=media_type,
+        license_id=license_record["license_id"],
+        redistribution_status=record["redistribution_allowed"],
+        capture_notes=capture_notes,
+    )
+
+
+def validate_dataset_snapshots(
+    snapshots: Iterable[DatasetSnapshot], *, catalog: dict, licenses: dict
+) -> None:
+    """Validate immutable snapshots against the existing source and rights registries."""
+    rows = list(snapshots)
+    ids = [row.snapshot_id for row in rows]
+    if len(ids) != len(set(ids)):
+        raise SourceCatalogError("Duplicate snapshot_id values")
+    for row in rows:
+        source = source_by_id(catalog, row.source_id)
+        license_record = license_by_source_id(licenses, row.source_id)
+        if row.snapshot_id != snapshot_id_for(row.source_id, row.sha256):
+            raise SourceCatalogError("snapshot_id does not match source_id and captured bytes")
+        if row.source_release != source["release"]:
+            raise SourceCatalogError(f"{row.snapshot_id} release is not registered in sources.json")
+        if row.license_id != license_record["license_id"]:
+            raise SourceCatalogError(f"{row.snapshot_id} license_id does not match licenses.json")
+        _validate_https(row.source_url, field="source_url")
+        if row.retrieval_method not in RETRIEVAL_METHODS:
+            raise SourceCatalogError(f"{row.snapshot_id} has invalid retrieval_method")
+        _validate_utc_timestamp(row.retrieved_at, field="retrieved_at")
+        observation_start = _observation_bound(
+            row.source_observation_start, field="source_observation_start", end=False
+        )
+        observation_end = _observation_bound(
+            row.source_observation_end, field="source_observation_end", end=True
+        )
+        if observation_end < observation_start:
+            raise SourceCatalogError("source_observation_end cannot precede start")
+        _validate_relative_path(row.local_path, field="local_path")
+        if not row.media_type or "/" not in row.media_type:
+            raise SourceCatalogError(f"{row.snapshot_id} has invalid media_type")
+        if not row.redistribution_status:
+            raise SourceCatalogError(f"{row.snapshot_id} lacks redistribution_status")
+        if row.retrieval_method == "manual_evidence" and not row.capture_notes.strip():
+            raise SourceCatalogError("manual_evidence snapshots require capture_notes")
+
+
+def validate_transformation_runs(
+    runs: Iterable[TransformationRun], *, snapshots: Iterable[DatasetSnapshot]
+) -> None:
+    """Validate deterministic transformations and their snapshot foreign keys."""
+    rows = list(runs)
+    snapshot_ids = {row.snapshot_id for row in snapshots}
+    run_ids = [row.transformation_run_id for row in rows]
+    if len(run_ids) != len(set(run_ids)):
+        raise SourceCatalogError("Duplicate transformation_run_id values")
+    for row in rows:
+        if not COMMIT_PATTERN.fullmatch(row.code_commit):
+            raise SourceCatalogError("code_commit must be a full lowercase Git SHA")
+        if not row.entry_point.strip():
+            raise SourceCatalogError("entry_point must be non-empty")
+        try:
+            parameters = json.loads(row.parameters_json)
+            input_ids = json.loads(row.input_snapshot_ids)
+        except json.JSONDecodeError as error:
+            raise SourceCatalogError("Transformation JSON fields must be valid JSON") from error
+        if not isinstance(parameters, dict) or row.parameters_json != _canonical_json(parameters):
+            raise SourceCatalogError("parameters_json must be a canonical JSON object")
+        if (
+            not isinstance(input_ids, list)
+            or not input_ids
+            or input_ids != sorted(set(input_ids))
+            or row.input_snapshot_ids != _canonical_json(input_ids)
+        ):
+            raise SourceCatalogError("input_snapshot_ids must be canonical, unique, and sorted")
+        unknown = sorted(set(input_ids).difference(snapshot_ids))
+        if unknown:
+            raise SourceCatalogError(f"Unknown input snapshot IDs: {', '.join(unknown)}")
+        started = _validate_utc_timestamp(row.started_at, field="started_at")
+        completed = _validate_utc_timestamp(row.completed_at, field="completed_at")
+        if completed < started:
+            raise SourceCatalogError("completed_at cannot precede started_at")
+        _validate_relative_path(row.output_path, field="output_path")
+        _validate_sha256(row.output_sha256, field="output_sha256")
+        expected = transformation_run_id_for(
+            code_commit=row.code_commit,
+            entry_point=row.entry_point,
+            parameters=parameters,
+            input_snapshot_ids=input_ids,
+            output_sha256=row.output_sha256,
+        )
+        if row.transformation_run_id != expected:
+            raise SourceCatalogError("transformation_run_id does not match immutable lineage")
+
+
+def validate_evidence_lineage(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    snapshots: Iterable[DatasetSnapshot],
+    runs: Iterable[TransformationRun],
+) -> None:
+    """Reject evidence rows that cannot reach a captured input and transformation."""
+    snapshot_by_id = {row.snapshot_id: row for row in snapshots}
+    run_by_id = {row.transformation_run_id: row for row in runs}
+    for index, record in enumerate(records):
+        snapshot_id = record.get("snapshot_id")
+        run_id = record.get("transformation_run_id")
+        if not snapshot_id or snapshot_id not in snapshot_by_id:
+            raise SourceCatalogError(f"Evidence row {index} has no registered snapshot")
+        if not run_id or run_id not in run_by_id:
+            raise SourceCatalogError(f"Evidence row {index} has no registered transformation")
+        input_ids = set(json.loads(run_by_id[run_id].input_snapshot_ids))
+        if snapshot_id not in input_ids:
+            raise SourceCatalogError(
+                f"Evidence row {index} snapshot is not an input to its transformation"
+            )
+        snapshot = snapshot_by_id[snapshot_id]
+        if record.get("source_id", snapshot.source_id) != snapshot.source_id:
+            raise SourceCatalogError(f"Evidence row {index} source_id conflicts with snapshot")
+        if record.get("source_release", snapshot.source_release) != snapshot.source_release:
+            raise SourceCatalogError(f"Evidence row {index} release conflicts with snapshot")
+
+
+def _load_csv_records(path: str | Path, fields: list[str]) -> list[dict[str, str]]:
+    with Path(path).open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames != fields:
+            raise SourceCatalogError(f"{Path(path).name} header does not match required schema")
+        return list(reader)
+
+
+def load_dataset_snapshots(path: str | Path) -> list[DatasetSnapshot]:
+    return [DatasetSnapshot(**row) for row in _load_csv_records(path, SNAPSHOT_FIELDS)]
+
+
+def load_transformation_runs(path: str | Path) -> list[TransformationRun]:
+    return [TransformationRun(**row) for row in _load_csv_records(path, TRANSFORMATION_FIELDS)]

--- a/src/urban_growth/sources.py
+++ b/src/urban_growth/sources.py
@@ -292,6 +292,11 @@ def main() -> None:
     subparsers.add_parser("list")
     subparsers.add_parser("verify-catalog")
     subparsers.add_parser("verify-licenses")
+    provenance = subparsers.add_parser("verify-reliability-provenance")
+    provenance.add_argument("--snapshots", default="data/reliability_snapshots.csv")
+    provenance.add_argument(
+        "--transformations", default="data/reliability_transformations.csv"
+    )
     license_check = subparsers.add_parser("check-license")
     license_check.add_argument("--source-id", required=True)
     license_check.add_argument("--use", required=True, choices=sorted(LICENSE_USE_FIELDS))
@@ -311,6 +316,23 @@ def main() -> None:
     elif args.command == "verify-licenses":
         registry = load_licenses(license_path, catalog=catalog)
         print(f"valid: {len(registry['sources'])} license decisions; default=deny")
+    elif args.command == "verify-reliability-provenance":
+        from urban_growth.reliability_provenance import (
+            load_dataset_snapshots,
+            load_transformation_runs,
+            validate_dataset_snapshots,
+            validate_transformation_runs,
+        )
+
+        registry = load_licenses(license_path, catalog=catalog)
+        snapshots = load_dataset_snapshots(args.snapshots)
+        transformations = load_transformation_runs(args.transformations)
+        validate_dataset_snapshots(snapshots, catalog=catalog, licenses=registry)
+        validate_transformation_runs(transformations, snapshots=snapshots)
+        print(
+            f"valid: {len(snapshots)} reliability snapshots; "
+            f"{len(transformations)} transformation runs"
+        )
     elif args.command == "check-license":
         registry = load_licenses(license_path, catalog=catalog)
         try:

--- a/tests/test_reliability_provenance.py
+++ b/tests/test_reliability_provenance.py
@@ -1,0 +1,232 @@
+import csv
+from dataclasses import replace
+
+import pytest
+
+from urban_growth.reliability_provenance import (
+    DatasetSnapshot,
+    TransformationRun,
+    load_dataset_snapshots,
+    load_transformation_runs,
+    snapshot_from_manifest_record,
+    snapshot_id_for,
+    validate_dataset_snapshots,
+    validate_evidence_lineage,
+    validate_transformation_runs,
+)
+from urban_growth.sources import SourceCatalogError, load_catalog, load_licenses
+
+HASH_A = "a" * 64
+HASH_B = "b" * 64
+COMMIT = "c" * 40
+
+
+def _snapshot(*, sha256: str = HASH_A) -> DatasetSnapshot:
+    return DatasetSnapshot(
+        snapshot_id=snapshot_id_for("un_wpp_2024", sha256),
+        source_id="un_wpp_2024",
+        source_url="https://population.un.org/wpp/example.csv",
+        retrieval_method="file_download",
+        retrieved_at="2026-09-02T20:15:00Z",
+        source_release="2024 Revision",
+        source_observation_start="1950",
+        source_observation_end="2023",
+        local_path=f"data/raw/{sha256[:8]}.csv",
+        sha256=sha256,
+        media_type="text/csv",
+        license_id="unresolved_exact_release",
+        redistribution_status="not_committed",
+        capture_notes="Synthetic test metadata; no source bytes included.",
+    )
+
+
+def _run(snapshot: DatasetSnapshot) -> TransformationRun:
+    return TransformationRun.build(
+        code_commit=COMMIT,
+        entry_point="scripts/build_reliability.py",
+        parameters={"dimension": "census", "strict": True},
+        input_snapshot_ids=[snapshot.snapshot_id],
+        started_at="2026-09-02T20:20:00Z",
+        completed_at="2026-09-02T20:21:00Z",
+        output_path="data/processed/reliability.csv",
+        output_sha256=HASH_B,
+    )
+
+
+def _registries() -> tuple[dict, dict]:
+    catalog = load_catalog("data/sources.json")
+    return catalog, load_licenses("data/licenses.json", catalog=catalog)
+
+
+def test_repository_provenance_registries_have_locked_headers() -> None:
+    catalog, licenses = _registries()
+    snapshots = load_dataset_snapshots("data/reliability_snapshots.csv")
+    runs = load_transformation_runs("data/reliability_transformations.csv")
+    assert snapshots == []
+    assert runs == []
+    validate_dataset_snapshots(snapshots, catalog=catalog, licenses=licenses)
+    validate_transformation_runs(runs, snapshots=snapshots)
+
+
+def test_legacy_manifest_promotion_requires_explicit_capture_metadata() -> None:
+    catalog, licenses = _registries()
+    with open("data/manifest.csv", newline="", encoding="utf-8") as handle:
+        record = next(csv.DictReader(handle))
+    snapshot = snapshot_from_manifest_record(
+        record,
+        catalog=catalog,
+        licenses=licenses,
+        retrieval_method="file_download",
+        retrieved_at="2026-08-27T14:30:00Z",
+        media_type="application/zip",
+        source_observation_start="1950",
+        source_observation_end="2018",
+        capture_notes="UTC timestamp recovered from acquisition log.",
+    )
+    assert snapshot.snapshot_id == f"{record['source_id']}:{record['sha256']}"
+    assert snapshot.license_id == "CC-BY-3.0-IGO"
+    validate_dataset_snapshots([snapshot], catalog=catalog, licenses=licenses)
+
+
+def test_date_only_retrieval_does_not_fake_timestamp_precision() -> None:
+    catalog, licenses = _registries()
+    with pytest.raises(SourceCatalogError, match="UTC timestamp"):
+        validate_dataset_snapshots(
+            [replace(_snapshot(), retrieved_at="2026-09-02")],
+            catalog=catalog,
+            licenses=licenses,
+        )
+
+
+def test_snapshot_requires_observation_period_and_manual_evidence_notes() -> None:
+    catalog, licenses = _registries()
+    with pytest.raises(SourceCatalogError, match="source_observation_start"):
+        validate_dataset_snapshots(
+            [replace(_snapshot(), source_observation_start="")],
+            catalog=catalog,
+            licenses=licenses,
+        )
+    with pytest.raises(SourceCatalogError, match="cannot precede"):
+        validate_dataset_snapshots(
+            [
+                replace(
+                    _snapshot(),
+                    source_observation_start="2024",
+                    source_observation_end="2023",
+                )
+            ],
+            catalog=catalog,
+            licenses=licenses,
+        )
+    with pytest.raises(SourceCatalogError, match="require capture_notes"):
+        validate_dataset_snapshots(
+            [replace(_snapshot(), retrieval_method="manual_evidence", capture_notes="")],
+            catalog=catalog,
+            licenses=licenses,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("snapshot_id", "invented", "captured bytes"),
+        ("source_url", "http://example.com/data.csv", "HTTPS"),
+        ("retrieval_method", "live_api", "retrieval_method"),
+        ("local_path", "../outside.csv", "relative project path"),
+        ("license_id", "invented-license", "licenses.json"),
+        ("source_release", "2026 Revision", "sources.json"),
+    ],
+)
+def test_snapshot_validation_fails_closed(field: str, value: str, message: str) -> None:
+    catalog, licenses = _registries()
+    with pytest.raises(SourceCatalogError, match=message):
+        validate_dataset_snapshots(
+            [replace(_snapshot(), **{field: value})],
+            catalog=catalog,
+            licenses=licenses,
+        )
+
+
+def test_revised_captures_coexist_without_overwriting_prior_bytes() -> None:
+    catalog, licenses = _registries()
+    snapshots = [_snapshot(sha256=HASH_A), _snapshot(sha256=HASH_B)]
+    validate_dataset_snapshots(snapshots, catalog=catalog, licenses=licenses)
+    assert len({row.snapshot_id for row in snapshots}) == 2
+    with pytest.raises(SourceCatalogError, match="Duplicate snapshot_id"):
+        validate_dataset_snapshots(
+            [snapshots[0], snapshots[0]], catalog=catalog, licenses=licenses
+        )
+
+
+def test_transformation_identity_is_deterministic_and_validated() -> None:
+    snapshot = _snapshot()
+    first = _run(snapshot)
+    second = _run(snapshot)
+    assert first.transformation_run_id == second.transformation_run_id
+    assert first.parameters_json == '{"dimension":"census","strict":true}'
+    validate_transformation_runs([first], snapshots=[snapshot])
+
+
+def test_transformation_rejects_unknown_input_and_noncanonical_parameters() -> None:
+    snapshot = _snapshot()
+    run = _run(snapshot)
+    with pytest.raises(SourceCatalogError, match="Unknown input snapshot"):
+        validate_transformation_runs(
+            [replace(run, input_snapshot_ids='["missing"]')], snapshots=[snapshot]
+        )
+    with pytest.raises(SourceCatalogError, match="canonical JSON object"):
+        validate_transformation_runs(
+            [replace(run, parameters_json='{"strict": true, "dimension": "census"}')],
+            snapshots=[snapshot],
+        )
+
+
+def test_transformation_rejects_bad_commit_and_reverse_chronology() -> None:
+    snapshot = _snapshot()
+    run = _run(snapshot)
+    with pytest.raises(SourceCatalogError, match="full lowercase Git SHA"):
+        validate_transformation_runs([replace(run, code_commit="abc")], snapshots=[snapshot])
+    with pytest.raises(SourceCatalogError, match="cannot precede"):
+        validate_transformation_runs(
+            [replace(run, completed_at="2026-09-02T20:19:00Z")], snapshots=[snapshot]
+        )
+
+
+def test_evidence_rows_require_connected_snapshot_and_transformation() -> None:
+    snapshot = _snapshot()
+    run = _run(snapshot)
+    evidence = {
+        "country_id": "USA",
+        "source_id": snapshot.source_id,
+        "source_release": snapshot.source_release,
+        "snapshot_id": snapshot.snapshot_id,
+        "transformation_run_id": run.transformation_run_id,
+    }
+    validate_evidence_lineage([evidence], snapshots=[snapshot], runs=[run])
+    with pytest.raises(SourceCatalogError, match="no registered snapshot"):
+        validate_evidence_lineage(
+            [{**evidence, "snapshot_id": "missing"}], snapshots=[snapshot], runs=[run]
+        )
+    with pytest.raises(SourceCatalogError, match="no registered transformation"):
+        validate_evidence_lineage(
+            [{**evidence, "transformation_run_id": "missing"}],
+            snapshots=[snapshot],
+            runs=[run],
+        )
+
+
+def test_evidence_snapshot_must_be_an_input_to_declared_transformation() -> None:
+    snapshot = _snapshot(sha256=HASH_A)
+    other = _snapshot(sha256=HASH_B)
+    run = _run(other)
+    with pytest.raises(SourceCatalogError, match="not an input"):
+        validate_evidence_lineage(
+            [
+                {
+                    "snapshot_id": snapshot.snapshot_id,
+                    "transformation_run_id": run.transformation_run_id,
+                }
+            ],
+            snapshots=[snapshot, other],
+            runs=[run],
+        )


### PR DESCRIPTION
Closes #167. Advances #162 and unblocks #169.

## Summary

- add immutable dataset-snapshot and deterministic transformation-run schemas
- bind snapshot records to the existing source catalog, license registry, exact release, captured bytes, UTC retrieval time, observation period, media type, and redistribution status
- distinguish file downloads, captured API responses, and documented manual evidence
- require canonical parameters, full Git SHAs, exact input snapshot IDs, output hashes, and chronological UTC run timestamps
- fail evidence rows unless the declared snapshot is an input to the declared transformation
- preserve revised captures under checksum-derived identities instead of overwriting prior evidence
- add header-only registries and a CLI verification command
- require explicit metadata when promoting legacy date-only manifest rows; do not invent midnight timestamps

## Validation

- `uv run --locked --extra dev pytest -q` — 311 passed
- `uv run --locked --extra dev ruff check .` — passed
- `uv run --locked --extra dev urban-growth-sources verify-reliability-provenance` — valid, 0 snapshots and 0 transformation runs
- `git diff --check` — passed

## Evidence scope

This is provenance infrastructure only. The committed registries contain headers and no empirical reliability evidence. The PR does not score countries, reproduce PDQR, or create tiers.