### PR TITLE
Replace city reliability classifier with evidence intake

### DIFF
--- a/.github/workflows/city-reliability-evidence-intake.yml
+++ b/.github/workflows/city-reliability-evidence-intake.yml
@@ -1,0 +1,66 @@
+name: City-level reliability evidence intake
+
+on:
+  workflow_dispatch:
+    inputs:
+      location_id:
+        description: "Stable project identifier; never a place name used as a join key"
+        required: true
+        type: string
+      location_label:
+        description: "Human-readable place or statistic label"
+        required: true
+        type: string
+      reference_date:
+        description: "Evidence-availability date (YYYY-MM-DD)"
+        required: true
+        type: string
+      use_case_id:
+        description: "Declared downstream use; this intake does not decide fitness"
+        required: true
+        type: choice
+        default: descriptive_city_evidence_v1
+        options:
+          - descriptive_city_evidence_v1
+          - city_growth_estimation
+          - locality_forecasting
+          - historical_city_panel
+      evidence_json:
+        description: >-
+          JSON object with verification, incentive, aggregate_check, conduit, and
+          granular_treatment assertions; see docs/city-reliability-evidence-intake.md
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  validate-and-stage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Validate and stage documentary evidence
+        env:
+          LOCATION_ID: ${{ inputs.location_id }}
+          LOCATION_LABEL: ${{ inputs.location_label }}
+          REFERENCE_DATE: ${{ inputs.reference_date }}
+          USE_CASE_ID: ${{ inputs.use_case_id }}
+          EVIDENCE_JSON: ${{ inputs.evidence_json }}
+          SUBMITTED_BY: ${{ github.actor }}
+        run: PYTHONPATH=src python3 scripts/capture_city_reliability_evidence.py
+
+      - name: Upload staged evidence for review
+        uses: actions/upload-artifact@v4
+        with:
+          name: city-reliability-evidence-${{ github.run_id }}
+          path: city-reliability-intake.json
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/city-reliability-evidence-intake.md
+++ b/docs/city-reliability-evidence-intake.md
@@ -1,0 +1,48 @@
+# City-level reliability evidence intake
+
+This manual workflow captures **staged documentary assertions**. It is not a classifier.
+It never emits a score, tier, band, archetype, or city-fitness decision. The five signals
+are retained separately and do not override the City Data Fitness Standard or the
+country-level reliability matrix.
+
+Each non-unknown assertion requires `value`, `source_id`, `snapshot_id`,
+`source_release`, `observation_date`, and `citation`. The workflow validates structure but
+does not pretend that a typed snapshot identifier is registered. Its JSON artifact is
+therefore marked `analytical_use_authorized: false`. Promotion requires snapshot-registry
+verification, a registered transformation, and a separate use-specific fitness decision.
+
+Unknown evidence uses `value: "unknown"` and a substantive `notes` explanation. It must
+not contain placeholder provenance. In particular, `no_issue_documented` and
+`no_documented_incentive` mean that a cited source makes that bounded documentary claim;
+they are not synonyms for missing evidence and receive no favorable numerical treatment.
+
+## Payload shape
+
+```json
+{
+  "verification": {
+    "value": "place_direct",
+    "source_id": "registered_source_id",
+    "snapshot_id": "candidate_snapshot_id",
+    "source_release": "named release",
+    "observation_date": "2025-01-01",
+    "citation": "page, table, or record locator"
+  },
+  "incentive": {"value": "unknown", "notes": "No reviewed evidence yet."},
+  "aggregate_check": {"value": "unknown", "notes": "No reviewed evidence yet."},
+  "conduit": {"value": "unknown", "notes": "No reviewed evidence yet."},
+  "granular_treatment": {"value": "unknown", "notes": "No reviewed evidence yet."}
+}
+```
+
+Allowed values:
+
+| Signal | Values |
+|---|---|
+| `verification` | `none_documented`, `country_level_only`, `place_direct`, `unknown` |
+| `incentive` | `aligned_distortion_risk`, `heterogeneous_incentives`, `no_documented_incentive`, `unknown` |
+| `aggregate_check` | `none_documented`, `partial`, `strong`, `unknown` |
+| `conduit` | `obscured`, `ordinary`, `heightened_scrutiny`, `unknown` |
+| `granular_treatment` | `suspected_undisclosed`, `disclosed_bounded`, `no_issue_documented`, `unknown` |
+
+The word `strong` is source-specific documentary text, not a universal reliability rank.

--- a/docs/reliability-matrix-design.md
+++ b/docs/reliability-matrix-design.md
@@ -65,6 +65,13 @@ The reliability matrix concerns evidence about national population systems and t
 suitability of that evidence for specified uses. It does not overwrite city-level
 geographic, temporal, or outcome fitness decisions.
 
+The manual city-level intake documented in
+`docs/city-reliability-evidence-intake.md` is a staging mechanism only. Its documentary
+signals are not matrix dimensions, and an intake artifact is not analytically eligible
+until its snapshots and transformation are registered and the relevant use-specific City
+Data Fitness Standard gate is applied. The intake cannot emit or imply a score, tier,
+band, archetype, or cross-signal classification.
+
 ## Unit and identifier rules
 
 The default country identifier is a project-controlled `country_id`. Source identifiers

--- a/scripts/capture_city_reliability_evidence.py
+++ b/scripts/capture_city_reliability_evidence.py
@@ -40,7 +40,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-EXE002 The file is executable but no shebang is present
---> scripts/capture_city_reliability_evidence.py:1:1
-
-Found 1 error.

--- a/scripts/capture_city_reliability_evidence.py
+++ b/scripts/capture_city_reliability_evidence.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Create a staged city-reliability evidence artifact from workflow inputs."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from urban_growth.city_reliability_intake import canonical_json, validate_intake
+
+
+def main() -> None:
+    payload = json.loads(os.environ["EVIDENCE_JSON"])
+    record = validate_intake(
+        payload,
+        location_id=os.environ["LOCATION_ID"],
+        location_label=os.environ["LOCATION_LABEL"],
+        reference_date=os.environ["REFERENCE_DATE"],
+        use_case_id=os.environ["USE_CASE_ID"],
+        submitted_by=os.environ["SUBMITTED_BY"],
+    )
+    output_path = Path(os.environ.get("OUTPUT_PATH", "city-reliability-intake.json"))
+    output_path.write_text(canonical_json(record), encoding="utf-8")
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        lines = [
+            "## City-level reliability evidence intake",
+            "",
+            f"- Location: `{record['location_id']}` — {record['location_label']}",
+            f"- Reference date: `{record['reference_date']}`",
+            f"- Use case: `{record['use_case_id']}`",
+            "- Status: staged documentary evidence; analytical use is not authorized",
+            "",
+            "No score, tier, band, archetype, or cross-signal classification was produced.",
+        ]
+        with Path(summary_path).open("a", encoding="utf-8") as handle:
+            handle.write("\n".join(lines) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/capture_city_reliability_evidence.py
+++ b/scripts/capture_city_reliability_evidence.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Create a staged city-reliability evidence artifact from workflow inputs."""
 
 from __future__ import annotations
@@ -41,3 +40,7 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+EXE002 The file is executable but no shebang is present
+--> scripts/capture_city_reliability_evidence.py:1:1
+
+Found 1 error.

--- a/src/urban_growth/city_reliability_intake.py
+++ b/src/urban_growth/city_reliability_intake.py
@@ -1,0 +1,142 @@
+"""Validate staged, city-level documentary reliability evidence.
+
+This module deliberately does not calculate a score, band, archetype, or eligibility
+decision.  It creates a reviewable intake record that must still be promoted through the
+repository's snapshot and transformation registries before analytical use.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import date
+from typing import Any
+
+SIGNAL_VALUES = {
+    "verification": {"none_documented", "country_level_only", "place_direct", "unknown"},
+    "incentive": {
+        "aligned_distortion_risk",
+        "heterogeneous_incentives",
+        "no_documented_incentive",
+        "unknown",
+    },
+    "aggregate_check": {"none_documented", "partial", "strong", "unknown"},
+    "conduit": {"obscured", "ordinary", "heightened_scrutiny", "unknown"},
+    "granular_treatment": {
+        "suspected_undisclosed",
+        "disclosed_bounded",
+        "no_issue_documented",
+        "unknown",
+    },
+}
+
+ASSERTION_FIELDS = {
+    "value",
+    "source_id",
+    "snapshot_id",
+    "source_release",
+    "observation_date",
+    "citation",
+    "notes",
+}
+
+
+class CityReliabilityIntakeError(ValueError):
+    """Raised when a staged documentary record violates the intake contract."""
+
+
+def _date(value: Any, *, field: str) -> str:
+    if not isinstance(value, str):
+        raise CityReliabilityIntakeError(f"{field} must be an ISO date")
+    try:
+        date.fromisoformat(value)
+    except ValueError as error:
+        raise CityReliabilityIntakeError(f"{field} must be an ISO date") from error
+    return value
+
+
+def _text(value: Any, *, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise CityReliabilityIntakeError(f"{field} must be non-empty text")
+    return value.strip()
+
+
+def validate_intake(
+    payload: Mapping[str, Any],
+    *,
+    location_id: str,
+    location_label: str,
+    reference_date: str,
+    use_case_id: str,
+    submitted_by: str,
+) -> dict[str, Any]:
+    """Return a canonical staged record without combining documentary signals."""
+    forbidden = {"score", "band", "tier", "archetype", "classification"}
+    present_forbidden = sorted(forbidden.intersection(payload))
+    if present_forbidden:
+        raise CityReliabilityIntakeError(
+            "Composite outputs are prohibited: " + ", ".join(present_forbidden)
+        )
+
+    unknown_signals = sorted(set(payload).difference(SIGNAL_VALUES))
+    missing_signals = sorted(set(SIGNAL_VALUES).difference(payload))
+    if unknown_signals or missing_signals:
+        raise CityReliabilityIntakeError(
+            f"Signal set mismatch; missing={missing_signals}, unknown={unknown_signals}"
+        )
+
+    assertions: dict[str, dict[str, str]] = {}
+    for signal, allowed_values in SIGNAL_VALUES.items():
+        raw = payload[signal]
+        if not isinstance(raw, Mapping):
+            raise CityReliabilityIntakeError(f"{signal} must be an object")
+        extra = sorted(set(raw).difference(ASSERTION_FIELDS))
+        if extra:
+            raise CityReliabilityIntakeError(f"{signal} has unknown fields: {extra}")
+        value = _text(raw.get("value"), field=f"{signal}.value")
+        if value not in allowed_values:
+            raise CityReliabilityIntakeError(
+                f"{signal}.value must be one of {sorted(allowed_values)}"
+            )
+
+        assertion = {"value": value}
+        if value == "unknown":
+            assertion["notes"] = _text(raw.get("notes"), field=f"{signal}.notes")
+            # Unknown is a real missingness state; invented placeholder provenance is worse.
+            supplied_provenance = sorted(
+                key for key in ASSERTION_FIELDS - {"value", "notes"} if raw.get(key)
+            )
+            if supplied_provenance:
+                raise CityReliabilityIntakeError(
+                    f"{signal} is unknown but supplies assertion provenance: {supplied_provenance}"
+                )
+        else:
+            for field in ("source_id", "snapshot_id", "source_release", "citation"):
+                assertion[field] = _text(raw.get(field), field=f"{signal}.{field}")
+            assertion["observation_date"] = _date(
+                raw.get("observation_date"), field=f"{signal}.observation_date"
+            )
+            if raw.get("notes"):
+                assertion["notes"] = _text(raw["notes"], field=f"{signal}.notes")
+        assertions[signal] = assertion
+
+    return {
+        "schema_version": "city_reliability_intake_v1",
+        "record_status": "staged_documentary_evidence",
+        "analytical_use_authorized": False,
+        "location_id": _text(location_id, field="location_id"),
+        "location_label": _text(location_label, field="location_label"),
+        "reference_date": _date(reference_date, field="reference_date"),
+        "use_case_id": _text(use_case_id, field="use_case_id"),
+        "submitted_by": _text(submitted_by, field="submitted_by"),
+        "signals": assertions,
+        "promotion_requirements": [
+            "verify each non-unknown snapshot_id against data/reliability_snapshots.csv",
+            "create a registered deterministic transformation run",
+            "apply the use-specific city data fitness gate separately",
+        ],
+    }
+
+
+def canonical_json(record: Mapping[str, Any]) -> str:
+    return json.dumps(record, ensure_ascii=False, indent=2, sort_keys=True) + "\n"

--- a/tests/test_city_reliability_intake.py
+++ b/tests/test_city_reliability_intake.py
@@ -1,0 +1,79 @@
+from copy import deepcopy
+
+import pytest
+
+from urban_growth.city_reliability_intake import CityReliabilityIntakeError, validate_intake
+
+
+def _payload() -> dict:
+    unknown = {"value": "unknown", "notes": "No reviewed evidence yet."}
+    return {
+        "verification": {
+            "value": "place_direct",
+            "source_id": "source",
+            "snapshot_id": "snapshot",
+            "source_release": "2025 release",
+            "observation_date": "2025-01-01",
+            "citation": "Table 2, row 3",
+        },
+        "incentive": deepcopy(unknown),
+        "aggregate_check": deepcopy(unknown),
+        "conduit": deepcopy(unknown),
+        "granular_treatment": deepcopy(unknown),
+    }
+
+
+def _validate(payload: dict) -> dict:
+    return validate_intake(
+        payload,
+        location_id="USA-PLACE-123",
+        location_label="Example place",
+        reference_date="2026-09-03",
+        use_case_id="descriptive_city_evidence_v1",
+        submitted_by="analyst",
+    )
+
+
+def test_intake_preserves_signals_and_prohibits_analytical_use() -> None:
+    record = _validate(_payload())
+    assert record["analytical_use_authorized"] is False
+    assert record["record_status"] == "staged_documentary_evidence"
+    assert record["signals"]["verification"]["value"] == "place_direct"
+    assert not {"score", "band", "tier", "archetype"}.intersection(record)
+
+
+def test_missing_evidence_is_explicit_unknown_without_fake_provenance() -> None:
+    payload = _payload()
+    payload["incentive"]["snapshot_id"] = "placeholder"
+    with pytest.raises(CityReliabilityIntakeError, match="unknown but supplies"):
+        _validate(payload)
+
+
+def test_observed_assertion_requires_dated_provenance() -> None:
+    payload = _payload()
+    del payload["verification"]["snapshot_id"]
+    with pytest.raises(CityReliabilityIntakeError, match="snapshot_id"):
+        _validate(payload)
+    payload = _payload()
+    payload["verification"]["observation_date"] = "2025"
+    with pytest.raises(CityReliabilityIntakeError, match="ISO date"):
+        _validate(payload)
+
+
+@pytest.mark.parametrize("forbidden", ["score", "band", "tier", "archetype", "classification"])
+def test_composite_outputs_are_rejected(forbidden: str) -> None:
+    payload = _payload()
+    payload[forbidden] = "high"
+    with pytest.raises(CityReliabilityIntakeError, match="Composite outputs are prohibited"):
+        _validate(payload)
+
+
+def test_signal_set_and_controlled_values_fail_closed() -> None:
+    payload = _payload()
+    del payload["conduit"]
+    with pytest.raises(CityReliabilityIntakeError, match="Signal set mismatch"):
+        _validate(payload)
+    payload = _payload()
+    payload["verification"]["value"] = "2"
+    with pytest.raises(CityReliabilityIntakeError, match="must be one of"):
+        _validate(payload)


### PR DESCRIPTION
## Summary

- replace the proposed universal classifier with a staged documentary-evidence workflow
- preserve the five signals independently and add explicit `unknown` handling
- require dated source, release, snapshot, and citation metadata for every observed assertion
- prohibit score, tier, band, archetype, and cross-signal classification fields
- mark artifacts as unauthorized for analytical use until provenance registration and a use-specific City Data Fitness gate are complete
- document the boundary in the authoritative reliability-matrix design

## Validation

- `uv run --locked --extra dev ruff check .`
- `uv run --locked --extra dev pytest -q` — 320 passed
- manual CLI smoke test with an all-unknown payload and JSON parse validation

## Scope

This PR does not register empirical evidence or make any claim about a real city. The workflow produces a 30-day review artifact only; it does not commit evidence to the repository.