### PR TITLE
Enforce owner-only repository governance controls

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,3 +32,10 @@ Gate advanced:
 <!-- List unresolved licensing, geography, source-method, or governance decisions. Use
 "None" only after checking. A manual block cannot be closed by placeholder code. -->
 
+## Owner attestation
+
+<!-- This repository is owner-controlled and does not claim independent review. -->
+
+- [ ] I reviewed the final diff after the last push.
+- [ ] I checked applicable methodological, geographic, provenance, and licensing gates.
+- [ ] I am not representing this change as independently or peer reviewed.

--- a/.github/workflows/city-reliability-evidence-intake.yml
+++ b/.github/workflows/city-reliability-evidence-intake.yml
@@ -40,10 +40,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.11"
 
@@ -58,7 +58,7 @@ jobs:
         run: PYTHONPATH=src python3 scripts/capture_city_reliability_evidence.py
 
       - name: Upload staged evidence for review
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: city-reliability-evidence-${{ github.run_id }}
           path: city-reliability-intake.json

--- a/.github/workflows/dynamic-bootstrap-coverage.yml
+++ b/.github/workflows/dynamic-bootstrap-coverage.yml
@@ -27,8 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.11"
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
@@ -43,7 +43,7 @@ jobs:
           --cities 48 --countries 6 --seed 314159
           --persistence ${{ matrix.persistence }} --panel-length ${{ matrix.panel_length }}
           --output outputs/dynamic_bootstrap_coverage_${{ matrix.tag }}.csv
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dynamic-bootstrap-coverage-${{ matrix.tag }}
           path: outputs/dynamic_bootstrap_coverage_${{ matrix.tag }}.csv
@@ -53,8 +53,8 @@ jobs:
     needs: coverage-cell
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.11"
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
@@ -62,7 +62,7 @@ jobs:
           version: "0.11.33"
           enable-cache: true
       - run: uv sync --locked
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: dynamic-bootstrap-coverage-*
           path: coverage-artifacts
@@ -71,7 +71,7 @@ jobs:
           uv run --locked python scripts/combine_dynamic_bootstrap_coverage.py
           --input-dir coverage-artifacts
           --output outputs/dynamic_bootstrap_coverage.csv
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dynamic-bootstrap-coverage-combined
           path: outputs/dynamic_bootstrap_coverage.csv

--- a/.github/workflows/ghsl-redteam-130.yml
+++ b/.github/workflows/ghsl-redteam-130.yml
@@ -12,12 +12,15 @@ on:
       - "src/urban_growth/adapters/ghsl_ucdb.py"
       - "src/urban_growth/forecast.py"
 
+permissions:
+  contents: read
+
 jobs:
   ghsl-redteam:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.11"
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
@@ -33,7 +36,7 @@ jobs:
           mtuc_url="https://jeodpp.jrc.ec.europa.eu/ftp/jrc-opendata/GHSL/GHS_UCDB_GLOBE_R2024A/GHS_UCDB_MTUC_GLOBE_R2024A/V1-2/GHS_UCDB_MTUC_GLOBE_R2024A_V1_2.zip"
           curl --fail --location --retry 3 --retry-delay 2 "$theme_url" -o downloads/theme.zip
           curl --fail --location --retry 3 --retry-delay 2 "$mtuc_url" -o downloads/mtuc.zip
-          sha256sum downloads/theme.zip downloads/mtuc.zip | tee ghsl-source-zip-sha256.txt
+          head -n 2 results/ghsl_redteam_130_source_sha256.txt | sha256sum --check --strict -
           unzip -q downloads/theme.zip -d downloads/theme
           unzip -q downloads/mtuc.zip -d downloads/mtuc
           theme_csv=$(find downloads/theme -type f -iname '*.csv' | head -n 1)
@@ -57,7 +60,7 @@ jobs:
             curl --fail --location --retry 3 --retry-delay 2 \
               "$base/$file" --output "data/raw/$file"
           done
-          sha256sum data/raw/WUP2025-*.xlsx | tee wup-source-sha256.txt
+          tail -n +3 results/ghsl_redteam_130_source_sha256.txt | sha256sum --check --strict -
       - name: Run GHSL issue 130 diagnostics
         run: uv run --locked python scripts/run_ghsl_redteam_130.py
       - name: Print core diagnostics
@@ -69,11 +72,9 @@ jobs:
           cat outputs/ghsl_redteam_130/fixed_origin_risk_set_coverage.csv
           echo '--- built-up entanglement ---'
           cat outputs/ghsl_redteam_130/fixed_origin_built_up_entanglement.csv
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ghsl-redteam-130
           path: |
             outputs/ghsl_redteam_130/*.csv
-            ghsl-source-zip-sha256.txt
-            ghsl-source-csv-sha256.txt
-            wup-source-sha256.txt
+            results/ghsl_redteam_130_source_sha256.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.11"
 
@@ -34,6 +34,9 @@ jobs:
 
       - name: Validate source licensing registry
         run: uv run --locked --extra dev urban-growth-sources verify-licenses
+
+      - name: Validate repository governance controls
+        run: uv run --locked --extra dev python scripts/check_repository_governance.py
 
       - name: Test
         run: uv run --locked --extra dev pytest -q

--- a/.github/workflows/wup-contemporaneous-country.yml
+++ b/.github/workflows/wup-contemporaneous-country.yml
@@ -12,12 +12,15 @@ on:
       - "src/urban_growth/wup_lineage.py"
       - "src/urban_growth/forecast.py"
 
+permissions:
+  contents: read
+
 jobs:
   contemporaneous-country:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.11"
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
@@ -39,16 +42,18 @@ jobs:
             curl --fail --location --retry 3 --retry-delay 2 \
               "$base/$file" --output "data/raw/$file"
           done
-          sha256sum data/raw/WUP2025-*.xlsx | tee outputs-wup-source-sha256.txt
+          grep -E '^[0-9a-f]{64}  ' results/wup_h1_incremental_source_sha256.txt \
+            | sed 's#  #  data/raw/#' \
+            | sha256sum --check --strict -
       - name: Run contemporaneous country diagnostic
         run: uv run --locked python scripts/run_wup_contemporaneous_country_baseline.py
       - name: Print metrics
         run: cat outputs/wup_contemporaneous_country_metrics.csv
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: wup-contemporaneous-country-diagnostic
           path: |
             outputs/wup_contemporaneous_country_metrics.csv
             outputs/wup_contemporaneous_country_bootstrap.csv
             outputs/wup_contemporaneous_country_time_bootstrap.csv
-            outputs-wup-source-sha256.txt
+            results/wup_h1_incremental_source_sha256.txt

--- a/.github/workflows/wup-h1-empirical.yml
+++ b/.github/workflows/wup-h1-empirical.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.11"
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
@@ -38,7 +38,9 @@ jobs:
             curl --fail --location --retry 3 --retry-delay 2 \
               "$base/$file" --output "data/raw/$file"
           done
-          sha256sum data/raw/WUP2025-*.xlsx | tee outputs-wup-source-sha256.txt
+          grep -E '^[0-9a-f]{64}  ' results/wup_h1_incremental_source_sha256.txt \
+            | sed 's#  #  data/raw/#' \
+            | sha256sum --check --strict -
       - name: Run corrected-lineage H1 diagnostic
         run: >-
           uv run --locked python scripts/run_wup_h1_incremental.py
@@ -46,10 +48,10 @@ jobs:
           --output outputs/wup_h1_incremental_recent_growth_by_origin.csv
       - name: Print empirical result
         run: cat outputs/wup_h1_incremental_recent_growth_by_origin.csv
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: wup-h1-incremental-empirical
           path: |
             outputs/wup_h1_incremental_recent_growth_by_origin.csv
-            outputs-wup-source-sha256.txt
+            results/wup_h1_incremental_source_sha256.txt
           if-no-files-found: error

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,5 +60,13 @@ not acceptable.
 
 ## Review ownership
 
-The repository owner currently performs final review. `CODEOWNERS` requests that
-review automatically; it does not replace branch protection or the required CI check.
+This is currently an owner-controlled repository. The owner authors and performs final
+review of changes; the project does not claim independent review, peer review, or
+segregation of duties. Requiring an approval would create false review theater because an
+author cannot supply independent approval of their own pull request.
+
+`CODEOWNERS` records decision ownership. Pull requests, the required CI check, current-
+branch enforcement, resolved review threads, and the owner-attestation checklist reduce
+accidental error, but none substitutes for an independent reviewer. If a qualified second
+reviewer is added later, the branch rules must then require their approval and dismiss
+stale approvals after new pushes.

--- a/scripts/check_repository_governance.py
+++ b/scripts/check_repository_governance.py
@@ -1,0 +1,6 @@
+"""CLI wrapper for repository governance validation."""
+
+from urban_growth.repository_governance import main
+
+if __name__ == "__main__":
+    main()

--- a/src/urban_growth/repository_governance.py
+++ b/src/urban_growth/repository_governance.py
@@ -1,0 +1,62 @@
+"""Fail CI when repository-level governance controls regress."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ACTION_USE = re.compile(r"^\s*-?\s*uses:\s*([^\s#]+)", re.MULTILINE)
+PINNED_ACTION = re.compile(r"^[^/\s]+/[^@\s]+@[0-9a-f]{40}$")
+EMPIRICAL_WORKFLOWS = {
+    "ghsl-redteam-130.yml",
+    "wup-contemporaneous-country.yml",
+    "wup-h1-empirical.yml",
+}
+PROHIBITED_RELIABILITY_PATTERNS = {
+    "legacy classifier entry point": "scripts/classify_reliability.py",
+    "composite-score summation": "sum(scores.values())",
+    "classifier output band": "band={band}",
+    "classifier output score": "score={total}",
+    "classifier output archetype": "archetype={archetype}",
+}
+
+
+def governance_errors(root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+    workflow_dir = root / ".github" / "workflows"
+    workflows = sorted(workflow_dir.glob("*.yml")) + sorted(workflow_dir.glob("*.yaml"))
+    if not workflows:
+        return ["No GitHub Actions workflows found"]
+
+    for workflow in workflows:
+        text = workflow.read_text(encoding="utf-8")
+        if not re.search(r"^permissions:\n  contents: read\s*$", text, re.MULTILINE):
+            errors.append(f"{workflow.relative_to(root)} lacks explicit contents: read permissions")
+        for action in ACTION_USE.findall(text):
+            if action.startswith(("./", "docker://")):
+                continue
+            if not PINNED_ACTION.fullmatch(action):
+                errors.append(
+                    f"{workflow.relative_to(root)} uses mutable action reference {action}"
+                )
+        if workflow.name in EMPIRICAL_WORKFLOWS and "sha256sum --check --strict" not in text:
+            errors.append(f"{workflow.relative_to(root)} does not verify registered input hashes")
+
+    searchable = [workflow_dir, root / "scripts"]
+    for label, pattern in PROHIBITED_RELIABILITY_PATTERNS.items():
+        for directory in searchable:
+            for path in directory.rglob("*"):
+                if (
+                    path.is_file()
+                    and pattern in path.read_text(encoding="utf-8", errors="ignore")
+                ):
+                    errors.append(f"{path.relative_to(root)} contains prohibited {label}")
+    return errors
+
+
+def main() -> None:
+    errors = governance_errors()
+    if errors:
+        raise SystemExit("Repository governance validation failed:\n- " + "\n- ".join(errors))
+    print("Repository governance controls validated")

--- a/tests/test_repository_governance.py
+++ b/tests/test_repository_governance.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+from urban_growth.repository_governance import governance_errors
+
+
+def test_repository_governance_controls() -> None:
+    assert governance_errors(Path(".")) == []
+
+
+def _write_workflow(root: Path, name: str, body: str) -> None:
+    workflow_dir = root / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True, exist_ok=True)
+    (workflow_dir / name).write_text(body, encoding="utf-8")
+    (root / "scripts").mkdir(exist_ok=True)
+
+
+def test_governance_rejects_mutable_action_and_inherited_permissions(tmp_path: Path) -> None:
+    _write_workflow(
+        tmp_path,
+        "tests.yml",
+        "name: tests\nsteps:\n  - uses: actions/checkout@v7\n",
+    )
+    errors = governance_errors(tmp_path)
+    assert any("lacks explicit contents: read" in error for error in errors)
+    assert any("mutable action reference actions/checkout@v7" in error for error in errors)
+
+
+def test_governance_rejects_empirical_workflow_without_hash_gate(tmp_path: Path) -> None:
+    _write_workflow(
+        tmp_path,
+        "wup-h1-empirical.yml",
+        "name: empirical\npermissions:\n  contents: read\nsteps: []\n",
+    )
+    assert any("does not verify registered input hashes" in error for error in governance_errors(tmp_path))
+
+
+def test_governance_rejects_legacy_classifier(tmp_path: Path) -> None:
+    _write_workflow(
+        tmp_path,
+        "tests.yml",
+        "name: tests\npermissions:\n  contents: read\nsteps: []\n",
+    )
+    (tmp_path / "scripts" / "legacy.py").write_text(
+        "total = sum(scores.values())\n", encoding="utf-8"
+    )
+    assert any("composite-score summation" in error for error in governance_errors(tmp_path))


### PR DESCRIPTION
## Objective

Make the current owner-only governance model explicit and enforce the safeguards that do not depend on a fictitious independent approval.

Gate advanced: repository governance and reproducibility

## Changes

- document that the repository is owner-controlled and does not claim independent or peer review
- add final-diff, methodology/licensing, and representation attestations to the PR template
- pin every GitHub Action to a full commit SHA
- require explicit `contents: read` permissions in every workflow
- verify registered WUP and GHSL SHA-256 values before empirical analysis begins
- add a required-CI governance validator for immutable action references, workflow permissions, empirical hash gates, and prohibited reliability classifiers
- add positive and failure-mode tests for those controls

## Evidence

- `PYTHONPATH=src python scripts/check_repository_governance.py`
- `uv run --locked --extra dev ruff check .`
- `uv run --locked --extra dev pytest -q` — 324 passed
- `git diff --check`

## Manual review required

Owner-only governance is intentional for now. This PR does not claim independent review or segregation of duties.