### PR TITLE
Add contemporaneous-country H1 hierarchy

### DIFF
--- a/.github/workflows/wup-contemporaneous-country.yml
+++ b/.github/workflows/wup-contemporaneous-country.yml
@@ -56,4 +56,5 @@ jobs:
             outputs/wup_contemporaneous_country_metrics.csv
             outputs/wup_contemporaneous_country_bootstrap.csv
             outputs/wup_contemporaneous_country_time_bootstrap.csv
+            outputs/wup_contemporaneous_country_h1_hierarchy.csv
             results/wup_h1_incremental_source_sha256.txt

--- a/docs/h1-incremental-information-test.md
+++ b/docs/h1-incremental-information-test.md
@@ -7,6 +7,27 @@ The registered diagnostic in `src/urban_growth/h1_information.py` therefore comp
 1. `country_loo_only`: the leave-city-out historical country mean; and
 2. `country_loo_plus_recent_growth`: the same country baseline plus a coefficient on the city's recent growth deviation from its country's training-sample recent-growth mean.
 
+## Contemporaneous-country re-test
+
+The separate #133 lineage uses the same-origin mean recent growth of all other cities in
+the focal city's country as the primary country-context predictor. A singleton-country
+row uses the same-origin global leave-city-out mean. Neither construction uses the focal
+city or a future outcome.
+
+For each forecast origin, coefficients are fit only on rows whose outcomes end by that
+origin. Four models are scored on identical test rows:
+
+1. contemporaneous leave-city-out country context;
+2. that context plus the focal city's deviation from it;
+3. historical leave-city-out country outcome context; and
+4. that historical context plus recent city growth, retained as a continuity sensitivity.
+
+The complete hierarchy is reported separately for each origin under row weighting and
+equal-country weighting. Equal-country fitting gives every country total weight one;
+equal-country MAE averages country MAEs and equal-country RMSE is the square root of the
+mean country MSE. Model winners are descriptive per-origin outputs. They are not pooled
+across origins and do not select a model or tune a hyperparameter for later origins.
+
 The recent-growth coefficient is estimated after country demeaning and uses only training intervals whose outcomes end by the forecast origin. The test reports the coefficient, matched row counts, MAE and RMSE for both models, and the recent-minus-country error deltas. A negative delta means recent growth improves the country-context forecast.
 
 This diagnostic does **not** retroactively redefine the preregistered universal H1. It separates two questions that were previously conflated:

--- a/scripts/run_wup_contemporaneous_country_baseline.py
+++ b/scripts/run_wup_contemporaneous_country_baseline.py
@@ -14,6 +14,7 @@ from urban_growth.adapters.wup import (
 from urban_growth.contemporaneous_baseline import (
     contemporaneous_country_baseline_errors,
     evaluate_contemporaneous_country_baseline,
+    evaluate_contemporaneous_country_h1_hierarchy,
 )
 from urban_growth.forecast import (
     build_forecast_intervals,
@@ -46,6 +47,11 @@ def main() -> None:
         type=Path,
         default=Path("outputs/wup_contemporaneous_country_time_bootstrap.csv"),
     )
+    parser.add_argument(
+        "--hierarchy-output",
+        type=Path,
+        default=Path("outputs/wup_contemporaneous_country_h1_hierarchy.csv"),
+    )
     args = parser.parse_args()
     raw = args.raw_dir
     population = classify_wup_city_population_lineage(
@@ -54,14 +60,16 @@ def main() -> None:
     city_year = build_wup_city_year_panel(
         population,
         read_f25_city_land_area(raw / "WUP2025-F25-DEGURBA-Cities_AREA_km2.xlsx"),
-        read_f30_built_up_area_per_capita(
-            raw / "WUP2025-F30-DEGURBA-Cities_BU_m2_per_capita.xlsx"
-        ),
+        read_f30_built_up_area_per_capita(raw / "WUP2025-F30-DEGURBA-Cities_BU_m2_per_capita.xlsx"),
         read_f34_population_density(raw / "WUP2025-F34-DEGURBA-Cities_Pop_density.xlsx"),
     )
     intervals = build_forecast_intervals(city_year, OBSERVED_PANEL_ORIGINS)
     scoring = intervals.loc[intervals["period_start"].isin(OBSERVED_SCORING_ORIGINS)].copy()
     metrics = evaluate_contemporaneous_country_baseline(scoring)
+    hierarchy = evaluate_contemporaneous_country_h1_hierarchy(
+        intervals,
+        OBSERVED_SCORING_ORIGINS,
+    )
     errors = contemporaneous_country_baseline_errors(scoring)
     bootstrap = cluster_bootstrap_paired_difference(
         errors,
@@ -78,6 +86,7 @@ def main() -> None:
         (args.metrics_output, metrics),
         (args.bootstrap_output, bootstrap),
         (args.country_time_bootstrap_output, country_time),
+        (args.hierarchy_output, hierarchy),
     ]:
         path.parent.mkdir(parents=True, exist_ok=True)
         frame.to_csv(path, index=False)

--- a/src/urban_growth/contemporaneous_baseline.py
+++ b/src/urban_growth/contemporaneous_baseline.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from urban_growth.forecast import score_forecast
+from urban_growth.forecast import (
+    baseline_predictions,
+    rolling_origin_splits,
+    score_forecast,
+)
 from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
 
 
@@ -88,9 +92,7 @@ def evaluate_contemporaneous_country_baseline(
                 "n": persistence.n,
                 "persistence_mae": persistence.mae,
                 "contemporaneous_country_mae": contemporary.mae,
-                "mae_delta_persistence_minus_contemporaneous": (
-                    persistence.mae - contemporary.mae
-                ),
+                "mae_delta_persistence_minus_contemporaneous": (persistence.mae - contemporary.mae),
                 "persistence_rmse": persistence.rmse,
                 "contemporaneous_country_rmse": contemporary.rmse,
                 "rmse_delta_persistence_minus_contemporaneous": (
@@ -98,9 +100,7 @@ def evaluate_contemporaneous_country_baseline(
                 ),
                 "persistence_beats_contemporaneous_mae": persistence.mae < contemporary.mae,
                 "persistence_beats_contemporaneous_rmse": persistence.rmse < contemporary.rmse,
-                "fallback_rows": int(
-                    group["contemporaneous_country_fallback_global_loo"].sum()
-                ),
+                "fallback_rows": int(group["contemporaneous_country_fallback_global_loo"].sum()),
                 "comparator_information_time": "forecast_origin",
                 "comparator_leave_city_out": True,
             }
@@ -120,9 +120,14 @@ def contemporaneous_country_baseline_errors(
     peer = "country_contemporaneous_recent_growth_leave_city_out"
     required = {"city_id", "country_code", "period_start", outcome_column, "recent_growth", peer}
     require_columns(working, required, source_name="contemporaneous baseline errors")
-    id_columns = [c for c in ["city_id", "country_code", "city_name", "period_start"] if c in working]
+    id_columns = [
+        c for c in ["city_id", "country_code", "city_name", "period_start"] if c in working
+    ]
     rows = []
-    for model, column in [("persistence", "recent_growth"), ("country_contemporaneous_recent_growth_leave_city_out", peer)]:
+    for model, column in [
+        ("persistence", "recent_growth"),
+        ("country_contemporaneous_recent_growth_leave_city_out", peer),
+    ]:
         frame = working[id_columns].copy()
         frame["origin"] = working["period_start"].to_numpy()
         frame["model"] = model
@@ -132,3 +137,166 @@ def contemporaneous_country_baseline_errors(
         frame["absolute_error"] = frame["error"].abs()
         rows.append(frame)
     return pd.concat(rows, ignore_index=True)
+
+
+def _country_balanced_losses(
+    actual: pd.Series,
+    predicted: pd.Series,
+    country: pd.Series,
+) -> tuple[float, float]:
+    errors = pd.DataFrame(
+        {
+            "country_code": country.to_numpy(),
+            "error": predicted.to_numpy() - actual.to_numpy(),
+        }
+    )
+    by_country = (
+        errors.assign(
+            absolute_error=lambda frame: frame["error"].abs(),
+            squared_error=lambda frame: frame["error"].pow(2),
+        )
+        .groupby("country_code")[["absolute_error", "squared_error"]]
+        .mean()
+    )
+    return float(by_country["absolute_error"].mean()), float(
+        np.sqrt(by_country["squared_error"].mean())
+    )
+
+
+def _weighted_slope(x: pd.Series, y: pd.Series, weights: pd.Series) -> float:
+    denominator = float(np.sum(weights * x.pow(2)))
+    if denominator <= 0:
+        raise SourceSchemaError("H1 contemporaneous deviation has no estimable variation")
+    return float(np.sum(weights * x * y) / denominator)
+
+
+def evaluate_contemporaneous_country_h1_hierarchy(
+    panel: pd.DataFrame,
+    origins: list[int],
+    *,
+    outcome_column: str = "future_growth",
+) -> pd.DataFrame:
+    """Evaluate the H1 model hierarchy per origin without future information.
+
+    The primary nested comparison adds the focal city's deviation from its
+    same-origin, leave-city-out country peer signal. Coefficients are estimated
+    only on prior-origin rows. Row-weighted and equal-country fits and losses are
+    reported separately. Historical country-context models are retained only as
+    continuity sensitivities.
+    """
+    required = {
+        "city_id",
+        "country_code",
+        "period_start",
+        "period_end",
+        "recent_growth",
+        outcome_column,
+    }
+    require_columns(panel, required, source_name="H1 contemporaneous hierarchy panel")
+    reject_duplicate_keys(
+        panel,
+        ["city_id", "period_start", "period_end"],
+        source_name="H1 contemporaneous hierarchy panel",
+    )
+    if not origins or len(origins) != len(set(origins)):
+        raise SourceSchemaError("H1 contemporaneous origins must be unique and non-empty")
+
+    working = attach_contemporaneous_country_recent_growth(panel)
+    peer = "country_contemporaneous_recent_growth_leave_city_out"
+    rows: list[dict[str, object]] = []
+    for origin, train_index, test_index in rolling_origin_splits(working, sorted(origins)):
+        needed = ["country_code", "recent_growth", peer, outcome_column]
+        train = working.loc[train_index].dropna(subset=needed).copy()
+        test = working.loc[test_index].dropna(subset=needed).copy()
+        train = train.loc[np.isfinite(train[["recent_growth", peer, outcome_column]]).all(axis=1)]
+        test = test.loc[np.isfinite(test[["recent_growth", peer, outcome_column]]).all(axis=1)]
+        if train.empty or test.empty:
+            continue
+
+        historical = baseline_predictions(train, test, outcome_column=outcome_column)
+        matched = pd.DataFrame(
+            {
+                "actual": test[outcome_column],
+                "country_code": test["country_code"],
+                "recent_growth": test["recent_growth"],
+                "contemporaneous_country": test[peer],
+                "historical_country": historical["country_mean_leave_city_out"],
+            },
+            index=test.index,
+        ).dropna()
+        if matched.empty:
+            continue
+
+        train_deviation = train["recent_growth"] - train[peer]
+        train_residual = train[outcome_column] - train[peer]
+        country_sizes = train.groupby("country_code")["city_id"].transform("size")
+        fit_weights = {
+            "row_weighted": pd.Series(1.0, index=train.index),
+            "country_balanced": 1.0 / country_sizes,
+        }
+
+        historical_means = train.groupby("country_code")[
+            [outcome_column, "recent_growth"]
+        ].transform("mean")
+        historical_x = train["recent_growth"] - historical_means["recent_growth"]
+        historical_y = train[outcome_column] - historical_means[outcome_column]
+
+        for weighting, weights in fit_weights.items():
+            beta = _weighted_slope(train_deviation, train_residual, weights)
+            historical_beta = _weighted_slope(historical_x, historical_y, weights)
+            country_recent = train.groupby("country_code")["recent_growth"].mean()
+            global_recent = float(train["recent_growth"].mean())
+            test_country_recent = matched["country_code"].map(country_recent).fillna(global_recent)
+            predictions = {
+                "contemporaneous_country_only": matched["contemporaneous_country"],
+                "contemporaneous_country_plus_city_deviation": matched["contemporaneous_country"]
+                + beta * (matched["recent_growth"] - matched["contemporaneous_country"]),
+                "historical_country_loo_only": matched["historical_country"],
+                "historical_country_loo_plus_recent_growth": matched["historical_country"]
+                + historical_beta * (matched["recent_growth"] - test_country_recent),
+            }
+            metrics: dict[str, tuple[float, float]] = {}
+            for model, prediction in predictions.items():
+                if weighting == "row_weighted":
+                    score = score_forecast(matched["actual"], prediction)
+                    metrics[model] = (score.mae, score.rmse)
+                else:
+                    metrics[model] = _country_balanced_losses(
+                        matched["actual"], prediction, matched["country_code"]
+                    )
+            winner_mae = min(metrics, key=lambda model: metrics[model][0])
+            winner_rmse = min(metrics, key=lambda model: metrics[model][1])
+            baseline_mae, baseline_rmse = metrics["contemporaneous_country_only"]
+            for model, (mae, rmse) in metrics.items():
+                model_beta = (
+                    beta
+                    if model == "contemporaneous_country_plus_city_deviation"
+                    else historical_beta
+                    if model == "historical_country_loo_plus_recent_growth"
+                    else np.nan
+                )
+                rows.append(
+                    {
+                        "origin": int(origin),
+                        "weighting": weighting,
+                        "model": model,
+                        "n": len(matched),
+                        "country_count": int(matched["country_code"].nunique()),
+                        "candidate_train_n": len(working.loc[train_index]),
+                        "matched_train_n": len(train),
+                        "beta": model_beta,
+                        "mae": mae,
+                        "rmse": rmse,
+                        "mae_delta_vs_contemporaneous_country": mae - baseline_mae,
+                        "rmse_delta_vs_contemporaneous_country": rmse - baseline_rmse,
+                        "mae_winner": model == winner_mae,
+                        "rmse_winner": model == winner_rmse,
+                        "test_rows_identical_across_models": True,
+                        "training_precedes_origin": True,
+                        "contemporaneous_country_leave_city_out": True,
+                        "contemporaneous_country_uses_future_outcome": False,
+                    }
+                )
+    if not rows:
+        raise SourceSchemaError("No H1 contemporaneous hierarchy evaluations were produced")
+    return pd.DataFrame(rows).sort_values(["origin", "weighting", "model"]).reset_index(drop=True)

--- a/tests/test_contemporaneous_baseline.py
+++ b/tests/test_contemporaneous_baseline.py
@@ -4,6 +4,7 @@ import pytest
 from urban_growth.contemporaneous_baseline import (
     attach_contemporaneous_country_recent_growth,
     evaluate_contemporaneous_country_baseline,
+    evaluate_contemporaneous_country_h1_hierarchy,
 )
 from urban_growth.io import SourceSchemaError
 
@@ -22,9 +23,7 @@ def _panel() -> pd.DataFrame:
 
 def test_contemporaneous_country_baseline_is_leave_city_out() -> None:
     result = attach_contemporaneous_country_recent_growth(_panel())
-    pred = result.set_index("city_id")[
-        "country_contemporaneous_recent_growth_leave_city_out"
-    ]
+    pred = result.set_index("city_id")["country_contemporaneous_recent_growth_leave_city_out"]
     assert pred.loc[1] == pytest.approx(0.03)
     assert pred.loc[2] == pytest.approx(0.01)
     # Singleton countries fall back to the global mean excluding the focal city.
@@ -56,3 +55,67 @@ def test_contemporaneous_country_baseline_requires_two_cities_per_origin() -> No
     one = _panel().iloc[[0]].copy()
     with pytest.raises(SourceSchemaError, match="at least two cities"):
         attach_contemporaneous_country_recent_growth(one)
+
+
+def test_h1_hierarchy_reports_every_model_and_weighting_on_matched_rows() -> None:
+    rows = []
+    for origin in [1990, 1995, 2000]:
+        for city_id, country, recent in [
+            (1, "A", 0.01),
+            (2, "A", 0.03),
+            (3, "B", 0.02),
+            (4, "B", 0.04),
+        ]:
+            rows.append(
+                {
+                    "city_id": city_id,
+                    "country_code": country,
+                    "period_start": origin,
+                    "period_end": origin + 5,
+                    "recent_growth": recent + (origin - 1990) / 1000,
+                    "future_growth": 0.5 * recent + (0.005 if country == "A" else 0.01),
+                }
+            )
+    result = evaluate_contemporaneous_country_h1_hierarchy(pd.DataFrame(rows), [2000])
+    assert set(result["weighting"]) == {"row_weighted", "country_balanced"}
+    assert set(result["model"]) == {
+        "contemporaneous_country_only",
+        "contemporaneous_country_plus_city_deviation",
+        "historical_country_loo_only",
+        "historical_country_loo_plus_recent_growth",
+    }
+    assert result["n"].eq(4).all()
+    assert result["country_count"].eq(2).all()
+    assert result["test_rows_identical_across_models"].all()
+    assert result["training_precedes_origin"].all()
+    assert not result["contemporaneous_country_uses_future_outcome"].any()
+    assert result.groupby("weighting")["mae_winner"].sum().eq(1).all()
+
+
+def test_h1_hierarchy_country_balancing_changes_unequal_country_fit() -> None:
+    rows = []
+    specifications = {
+        1990: [(1, "A", 0.00), (2, "A", 0.01), (3, "A", 0.02), (4, "B", 0.10), (5, "B", 0.20)],
+        1995: [(1, "A", 0.01), (2, "A", 0.02), (3, "A", 0.03), (4, "B", 0.20), (5, "B", 0.40)],
+        2000: [(1, "A", 0.02), (2, "A", 0.03), (3, "A", 0.04), (4, "B", 0.30), (5, "B", 0.60)],
+    }
+    for origin, cities in specifications.items():
+        for city_id, country, recent in cities:
+            slope = 0.2 if country == "A" else 1.5
+            rows.append(
+                {
+                    "city_id": city_id,
+                    "country_code": country,
+                    "period_start": origin,
+                    "period_end": origin + 5,
+                    "recent_growth": recent,
+                    "future_growth": slope * recent,
+                }
+            )
+    result = evaluate_contemporaneous_country_h1_hierarchy(pd.DataFrame(rows), [2000])
+    augmented = result.loc[
+        result["model"].eq("contemporaneous_country_plus_city_deviation")
+    ].set_index("weighting")
+    assert augmented.loc["row_weighted", "beta"] != pytest.approx(
+        augmented.loc["country_balanced", "beta"]
+    )


### PR DESCRIPTION
Implements the estimator and workflow portion of #133 without overwriting the existing H1 lineage.

- fits the same-origin leave-city-out country baseline and nested focal-city deviation model using only outcomes available by each origin
- reports the complete four-model hierarchy separately by origin
- reports row-weighted and equal-country fits and losses
- preserves identical test rows and explicit leakage guards
- adds the new hierarchy CSV to the official WUP workflow artifact

Verification:
- `uv run --locked --extra dev ruff check .`
- `uv run --locked --extra dev pytest -q` (331 passed)
- `git diff --check`

The issue remains open until the workflow output is committed, registered, and interpreted.