### PR TITLE
Run WUP H1 workflow on relevant pull requests

### DIFF
--- a/.github/workflows/wup-contemporaneous-country.yml
+++ b/.github/workflows/wup-contemporaneous-country.yml
@@ -2,6 +2,15 @@ name: WUP contemporaneous country diagnostic
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/wup-contemporaneous-country.yml"
+      - "scripts/run_wup_contemporaneous_country_baseline.py"
+      - "src/urban_growth/contemporaneous_baseline.py"
+      - "src/urban_growth/wup_lineage.py"
+      - "src/urban_growth/forecast.py"
   push:
     branches:
       - redteam/contemporaneous-country-baseline


### PR DESCRIPTION
Adds pull-request execution for the issue #133 empirical workflow so changes to the estimator are tested against the registered WUP inputs before merge. The existing manual and dedicated-branch triggers remain intact.