### PR TITLE
Add WUP H1 source-basis stratification

### DIFF
--- a/.github/workflows/wup-source-basis-h1.yml
+++ b/.github/workflows/wup-source-basis-h1.yml
@@ -1,0 +1,72 @@
+name: WUP H1 source-basis stratification
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/wup-source-basis-h1.yml"
+      - "scripts/run_wup_source_basis_h1.py"
+      - "src/urban_growth/wup_source_basis.py"
+      - "src/urban_growth/adapters/wup.py"
+      - "src/urban_growth/forecast.py"
+  push:
+    branches:
+      - redteam/wup-source-basis-h1
+    paths:
+      - ".github/workflows/wup-source-basis-h1.yml"
+      - "scripts/run_wup_source_basis_h1.py"
+      - "src/urban_growth/wup_source_basis.py"
+
+permissions:
+  contents: read
+
+jobs:
+  source-basis:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.11"
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
+        with:
+          version: "0.11.33"
+      - run: uv sync --locked
+      - name: Acquire registered WUP inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p data/raw
+          city_base="https://population.un.org/wup/assets/Download/Cities"
+          for file in \
+            WUP2025-F21-DEGURBA-Cities_Pop.xlsx \
+            WUP2025-F25-DEGURBA-Cities_AREA_km2.xlsx \
+            WUP2025-F30-DEGURBA-Cities_BU_m2_per_capita.xlsx \
+            WUP2025-F34-DEGURBA-Cities_Pop_density.xlsx
+          do
+            curl --fail --location --retry 3 --retry-delay 2 \
+              "$city_base/$file" --output "data/raw/$file"
+          done
+          curl --fail --location --retry 3 --retry-delay 2 \
+            "https://population.un.org/wup/assets/Download/WUP2025-M01-DataSources-Degree-of-Urbanization.xlsx" \
+            --output "data/raw/WUP2025-M01-DataSources-Degree-of-Urbanization.xlsx"
+          grep -E '^[0-9a-f]{64}  ' results/wup_h1_incremental_source_sha256.txt \
+            | sed 's#  #  data/raw/#' \
+            | sha256sum --check --strict -
+          grep -E '^[0-9a-f]{64}  ' results/wup_m01_source_sha256.txt \
+            | sed 's#  #  data/raw/#' \
+            | sha256sum --check --strict -
+      - name: Run source-basis stratification
+        run: uv run --locked python scripts/run_wup_source_basis_h1.py
+      - name: Print metrics
+        run: cat outputs/wup_h1_source_basis_metrics.csv
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: wup-h1-source-basis
+          path: |
+            outputs/wup_h1_source_basis_classification.csv
+            outputs/wup_h1_source_basis_metrics.csv
+            results/wup_h1_incremental_source_sha256.txt
+            results/wup_m01_source_sha256.txt

--- a/data/sources.json
+++ b/data/sources.json
@@ -68,9 +68,15 @@
           "filename": "WUP2025-F34-DEGURBA-Cities_Pop_density.xlsx",
           "url": "https://population.un.org/wup/assets/Download/Cities/WUP2025-F34-DEGURBA-Cities_Pop_density.xlsx",
           "measure": "population_density_per_km2"
+        },
+        {
+          "table": "M01",
+          "filename": "WUP2025-M01-DataSources-Degree-of-Urbanization.xlsx",
+          "url": "https://population.un.org/wup/assets/Download/WUP2025-M01-DataSources-Degree-of-Urbanization.xlsx",
+          "measure": "country_level_ghsl_population_input_metadata"
         }
       ],
-      "notes": "F21 contains cities that reach 50,000 during 1975-2050, but annual values are blank while a city is below 50,000. This is time-varying threshold truncation, not a balanced history and not selection only at 2025. Keep estimates and projections distinct."
+      "notes": "F21 contains cities that reach 50,000 during 1975-2050, but annual values are blank while a city is below 50,000. This is time-varying threshold truncation, not a balanced history and not selection only at 2025. Keep estimates and projections distinct. M01 documents the latest country-level population input used by the underlying GHSL grid; it does not establish direct census lineage for an individual WUP city-year."
     },
     {
       "source_id": "un_wup_2018_cities",

--- a/docs/wup-source-basis-stratification.md
+++ b/docs/wup-source-basis-stratification.md
@@ -1,0 +1,40 @@
+# WUP source-basis stratification contract
+
+WUP 2025 M01 documents the latest population input used by the underlying GHSL
+population grid for each country or area. It records the input year, census/register/estimate
+process type and administrative granularity. It is a country-level construction-input record,
+not a city-year observation register.
+
+Accordingly, the #132 analysis attaches M01 metadata to every evaluated WUP city-origin row
+but records `city_direct_observation_status = unresolved` and
+`city_source_resolution = country_proxy_only`. No M01 census label is converted into a claim
+that a particular WUP city value is a direct census count.
+
+## Recency states
+
+Recency is measured against the forecast origin:
+
+- `post_origin_input`: the M01 input year is later than the historical origin, showing that
+  the current WUP revision backcasts that origin using information unavailable then;
+- `recent_direct_input`: census/register input is zero to ten years before the origin;
+- `stale_direct_input`: census/register input is more than ten years before the origin;
+- `estimate_input`: a non-direct estimate input predates the origin; and
+- `unresolved`: required M01 fields are unavailable.
+
+The signed year distance is retained. A later input is not mislabeled as a negative number of
+“years since census.”
+
+## Estimation
+
+The locked #133 nested comparison is repeated by origin within three documentary
+stratifications: recency state, source process type and input administrative level. The
+baseline is same-origin, same-country leave-city-out peer growth; the augmented model adds
+the focal city's deviation from that signal. Both are scored on identical rows.
+
+Each stratum reports rows, countries, population and population coverage. Row-weighted and
+equal-country fits are separate. A stratum is not backfilled from later data: if no matching
+prior-origin training rows exist, it is retained with
+`evaluation_status = insufficient_prior_stratum_training` and null estimates.
+
+This is a measurement-lineage sensitivity. It cannot identify census age as a causal
+mechanism, and it cannot replace validation against direct locality counts.

--- a/results/wup_m01_source_sha256.txt
+++ b/results/wup_m01_source_sha256.txt
@@ -1,0 +1,1 @@
+7879b00a54223e56f579551b05b0eda613dc0524e7f85c668389234d07073862  WUP2025-M01-DataSources-Degree-of-Urbanization.xlsx

--- a/scripts/run_wup_source_basis_h1.py
+++ b/scripts/run_wup_source_basis_h1.py
@@ -1,0 +1,74 @@
+"""Stratify the WUP H1 re-test by documented country population-input basis."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from urban_growth.adapters.wup import (
+    read_f21_city_population,
+    read_f25_city_land_area,
+    read_f30_built_up_area_per_capita,
+    read_f34_population_density,
+)
+from urban_growth.forecast import build_forecast_intervals
+from urban_growth.wup_lineage import classify_wup_city_population_lineage
+from urban_growth.wup_panel import build_wup_city_year_panel
+from urban_growth.wup_source_basis import (
+    attach_wup_source_basis,
+    evaluate_wup_h1_by_source_basis,
+    read_wup_m01_source_metadata,
+    source_basis_classification_rows,
+)
+
+OBSERVED_PANEL_ORIGINS = list(range(1980, 2020, 5))
+OBSERVED_SCORING_ORIGINS = list(range(1985, 2020, 5))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--raw-dir", type=Path, default=Path("data/raw"))
+    parser.add_argument(
+        "--classification-output",
+        type=Path,
+        default=Path("outputs/wup_h1_source_basis_classification.csv"),
+    )
+    parser.add_argument(
+        "--metrics-output",
+        type=Path,
+        default=Path("outputs/wup_h1_source_basis_metrics.csv"),
+    )
+    args = parser.parse_args()
+
+    raw = args.raw_dir
+    population = classify_wup_city_population_lineage(
+        read_f21_city_population(raw / "WUP2025-F21-DEGURBA-Cities_Pop.xlsx")
+    )
+    city_year = build_wup_city_year_panel(
+        population,
+        read_f25_city_land_area(raw / "WUP2025-F25-DEGURBA-Cities_AREA_km2.xlsx"),
+        read_f30_built_up_area_per_capita(raw / "WUP2025-F30-DEGURBA-Cities_BU_m2_per_capita.xlsx"),
+        read_f34_population_density(raw / "WUP2025-F34-DEGURBA-Cities_Pop_density.xlsx"),
+    )
+    intervals = build_forecast_intervals(city_year, OBSERVED_PANEL_ORIGINS)
+    metadata = read_wup_m01_source_metadata(
+        raw / "WUP2025-M01-DataSources-Degree-of-Urbanization.xlsx"
+    )
+    classified = attach_wup_source_basis(intervals, metadata)
+    scoring = classified.loc[classified["period_start"].isin(OBSERVED_SCORING_ORIGINS)].copy()
+    classification = source_basis_classification_rows(scoring)
+    metrics = evaluate_wup_h1_by_source_basis(
+        classified,
+        OBSERVED_SCORING_ORIGINS,
+    )
+    for path, frame in [
+        (args.classification_output, classification),
+        (args.metrics_output, metrics),
+    ]:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        frame.to_csv(path, index=False)
+        print(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/urban_growth/repository_governance.py
+++ b/src/urban_growth/repository_governance.py
@@ -12,6 +12,7 @@ EMPIRICAL_WORKFLOWS = {
     "ghsl-redteam-130.yml",
     "wup-contemporaneous-country.yml",
     "wup-h1-empirical.yml",
+    "wup-source-basis-h1.yml",
 }
 PROHIBITED_RELIABILITY_PATTERNS = {
     "legacy classifier entry point": "scripts/classify_reliability.py",
@@ -47,10 +48,7 @@ def governance_errors(root: Path = ROOT) -> list[str]:
     for label, pattern in PROHIBITED_RELIABILITY_PATTERNS.items():
         for directory in searchable:
             for path in directory.rglob("*"):
-                if (
-                    path.is_file()
-                    and pattern in path.read_text(encoding="utf-8", errors="ignore")
-                ):
+                if path.is_file() and pattern in path.read_text(encoding="utf-8", errors="ignore"):
                     errors.append(f"{path.relative_to(root)} contains prohibited {label}")
     return errors
 

--- a/src/urban_growth/wup_source_basis.py
+++ b/src/urban_growth/wup_source_basis.py
@@ -1,0 +1,281 @@
+"""WUP H1 robustness checks by documented population-input source basis."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from urban_growth.contemporaneous_baseline import (
+    attach_contemporaneous_country_recent_growth,
+)
+from urban_growth.forecast import rolling_origin_splits
+from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
+
+M01_REQUIRED = {
+    "ISO3_Code",
+    "Location",
+    "DataProcessType",
+    "DataProcess",
+    "DataStatusName",
+    "Input_Pop_year",
+    "Input_Pop_level",
+    "Input_Pop_source",
+}
+
+
+def read_wup_m01_source_metadata(path: str) -> pd.DataFrame:
+    """Read the WUP M01 country-level GHSL population-input metadata."""
+    frame = pd.read_excel(path, sheet_name="Input_Metadata")
+    require_columns(frame, M01_REQUIRED, source_name="WUP 2025 M01")
+    selected = frame[list(M01_REQUIRED)].rename(
+        columns={
+            "ISO3_Code": "country_code",
+            "Location": "source_country_name",
+            "DataProcessType": "source_process_type",
+            "DataProcess": "source_process",
+            "DataStatusName": "source_status",
+            "Input_Pop_year": "source_population_year",
+            "Input_Pop_level": "source_admin_level",
+            "Input_Pop_source": "source_citation",
+        }
+    )
+    reject_duplicate_keys(selected, ["country_code"], source_name="WUP 2025 M01")
+    if selected["country_code"].isna().any():
+        raise SourceSchemaError("WUP M01 country codes must be complete")
+    selected["source_population_year"] = pd.to_numeric(
+        selected["source_population_year"], errors="coerce"
+    ).astype("Int64")
+    selected["source_admin_level"] = pd.to_numeric(
+        selected["source_admin_level"], errors="coerce"
+    ).astype("Int64")
+    allowed = {"Census", "Register", "Estimate"}
+    unknown = sorted(set(selected["source_process_type"].dropna()) - allowed)
+    if unknown:
+        raise SourceSchemaError(f"Unknown WUP M01 process types: {', '.join(unknown)}")
+    return selected
+
+
+def attach_wup_source_basis(
+    intervals: pd.DataFrame,
+    metadata: pd.DataFrame,
+) -> pd.DataFrame:
+    """Attach country-input lineage while leaving city-level basis unresolved."""
+    require_columns(
+        intervals,
+        {"city_id", "country_code", "period_start"},
+        source_name="WUP source-basis intervals",
+    )
+    require_columns(
+        metadata,
+        {
+            "country_code",
+            "source_process_type",
+            "source_population_year",
+            "source_admin_level",
+        },
+        source_name="WUP M01 normalized metadata",
+    )
+    reject_duplicate_keys(metadata, ["country_code"], source_name="WUP M01 metadata")
+    result = intervals.merge(metadata, on="country_code", how="left", validate="many_to_one")
+    resolved = result["source_population_year"].notna() & result["source_process_type"].notna()
+    result["country_input_resolution"] = np.where(resolved, "resolved", "unresolved")
+    result["city_source_resolution"] = np.where(resolved, "country_proxy_only", "unresolved")
+    result["city_direct_observation_status"] = "unresolved"
+    result["source_population_year_distance"] = (
+        result["period_start"] - result["source_population_year"]
+    ).astype("Int64")
+    result["source_granularity"] = result["source_admin_level"].map(
+        lambda value: f"admin_{int(value)}" if pd.notna(value) else "unresolved"
+    )
+
+    process = result["source_process_type"].astype("string").str.lower()
+    distance = result["source_population_year_distance"]
+    result["source_process_stratum"] = process.fillna("unresolved")
+    result["source_recency_stratum"] = "unresolved"
+    result.loc[resolved & distance.lt(0), "source_recency_stratum"] = "post_origin_input"
+    direct = process.isin(["census", "register"])
+    result.loc[resolved & distance.ge(0) & direct & distance.le(10), "source_recency_stratum"] = (
+        "recent_direct_input"
+    )
+    result.loc[resolved & distance.gt(10) & direct, "source_recency_stratum"] = "stale_direct_input"
+    result.loc[resolved & distance.ge(0) & ~direct, "source_recency_stratum"] = "estimate_input"
+    return result
+
+
+def source_basis_classification_rows(intervals: pd.DataFrame) -> pd.DataFrame:
+    """Return one explicit source-basis classification per evaluated city-origin row."""
+    columns = [
+        "city_id",
+        "country_code",
+        "period_start",
+        "period_end",
+        "source_process_type",
+        "source_population_year",
+        "source_admin_level",
+        "source_population_year_distance",
+        "source_process_stratum",
+        "source_recency_stratum",
+        "source_granularity",
+        "country_input_resolution",
+        "city_source_resolution",
+        "city_direct_observation_status",
+    ]
+    require_columns(intervals, set(columns), source_name="WUP classified H1 rows")
+    result = intervals[columns].copy()
+    reject_duplicate_keys(
+        result,
+        ["city_id", "period_start", "period_end"],
+        source_name="WUP source-basis classification rows",
+    )
+    return result.sort_values(["period_start", "country_code", "city_id"]).reset_index(drop=True)
+
+
+def _slope(x: pd.Series, y: pd.Series, country: pd.Series, weighting: str) -> float:
+    if weighting == "country_balanced":
+        weights = 1.0 / country.groupby(country).transform("size")
+    else:
+        weights = pd.Series(1.0, index=x.index)
+    denominator = float(np.sum(weights * x.pow(2)))
+    if denominator <= 0:
+        return np.nan
+    return float(np.sum(weights * x * y) / denominator)
+
+
+def _losses(
+    actual: pd.Series,
+    predicted: pd.Series,
+    country: pd.Series,
+    weighting: str,
+) -> tuple[float, float]:
+    error = predicted.to_numpy() - actual.to_numpy()
+    frame = pd.DataFrame({"country": country.to_numpy(), "error": error})
+    if weighting == "row_weighted":
+        return float(np.abs(error).mean()), float(np.sqrt(np.square(error).mean()))
+    country_loss = (
+        frame.assign(
+            absolute_error=lambda value: value["error"].abs(),
+            squared_error=lambda value: value["error"].pow(2),
+        )
+        .groupby("country")[["absolute_error", "squared_error"]]
+        .mean()
+    )
+    return float(country_loss["absolute_error"].mean()), float(
+        np.sqrt(country_loss["squared_error"].mean())
+    )
+
+
+def evaluate_wup_h1_by_source_basis(
+    classified_intervals: pd.DataFrame,
+    origins: list[int],
+    *,
+    outcome_column: str = "future_growth",
+) -> pd.DataFrame:
+    """Evaluate the nested contemporaneous H1 model within source-basis strata."""
+    working = attach_contemporaneous_country_recent_growth(classified_intervals)
+    peer = "country_contemporaneous_recent_growth_leave_city_out"
+    required = {
+        "city_id",
+        "country_code",
+        "period_start",
+        "period_end",
+        "population_start",
+        "recent_growth",
+        outcome_column,
+        peer,
+        "source_recency_stratum",
+        "source_process_stratum",
+        "source_granularity",
+    }
+    require_columns(working, required, source_name="WUP source-basis H1 panel")
+    if not origins or len(origins) != len(set(origins)):
+        raise SourceSchemaError("WUP source-basis origins must be unique and non-empty")
+
+    rows: list[dict[str, object]] = []
+    stratifications = {
+        "recency": "source_recency_stratum",
+        "process_type": "source_process_stratum",
+        "admin_level": "source_granularity",
+    }
+    for origin, train_index, test_index in rolling_origin_splits(working, sorted(origins)):
+        origin_train = working.loc[train_index].copy()
+        origin_test = working.loc[test_index].copy()
+        finite = ["recent_growth", peer, outcome_column, "population_start"]
+        origin_train = origin_train.loc[np.isfinite(origin_train[finite]).all(axis=1)]
+        origin_test = origin_test.loc[np.isfinite(origin_test[finite]).all(axis=1)]
+        total_population = float(origin_test["population_start"].sum())
+        for stratification, column in stratifications.items():
+            for stratum, test in origin_test.groupby(column, dropna=False, sort=True):
+                train = origin_train.loc[origin_train[column].eq(stratum)].copy()
+                for weighting in ["row_weighted", "country_balanced"]:
+                    common = {
+                        "origin": int(origin),
+                        "stratification": stratification,
+                        "stratum": str(stratum),
+                        "weighting": weighting,
+                        "n": len(test),
+                        "country_count": int(test["country_code"].nunique()),
+                        "population": float(test["population_start"].sum()),
+                        "population_coverage_fraction": (
+                            float(test["population_start"].sum()) / total_population
+                            if total_population > 0
+                            else np.nan
+                        ),
+                        "matched_train_n": len(train),
+                        "training_precedes_origin": True,
+                        "test_rows_identical": True,
+                        "city_direct_observation_status": "unresolved",
+                        "source_scope": "country_input_proxy",
+                    }
+                    if train.empty:
+                        rows.append(
+                            {
+                                **common,
+                                "evaluation_status": "insufficient_prior_stratum_training",
+                                "beta": np.nan,
+                                "baseline_mae": np.nan,
+                                "augmented_mae": np.nan,
+                                "mae_delta_augmented_minus_baseline": np.nan,
+                                "baseline_rmse": np.nan,
+                                "augmented_rmse": np.nan,
+                                "rmse_delta_augmented_minus_baseline": np.nan,
+                                "augmented_improves_mae": pd.NA,
+                                "augmented_improves_rmse": pd.NA,
+                            }
+                        )
+                        continue
+                    train_x = train["recent_growth"] - train[peer]
+                    train_y = train[outcome_column] - train[peer]
+                    test_x = test["recent_growth"] - test[peer]
+                    beta = _slope(train_x, train_y, train["country_code"], weighting)
+                    if not np.isfinite(beta):
+                        continue
+                    baseline = test[peer]
+                    augmented = baseline + beta * test_x
+                    baseline_mae, baseline_rmse = _losses(
+                        test[outcome_column], baseline, test["country_code"], weighting
+                    )
+                    augmented_mae, augmented_rmse = _losses(
+                        test[outcome_column], augmented, test["country_code"], weighting
+                    )
+                    rows.append(
+                        {
+                            **common,
+                            "evaluation_status": "evaluated",
+                            "beta": beta,
+                            "baseline_mae": baseline_mae,
+                            "augmented_mae": augmented_mae,
+                            "mae_delta_augmented_minus_baseline": (augmented_mae - baseline_mae),
+                            "baseline_rmse": baseline_rmse,
+                            "augmented_rmse": augmented_rmse,
+                            "rmse_delta_augmented_minus_baseline": (augmented_rmse - baseline_rmse),
+                            "augmented_improves_mae": augmented_mae < baseline_mae,
+                            "augmented_improves_rmse": augmented_rmse < baseline_rmse,
+                        }
+                    )
+    if not rows:
+        raise SourceSchemaError("No WUP source-basis H1 evaluations were produced")
+    return (
+        pd.DataFrame(rows)
+        .sort_values(["origin", "stratification", "stratum", "weighting"])
+        .reset_index(drop=True)
+    )

--- a/tests/test_wup_source_basis.py
+++ b/tests/test_wup_source_basis.py
@@ -1,0 +1,102 @@
+from pathlib import Path
+
+import pandas as pd
+
+from urban_growth.wup_source_basis import (
+    attach_wup_source_basis,
+    evaluate_wup_h1_by_source_basis,
+    read_wup_m01_source_metadata,
+    source_basis_classification_rows,
+)
+
+
+def _intervals() -> pd.DataFrame:
+    rows = []
+    for origin in [1990, 1995, 2000]:
+        for city_id, country, recent in [
+            (1, "A", 0.01),
+            (2, "A", 0.03),
+            (3, "B", 0.02),
+            (4, "B", 0.04),
+            (5, "C", 0.025),
+        ]:
+            rows.append(
+                {
+                    "city_id": city_id,
+                    "country_code": country,
+                    "period_start": origin,
+                    "period_end": origin + 5,
+                    "population_start": 100_000 + city_id * 10_000,
+                    "recent_growth": recent,
+                    "future_growth": 0.5 * recent + (0.002 if country == "A" else 0.004),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _metadata() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "country_code": ["A", "B"],
+            "source_process_type": ["Census", "Estimate"],
+            "source_population_year": pd.Series([1990, 1988], dtype="Int64"),
+            "source_admin_level": pd.Series([2, 3], dtype="Int64"),
+        }
+    )
+
+
+def test_attach_source_basis_preserves_country_proxy_limit() -> None:
+    result = attach_wup_source_basis(_intervals(), _metadata())
+    test = result.loc[result["period_start"].eq(2000)].set_index("country_code")
+    assert test.loc["A", "source_recency_stratum"].iloc[0] == "recent_direct_input"
+    assert test.loc["B", "source_recency_stratum"].iloc[0] == "estimate_input"
+    assert test.loc["C", "source_recency_stratum"] == "unresolved"
+    assert result["city_direct_observation_status"].eq("unresolved").all()
+    assert (
+        result.loc[result["country_code"].eq("A"), "city_source_resolution"]
+        .eq("country_proxy_only")
+        .all()
+    )
+
+
+def test_source_basis_rows_are_explicit_and_unique() -> None:
+    classified = attach_wup_source_basis(_intervals(), _metadata())
+    rows = source_basis_classification_rows(classified)
+    assert len(rows) == len(classified)
+    assert not rows.duplicated(["city_id", "period_start", "period_end"]).any()
+    assert rows["city_direct_observation_status"].notna().all()
+
+
+def test_source_basis_h1_reports_strata_and_country_balancing() -> None:
+    classified = attach_wup_source_basis(_intervals(), _metadata())
+    result = evaluate_wup_h1_by_source_basis(classified, [2000])
+    assert set(result["weighting"]) == {"row_weighted", "country_balanced"}
+    assert set(result["stratification"]) == {
+        "recency",
+        "process_type",
+        "admin_level",
+    }
+    assert result["test_rows_identical"].all()
+    assert result["training_precedes_origin"].all()
+    assert result["city_direct_observation_status"].eq("unresolved").all()
+    assert result["population_coverage_fraction"].between(0, 1).all()
+
+
+def test_read_m01_normalizes_registered_fields(tmp_path: Path) -> None:
+    path = tmp_path / "m01.xlsx"
+    frame = pd.DataFrame(
+        {
+            "ISO3_Code": ["AAA"],
+            "Location": ["Alpha"],
+            "DataProcessType": ["Census"],
+            "DataProcess": ["Population and Housing Census"],
+            "DataStatusName": ["Final"],
+            "Input_Pop_year": [2010],
+            "Input_Pop_level": [2],
+            "Input_Pop_source": ["Official census"],
+        }
+    )
+    frame.to_excel(path, sheet_name="Input_Metadata", index=False)
+    result = read_wup_m01_source_metadata(str(path))
+    assert result.loc[0, "country_code"] == "AAA"
+    assert result.loc[0, "source_population_year"] == 2010


### PR DESCRIPTION
Implements the estimator and workflow portion of #132 without overstating M01 metadata.

- classifies every evaluated city-origin row using registered WUP M01 country-input metadata
- preserves city-level direct-observation status as `unresolved`, because M01 does not identify direct city counts
- distinguishes post-origin inputs, recent/stale direct inputs, estimates, and unresolved states
- re-estimates the locked #133 nested model by recency, process type, and administrative granularity
- reports row-weighted and equal-country results, counts, countries, population coverage, and explicit insufficient-training states
- registers and hash-verifies M01 alongside the existing WUP inputs

Verification: Ruff passed; 335 tests passed; full local empirical run classified 56,510 rows.

The issue remains open until the official workflow output is committed, registered, and interpreted.