### PR TITLE
Implement direct-count construction-smoothing gate

### DIFF
--- a/.github/workflows/construction-smoothing-124.yml
+++ b/.github/workflows/construction-smoothing-124.yml
@@ -1,0 +1,32 @@
+name: GHSL direct-count construction-smoothing gate
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/construction-smoothing-124.yml"
+      - "scripts/run_construction_smoothing_124.py"
+      - "src/urban_growth/construction_smoothing.py"
+      - "tests/test_construction_smoothing.py"
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark-gate:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.11"
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d
+        with:
+          version: "0.11.33"
+      - run: uv sync --locked --extra dev
+      - run: uv run --locked --extra dev pytest tests/test_construction_smoothing.py
+      - run: uv run --locked python scripts/run_construction_smoothing_124.py
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: construction-smoothing-124-status
+          path: outputs/construction_smoothing_124/benchmark_status.csv

--- a/docs/ghsl-direct-count-construction-smoothing.md
+++ b/docs/ghsl-direct-count-construction-smoothing.md
@@ -1,0 +1,31 @@
+# GHSL construction smoothing against direct locality counts
+
+Issue #124 is implemented as a matched, fail-closed red-team benchmark. It does not
+promote GHSL to independent confirmation of H1.
+
+The comparison fixes each national origin denominator before concordance or endpoint
+eligibility is evaluated. Unresolved localities remain in the coverage output. Only
+locality-period rows eligible in both the direct-count and GHSL streams enter the paired
+diagnostics, so future entrants cannot define membership.
+
+For the identical matched rows, the benchmark reports recent/future OLS coefficients,
+persistence and zero-growth MAE/RMSE, improvement over zero growth, sign reversals, and
+signed and absolute growth curvature. Results are stratified by official concordance
+quality, census recency, and GHSL boundary mode. The contrast table is always expressed
+as GHSL minus direct counts.
+
+## U.S. pilot decision
+
+The registered U.S. Census place pilot contains direct enumerations for 2010 and 2020.
+Those two waves yield one growth interval, not a recent-growth predictor followed by a
+future-growth outcome. The repository's persistence gate requires at least two matched
+forecast origins. The current U.S. benchmark is therefore **not estimable** and remains
+unresolved pending a third direct-count wave plus defensible official adjacent-wave
+concordances.
+
+`scripts/run_construction_smoothing_124.py` writes this decision to
+`outputs/construction_smoothing_124/benchmark_status.csv`. If registered direct-count
+and GHSL interval files are supplied later, the same runner produces denominator
+coverage, matched source metrics, and GHSL-minus-direct contrasts. Similarity would
+weaken the smoothing explanation but would not prove construction effects absent;
+materially stronger GHSL persistence would be evidence consistent with smoothing.

--- a/scripts/run_construction_smoothing_124.py
+++ b/scripts/run_construction_smoothing_124.py
@@ -1,0 +1,50 @@
+"""Run or fail closed on the direct-count/GHSL construction-smoothing benchmark."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from urban_growth.construction_smoothing import compare_direct_counts_with_ghsl
+from urban_growth.io import SourceSchemaError
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--direct-input", type=Path)
+    parser.add_argument("--ghsl-input", type=Path)
+    parser.add_argument("--output-dir", type=Path, default=Path("outputs/construction_smoothing_124"))
+    args = parser.parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    status = {
+        "issue": 124,
+        "pilot": "US Census places",
+        "registered_direct_count_waves": "2010;2020",
+        "registered_direct_count_intervals": 1,
+        "minimum_forecast_origins_required": 2,
+        "benchmark_estimable": False,
+        "h1_independent_confirmation": False,
+        "decision": "unresolved_pending_third_direct_count_wave_and_official_concordance",
+    }
+    if args.direct_input and args.ghsl_input:
+        try:
+            coverage, metrics, contrasts = compare_direct_counts_with_ghsl(
+                pd.read_csv(args.direct_input), pd.read_csv(args.ghsl_input)
+            )
+        except SourceSchemaError as exc:
+            status["decision"] = str(exc)
+        else:
+            coverage.to_csv(args.output_dir / "denominator_coverage.csv", index=False)
+            metrics.to_csv(args.output_dir / "matched_source_metrics.csv", index=False)
+            contrasts.to_csv(args.output_dir / "ghsl_minus_direct_contrasts.csv", index=False)
+            status["benchmark_estimable"] = True
+            status["decision"] = "interpret_registered_contrasts"
+    pd.DataFrame([status]).to_csv(args.output_dir / "benchmark_status.csv", index=False)
+    print(pd.DataFrame([status]).to_csv(index=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/urban_growth/construction_smoothing.py
+++ b/src/urban_growth/construction_smoothing.py
@@ -1,0 +1,175 @@
+"""Matched direct-count/GHSL diagnostics for the construction-smoothing red team."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
+
+KEYS = ["country_code", "locality_id", "period_start"]
+REQUIRED = {
+    *KEYS,
+    "source",
+    "recent_growth",
+    "future_growth",
+    "analysis_eligible",
+    "concordance_quality",
+    "census_recency_years",
+    "boundary_mode",
+}
+
+
+def _validate(frame: pd.DataFrame, source: str) -> pd.DataFrame:
+    require_columns(frame, REQUIRED, source_name=source)
+    reject_duplicate_keys(frame, KEYS, source_name=source)
+    out = frame.copy()
+    if out["source"].nunique() != 1:
+        raise SourceSchemaError(f"{source} must contain exactly one source label")
+    for column in ["recent_growth", "future_growth", "census_recency_years"]:
+        out[column] = pd.to_numeric(out[column], errors="coerce")
+    if out["analysis_eligible"].isna().any():
+        raise SourceSchemaError(f"{source} has unknown analysis eligibility")
+    out["analysis_eligible"] = out["analysis_eligible"].astype(bool)
+    return out
+
+
+def _metrics(values: pd.DataFrame) -> dict[str, float | int]:
+    x = values["recent_growth"].to_numpy(dtype=float)
+    y = values["future_growth"].to_numpy(dtype=float)
+    design = np.column_stack([np.ones(len(x)), x])
+    intercept, beta = np.linalg.lstsq(design, y, rcond=None)[0]
+    persistence_error = y - x
+    zero_error = y
+    curvature = y - x
+    return {
+        "matched_analysis_rows": len(values),
+        "persistence_intercept": float(intercept),
+        "persistence_beta": float(beta),
+        "persistence_mae": float(np.mean(np.abs(persistence_error))),
+        "persistence_rmse": float(np.sqrt(np.mean(persistence_error**2))),
+        "zero_growth_mae": float(np.mean(np.abs(zero_error))),
+        "zero_growth_rmse": float(np.sqrt(np.mean(zero_error**2))),
+        "mae_improvement_vs_zero": float(
+            np.mean(np.abs(zero_error)) - np.mean(np.abs(persistence_error))
+        ),
+        "rmse_improvement_vs_zero": float(
+            np.sqrt(np.mean(zero_error**2)) - np.sqrt(np.mean(persistence_error**2))
+        ),
+        "sign_reversal_rate": float(np.mean(np.sign(x) != np.sign(y))),
+        "mean_growth_curvature": float(np.mean(curvature)),
+        "mean_absolute_growth_curvature": float(np.mean(np.abs(curvature))),
+    }
+
+
+def compare_direct_counts_with_ghsl(
+    direct: pd.DataFrame,
+    ghsl: pd.DataFrame,
+    *,
+    minimum_periods: int = 2,
+) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Return denominator coverage, source diagnostics, and GHSL-minus-direct contrasts.
+
+    Matching is performed only after each supplied origin denominator is retained. A
+    locality-period enters diagnostics only when both sources are eligible and finite.
+    At least two distinct forecast origins are required; a two-wave census pilot has
+    only one growth interval and cannot identify recent-to-future persistence.
+    """
+    if minimum_periods < 2:
+        raise SourceSchemaError("Construction-smoothing comparison requires at least two origins")
+    direct = _validate(direct, "direct-count origin denominator")
+    ghsl = _validate(ghsl, "GHSL origin denominator")
+    if not direct["source"].eq("direct_count").all():
+        raise SourceSchemaError("Direct-count rows must use source=direct_count")
+    if ghsl["source"].eq("direct_count").any():
+        raise SourceSchemaError("GHSL rows cannot use the direct-count source label")
+
+    coverage_rows: list[dict[str, object]] = []
+    for frame in [direct, ghsl]:
+        for (source, boundary), group in frame.groupby(["source", "boundary_mode"], dropna=False):
+            eligible = group["analysis_eligible"]
+            coverage_rows.append(
+                {
+                    "source": source,
+                    "boundary_mode": boundary,
+                    "origin_denominator_rows": len(group),
+                    "analysis_eligible_rows": int(eligible.sum()),
+                    "unresolved_rows": int((~eligible).sum()),
+                    "analysis_coverage": float(eligible.mean()),
+                    "denominator_defined_before_concordance": True,
+                }
+            )
+    coverage = pd.DataFrame(coverage_rows)
+
+    direct_columns = KEYS + [
+        "recent_growth", "future_growth", "analysis_eligible", "concordance_quality",
+        "census_recency_years",
+    ]
+    direct_match = direct[direct_columns].rename(
+        columns={column: f"direct_{column}" for column in direct_columns if column not in KEYS}
+    )
+    matched_parts: list[pd.DataFrame] = []
+    for (source, boundary), group in ghsl.groupby(["source", "boundary_mode"], dropna=False):
+        joined = direct_match.merge(group, on=KEYS, how="inner", validate="one_to_one")
+        usable = (
+            joined["direct_analysis_eligible"]
+            & joined["analysis_eligible"]
+            & joined[["direct_recent_growth", "direct_future_growth", "recent_growth", "future_growth"]]
+            .notna().all(axis=1)
+        )
+        joined = joined.loc[usable].copy()
+        joined["ghsl_source"] = source
+        joined["ghsl_boundary_mode"] = boundary
+        matched_parts.append(joined)
+    matched = pd.concat(matched_parts, ignore_index=True) if matched_parts else pd.DataFrame()
+    if matched.empty or matched["period_start"].nunique() < minimum_periods:
+        periods = 0 if matched.empty else int(matched["period_start"].nunique())
+        raise SourceSchemaError(
+            f"Direct-count benchmark is not estimable: {periods} matched forecast origins; "
+            f"at least {minimum_periods} are required"
+        )
+
+    diagnostics: list[dict[str, object]] = []
+    strata = [([], "overall")]
+    for column in ["direct_concordance_quality", "direct_census_recency_years"]:
+        strata.append(([column], column.removeprefix("direct_")))
+    for (ghsl_source, boundary), source_rows in matched.groupby(
+        ["ghsl_source", "ghsl_boundary_mode"], dropna=False
+    ):
+        for group_columns, stratum_name in strata:
+            groups = [((), source_rows)] if not group_columns else source_rows.groupby(group_columns, dropna=False)
+            for key, group in groups:
+                key = key if isinstance(key, tuple) else (key,)
+                for label, recent, future in [
+                    ("direct_count", "direct_recent_growth", "direct_future_growth"),
+                    (str(ghsl_source), "recent_growth", "future_growth"),
+                ]:
+                    values = group[[recent, future]].rename(
+                        columns={recent: "recent_growth", future: "future_growth"}
+                    )
+                    row: dict[str, object] = {
+                        "ghsl_source": ghsl_source,
+                        "boundary_mode": boundary,
+                        "stratum": stratum_name,
+                        "stratum_value": "overall" if not key else str(key[0]),
+                        "measured_source": label,
+                    }
+                    row.update(_metrics(values))
+                    diagnostics.append(row)
+    metrics = pd.DataFrame(diagnostics)
+    index = ["ghsl_source", "boundary_mode", "stratum", "stratum_value"]
+    direct_metrics = metrics.loc[metrics["measured_source"].eq("direct_count")].set_index(index)
+    ghsl_metrics = metrics.loc[~metrics["measured_source"].eq("direct_count")].set_index(index)
+    contrast_columns = [
+        "persistence_beta", "mae_improvement_vs_zero", "rmse_improvement_vs_zero",
+        "sign_reversal_rate", "mean_growth_curvature", "mean_absolute_growth_curvature",
+    ]
+    contrasts = ghsl_metrics[contrast_columns].subtract(direct_metrics[contrast_columns])
+    contrasts = contrasts.add_suffix("_ghsl_minus_direct").reset_index()
+    contrasts["construction_smoothing_interpretation"] = np.where(
+        (contrasts["persistence_beta_ghsl_minus_direct"] > 0)
+        & (contrasts["sign_reversal_rate_ghsl_minus_direct"] < 0),
+        "consistent_with_stronger_ghsl_persistence",
+        "no_materially_stronger_ghsl_pattern_established",
+    )
+    return coverage, metrics, contrasts

--- a/tests/test_construction_smoothing.py
+++ b/tests/test_construction_smoothing.py
@@ -1,0 +1,46 @@
+import pandas as pd
+import pytest
+
+from urban_growth.construction_smoothing import compare_direct_counts_with_ghsl
+from urban_growth.io import SourceSchemaError
+
+
+def panel(source: str, boundary: str, scale: float = 1.0) -> pd.DataFrame:
+    rows = []
+    for origin, pairs in [(2000, [(0.01, 0.02), (0.03, -0.01)]), (2010, [(0.02, 0.03), (-0.01, -0.02)])]:
+        for index, (recent, future) in enumerate(pairs):
+            rows.append({
+                "country_code": "USA", "locality_id": f"p{index}", "period_start": origin,
+                "source": source, "recent_growth": recent * scale, "future_growth": future * scale,
+                "analysis_eligible": not (origin == 2000 and index == 1),
+                "concordance_quality": "official_one_to_one", "census_recency_years": 0,
+                "boundary_mode": boundary,
+            })
+    return pd.DataFrame(rows)
+
+
+def test_comparison_preserves_denominators_and_produces_required_contrasts() -> None:
+    coverage, metrics, contrasts = compare_direct_counts_with_ghsl(
+        panel("direct_count", "official_dynamic"), panel("ghsl_fixed", "fixed_2025", 0.8)
+    )
+    direct_coverage = coverage.loc[coverage["source"].eq("direct_count")].iloc[0]
+    assert direct_coverage["origin_denominator_rows"] == 4
+    assert direct_coverage["unresolved_rows"] == 1
+    assert {"persistence_beta", "persistence_mae", "sign_reversal_rate", "mean_growth_curvature"} <= set(metrics)
+    assert "persistence_beta_ghsl_minus_direct" in contrasts
+
+
+def test_single_origin_fails_closed() -> None:
+    direct = panel("direct_count", "official_dynamic").query("period_start == 2010")
+    ghsl = panel("ghsl_fixed", "fixed_2025").query("period_start == 2010")
+    with pytest.raises(SourceSchemaError, match="1 matched forecast origins"):
+        compare_direct_counts_with_ghsl(direct, ghsl)
+
+
+def test_future_only_entrant_cannot_expand_direct_denominator() -> None:
+    direct = panel("direct_count", "official_dynamic")
+    ghsl = panel("ghsl_fixed", "fixed_2025")
+    entrant = ghsl.iloc[[0]].assign(locality_id="future-entrant")
+    coverage, metrics, _ = compare_direct_counts_with_ghsl(direct, pd.concat([ghsl, entrant]))
+    assert coverage.loc[coverage["source"].eq("ghsl_fixed"), "origin_denominator_rows"].iloc[0] == 5
+    assert metrics["matched_analysis_rows"].max() == 3


### PR DESCRIPTION
Implements the matched GHSL/direct-count red-team contract for #124.

- preserves origin denominators and reports unresolved rows
- computes matched coefficients, MAE/RMSE improvements, sign reversals, and curvature
- stratifies by concordance quality, census recency, and GHSL boundary mode
- fails closed when fewer than two matched forecast origins exist
- records the current two-wave U.S. pilot as not estimable and not independent H1 confirmation

Local verification: 339 tests passed; ruff passed.

Refs #124.