### PR TITLE
Add India qualification gate for issue 124

### DIFF
--- a/.github/workflows/construction-smoothing-124.yml
+++ b/.github/workflows/construction-smoothing-124.yml
@@ -7,7 +7,9 @@ on:
       - ".github/workflows/construction-smoothing-124.yml"
       - "scripts/run_construction_smoothing_124.py"
       - "src/urban_growth/construction_smoothing.py"
+      - "src/urban_growth/india_census_124.py"
       - "tests/test_construction_smoothing.py"
+      - "tests/test_india_census_124.py"
 
 permissions:
   contents: read
@@ -24,9 +26,20 @@ jobs:
         with:
           version: "0.11.33"
       - run: uv sync --locked --extra dev
-      - run: uv run --locked --extra dev pytest tests/test_construction_smoothing.py
+      - run: >-
+          uv run --locked --extra dev pytest
+          tests/test_construction_smoothing.py tests/test_india_census_124.py
       - run: uv run --locked python scripts/run_construction_smoothing_124.py
+      - run: uv run --locked python scripts/run_construction_smoothing_124.py --pilot india
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: construction-smoothing-124-status
           path: outputs/construction_smoothing_124/benchmark_status.csv
+          if-no-files-found: error
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: construction-smoothing-124-india-status
+          path: |
+            outputs/construction_smoothing_124/india_source_qualification.csv
+            outputs/construction_smoothing_124/india_benchmark_status.csv
+          if-no-files-found: error

--- a/docs/india-direct-count-validation-124.md
+++ b/docs/india-direct-count-validation-124.md
@@ -1,0 +1,48 @@
+# India direct-count qualification for issue #124
+
+India is scientifically relevant because it is both a large share of the WUP evaluation
+sample and materially influential in the 2020 persistence failure. It is not currently an
+identified direct-count validation panel.
+
+## Official-source assessment
+
+The Census of India catalog publishes 2011 A-04 population-class tables with historical
+town/urban-agglomeration populations for 1981, 1991, 2001, and 2011. Those four columns do
+not by themselves create an origin-valid panel. The table is classified using the 2011
+town and size-class frame. Treating its historical rows as the 1981 or 1991 denominator
+would select on later urban status, survival, and size—the exact denominator error this
+repository prohibits.
+
+The 2001 and 2011 Primary Census Abstract and Location Code Directory materials can
+support a historical transition and concordance-coverage audit. They provide only one
+transition, however, so they cannot supply recent growth followed by future growth. That
+exercise is permitted as historical data-quality work but cannot close #124 or independently
+confirm H1.
+
+Original 1981, 1991, 2001, and 2011 state town directories could eventually support two
+forecast origins if origin cohorts are reconstructed separately. The binding missing input
+is a registered, defensible official adjacent-wave concordance covering new towns,
+declassifications, splits, mergers, name changes, and boundary changes. Name matching is not
+an acceptable substitute.
+
+India's next population census has a March 1, 2027 reference date (October 1, 2026 for
+specified snow-bound areas). Locality outputs and crosswave concordances have not been
+released, so Census 2027 is a future validation path rather than current evidence.
+
+## Machine-readable decision
+
+Run:
+
+```bash
+uv run --locked python scripts/run_construction_smoothing_124.py --pilot india
+```
+
+The runner writes `india_source_qualification.csv` and `india_benchmark_status.csv`.
+The current decision is
+`unresolved_no_origin_valid_multiwave_concorded_town_panel`, with both
+`benchmark_estimable` and `h1_independent_confirmation` false.
+
+The next useful action is not to regress the A-04 historical columns. It is to inventory and
+digitize original town universes by wave, then quantify official concordance coverage against
+each origin denominator. If that coverage cannot be made defensible, India should remain a
+historical transition sensitivity and not be presented as validation.

--- a/scripts/run_construction_smoothing_124.py
+++ b/scripts/run_construction_smoothing_124.py
@@ -8,6 +8,10 @@ from pathlib import Path
 import pandas as pd
 
 from urban_growth.construction_smoothing import compare_direct_counts_with_ghsl
+from urban_growth.india_census_124 import (
+    india_issue_124_source_register,
+    qualify_india_issue_124_sources,
+)
 from urban_growth.io import SourceSchemaError
 
 
@@ -15,9 +19,17 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--direct-input", type=Path)
     parser.add_argument("--ghsl-input", type=Path)
+    parser.add_argument("--pilot", choices=["us", "india"], default="us")
     parser.add_argument("--output-dir", type=Path, default=Path("outputs/construction_smoothing_124"))
     args = parser.parse_args()
     args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.pilot == "india":
+        register, status = qualify_india_issue_124_sources(india_issue_124_source_register())
+        register.to_csv(args.output_dir / "india_source_qualification.csv", index=False)
+        status.to_csv(args.output_dir / "india_benchmark_status.csv", index=False)
+        print(status.to_csv(index=False))
+        return
 
     status = {
         "issue": 124,

--- a/src/urban_growth/india_census_124.py
+++ b/src/urban_growth/india_census_124.py
@@ -1,0 +1,165 @@
+"""Qualification gate for an India direct-count benchmark under issue #124."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
+
+REQUIRED = {
+    "candidate_id",
+    "official_source",
+    "waves",
+    "direct_locality_counts",
+    "origin_denominator_available",
+    "future_membership_conditioned",
+    "official_adjacent_wave_concordance",
+    "usable_forecast_origins",
+    "release_status",
+}
+
+
+def india_issue_124_source_register() -> pd.DataFrame:
+    """Return the registered official-source candidates and known identification limits."""
+    return pd.DataFrame(
+        [
+            {
+                "candidate_id": "india_a04_2011_historical_town_series",
+                "official_source": "Census of India 2011 A-04 population-class tables",
+                "waves": "1981;1991;2001;2011",
+                "direct_locality_counts": True,
+                "origin_denominator_available": False,
+                "future_membership_conditioned": True,
+                "official_adjacent_wave_concordance": False,
+                "usable_forecast_origins": 0,
+                "release_status": "released",
+                "qualification_note": (
+                    "Historical columns are published for the 2011 town/class frame; "
+                    "they cannot define 1981 or 1991 origin cohorts before later survival and size"
+                ),
+            },
+            {
+                "candidate_id": "india_pca_lcd_2001_2011",
+                "official_source": (
+                    "Census of India 2001/2011 Primary Census Abstract and Location Code Directory"
+                ),
+                "waves": "2001;2011",
+                "direct_locality_counts": True,
+                "origin_denominator_available": True,
+                "future_membership_conditioned": False,
+                "official_adjacent_wave_concordance": True,
+                "usable_forecast_origins": 0,
+                "release_status": "released",
+                "qualification_note": (
+                    "One historical transition can audit coverage and growth, but two waves "
+                    "cannot form a recent-growth predictor and later outcome"
+                ),
+            },
+            {
+                "candidate_id": "india_original_town_directories_1981_2011",
+                "official_source": "Census of India original state town directories",
+                "waves": "1981;1991;2001;2011",
+                "direct_locality_counts": True,
+                "origin_denominator_available": True,
+                "future_membership_conditioned": False,
+                "official_adjacent_wave_concordance": False,
+                "usable_forecast_origins": 0,
+                "release_status": "released_fragmented",
+                "qualification_note": (
+                    "Potential multi-origin source, but no registered national official crosswave "
+                    "town concordance currently resolves births, declassifications, splits, and merges"
+                ),
+            },
+            {
+                "candidate_id": "india_census_2027_locality_outputs",
+                "official_source": "Census of India 2027 locality outputs and concordances",
+                "waves": "2001;2011;2027",
+                "direct_locality_counts": True,
+                "origin_denominator_available": False,
+                "future_membership_conditioned": False,
+                "official_adjacent_wave_concordance": False,
+                "usable_forecast_origins": 0,
+                "release_status": "not_released",
+                "qualification_note": (
+                    "The census reference date is scheduled for 2027; locality outputs and "
+                    "crosswave concordances do not yet exist"
+                ),
+            },
+        ]
+    )
+
+
+def qualify_india_issue_124_sources(register: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Evaluate candidates without allowing future-defined membership to pass."""
+    require_columns(register, REQUIRED, source_name="India issue 124 source register")
+    reject_duplicate_keys(register, ["candidate_id"], source_name="India issue 124 source register")
+    out = register.copy()
+    for column in [
+        "direct_locality_counts",
+        "origin_denominator_available",
+        "future_membership_conditioned",
+        "official_adjacent_wave_concordance",
+    ]:
+        if out[column].isna().any():
+            raise SourceSchemaError(f"India source register has unknown {column}")
+        out[column] = out[column].astype(bool)
+    out["usable_forecast_origins"] = pd.to_numeric(
+        out["usable_forecast_origins"], errors="coerce"
+    )
+    if out["usable_forecast_origins"].isna().any():
+        raise SourceSchemaError("India source register has invalid usable forecast-origin counts")
+
+    out["issue_124_qualified"] = (
+        out["direct_locality_counts"]
+        & out["origin_denominator_available"]
+        & ~out["future_membership_conditioned"]
+        & out["official_adjacent_wave_concordance"]
+        & out["usable_forecast_origins"].ge(2)
+        & out["release_status"].eq("released")
+    )
+    out["exclusion_reason"] = "qualified"
+    out.loc[~out["direct_locality_counts"], "exclusion_reason"] = "not_direct_locality_counts"
+    out.loc[~out["origin_denominator_available"], "exclusion_reason"] = (
+        "origin_denominator_unavailable"
+    )
+    out.loc[out["future_membership_conditioned"], "exclusion_reason"] = (
+        "future_conditioned_town_universe"
+    )
+    out.loc[
+        out["origin_denominator_available"]
+        & ~out["future_membership_conditioned"]
+        & ~out["official_adjacent_wave_concordance"],
+        "exclusion_reason",
+    ] = "official_crosswave_concordance_unresolved"
+    out.loc[
+        out["origin_denominator_available"]
+        & ~out["future_membership_conditioned"]
+        & out["official_adjacent_wave_concordance"]
+        & out["usable_forecast_origins"].lt(2),
+        "exclusion_reason",
+    ] = "insufficient_forecast_origins"
+    out.loc[out["release_status"].eq("not_released"), "exclusion_reason"] = (
+        "official_locality_outputs_not_released"
+    )
+
+    qualified = out["issue_124_qualified"]
+    status = pd.DataFrame(
+        [
+            {
+                "issue": 124,
+                "pilot": "India Census towns",
+                "candidate_sources": len(out),
+                "qualified_sources": int(qualified.sum()),
+                "benchmark_estimable": bool(qualified.any()),
+                "h1_independent_confirmation": False,
+                "historical_2001_2011_transition_permitted": True,
+                "historical_transition_closes_issue_124": False,
+                "decision": (
+                    "ready_for_matched_benchmark"
+                    if qualified.any()
+                    else "unresolved_no_origin_valid_multiwave_concorded_town_panel"
+                ),
+            }
+        ]
+    )
+    return out, status

--- a/tests/test_india_census_124.py
+++ b/tests/test_india_census_124.py
@@ -1,0 +1,40 @@
+from urban_growth.india_census_124 import (
+    india_issue_124_source_register,
+    qualify_india_issue_124_sources,
+)
+
+
+def test_a04_future_conditioned_history_is_not_validation() -> None:
+    qualified, status = qualify_india_issue_124_sources(india_issue_124_source_register())
+    a04 = qualified.set_index("candidate_id").loc["india_a04_2011_historical_town_series"]
+    assert a04["exclusion_reason"] == "future_conditioned_town_universe"
+    assert not a04["issue_124_qualified"]
+    assert not status.iloc[0]["benchmark_estimable"]
+
+
+def test_2001_2011_transition_is_allowed_but_cannot_close_issue() -> None:
+    qualified, status = qualify_india_issue_124_sources(india_issue_124_source_register())
+    pca = qualified.set_index("candidate_id").loc["india_pca_lcd_2001_2011"]
+    assert pca["exclusion_reason"] == "insufficient_forecast_origins"
+    assert status.iloc[0]["historical_2001_2011_transition_permitted"]
+    assert not status.iloc[0]["historical_transition_closes_issue_124"]
+
+
+def test_candidate_passes_only_after_all_identification_requirements() -> None:
+    candidate = india_issue_124_source_register().iloc[[2]].copy()
+    candidate["official_adjacent_wave_concordance"] = True
+    candidate["usable_forecast_origins"] = 2
+    candidate["release_status"] = "released"
+    qualified, status = qualify_india_issue_124_sources(candidate)
+    assert qualified.iloc[0]["issue_124_qualified"]
+    assert status.iloc[0]["benchmark_estimable"]
+
+
+def test_future_conditioning_overrides_nominal_wave_count() -> None:
+    candidate = india_issue_124_source_register().iloc[[0]].copy()
+    candidate["origin_denominator_available"] = True
+    candidate["official_adjacent_wave_concordance"] = True
+    candidate["usable_forecast_origins"] = 2
+    qualified, _ = qualify_india_issue_124_sources(candidate)
+    assert qualified.iloc[0]["exclusion_reason"] == "future_conditioned_town_universe"
+    assert not qualified.iloc[0]["issue_124_qualified"]


### PR DESCRIPTION
Extends #124 with an India-specific direct-count source qualification gate.

- rejects Census 2011 A-04 histories as a validation panel because the town/class universe is conditioned on 2011
- permits the 2001-2011 PCA/LCD transition only as a historical concordance audit
- records original 1981-2011 town directories as blocked by unresolved official adjacent-wave concordances
- records Census 2027 locality outputs as not yet released
- emits machine-readable India source qualification and benchmark status artifacts

Current decision: `unresolved_no_origin_valid_multiwave_concorded_town_panel`; `benchmark_estimable=false`; `h1_independent_confirmation=false`.

Local verification: 343 tests passed; ruff passed.

Refs #124.