### PR TITLE
Add China qualification gate for issue 124

### DIFF
--- a/.github/workflows/construction-smoothing-124.yml
+++ b/.github/workflows/construction-smoothing-124.yml
@@ -7,8 +7,10 @@ on:
       - ".github/workflows/construction-smoothing-124.yml"
       - "scripts/run_construction_smoothing_124.py"
       - "src/urban_growth/construction_smoothing.py"
+      - "src/urban_growth/china_census_124.py"
       - "src/urban_growth/india_census_124.py"
       - "tests/test_construction_smoothing.py"
+      - "tests/test_china_census_124.py"
       - "tests/test_india_census_124.py"
 
 permissions:
@@ -29,12 +31,21 @@ jobs:
       - run: >-
           uv run --locked --extra dev pytest
           tests/test_construction_smoothing.py tests/test_india_census_124.py
+          tests/test_china_census_124.py
       - run: uv run --locked python scripts/run_construction_smoothing_124.py
       - run: uv run --locked python scripts/run_construction_smoothing_124.py --pilot india
+      - run: uv run --locked python scripts/run_construction_smoothing_124.py --pilot china
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: construction-smoothing-124-status
           path: outputs/construction_smoothing_124/benchmark_status.csv
+          if-no-files-found: error
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: construction-smoothing-124-china-status
+          path: |
+            outputs/construction_smoothing_124/china_source_qualification.csv
+            outputs/construction_smoothing_124/china_benchmark_status.csv
           if-no-files-found: error
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/docs/china-direct-count-validation-124.md
+++ b/docs/china-direct-count-validation-124.md
@@ -1,0 +1,56 @@
+# China direct-count qualification for issue #124
+
+China is highly relevant to #124 because it contributes a large share of the WUP city
+sample. It does not currently supply a qualified direct-locality validation panel.
+
+## Why three national censuses are insufficient
+
+The National Bureau of Statistics publishes the 2000, 2010, and 2020 national population
+censuses. These are direct enumerations, but three waves yield only one recent-to-future
+forecast origin: 2000–2010 growth predicting 2010–2020 growth. The repository's #124 gate
+requires at least two origins rather than estimating a general persistence relationship from
+one national decade pair.
+
+More importantly, the published county-level units include counties, county-level cities,
+and urban districts. These are administrative territories, not stable settlement footprints.
+Prefecture-level “cities” can contain extensive rural hinterlands. District annexations,
+splits, mergers, and code changes alter both population and land area independently of
+demographic growth. Matching unchanged names or administrative codes does not resolve this.
+
+## Why annual city series do not solve it
+
+China's statistical and urban-construction yearbooks contain long annual series, but the
+fields can refer to administrative-area population, urban districts, built-up areas,
+permanent residents, or hukou population. They are not interchangeable direct locality
+counts. Combining them would manufacture apparent growth from definition changes.
+
+NBS statistical division and urban-rural division codes distinguish main-city areas,
+urban-rural fringes, town centres, and rural areas for each vintage. They are useful inputs
+for a future geographic audit, but they do not themselves provide population counts or a
+population-weighted crosswave concordance.
+
+## Machine-readable decision
+
+Run:
+
+```bash
+uv run --locked python scripts/run_construction_smoothing_124.py --pilot china
+```
+
+The runner writes `china_source_qualification.csv` and
+`china_benchmark_status.csv`. The current decision is
+`unresolved_no_stable_locality_multiwave_population_concordance`, with
+`benchmark_estimable=false` and `h1_independent_confirmation=false`.
+
+A 2000–2020 county-level exercise is allowed only as an administrative-unit sensitivity.
+It cannot close #124 or be described as direct city validation. A qualifying path requires
+at least four direct-enumeration waves, origin-specific settlement footprints, consistent
+permanent-resident population concepts, and official population-weighted concordances for
+every adjacent transition. Until those inputs exist, China is not a shortcut around the
+U.S. and India constraints.
+
+Official source entry points:
+
+- NBS census data: https://www.stats.gov.cn/english/Statisticaldata/CensusData/
+- Seventh census release: https://www.stats.gov.cn/english/PressRelease/202105/t20210510_1817185.html
+- NBS statistical standards: https://www.stats.gov.cn/sj/tjbz/

--- a/scripts/run_construction_smoothing_124.py
+++ b/scripts/run_construction_smoothing_124.py
@@ -7,6 +7,10 @@ from pathlib import Path
 
 import pandas as pd
 
+from urban_growth.china_census_124 import (
+    china_issue_124_source_register,
+    qualify_china_issue_124_sources,
+)
 from urban_growth.construction_smoothing import compare_direct_counts_with_ghsl
 from urban_growth.india_census_124 import (
     india_issue_124_source_register,
@@ -19,7 +23,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--direct-input", type=Path)
     parser.add_argument("--ghsl-input", type=Path)
-    parser.add_argument("--pilot", choices=["us", "india"], default="us")
+    parser.add_argument("--pilot", choices=["us", "india", "china"], default="us")
     parser.add_argument("--output-dir", type=Path, default=Path("outputs/construction_smoothing_124"))
     args = parser.parse_args()
     args.output_dir.mkdir(parents=True, exist_ok=True)
@@ -28,6 +32,12 @@ def main() -> None:
         register, status = qualify_india_issue_124_sources(india_issue_124_source_register())
         register.to_csv(args.output_dir / "india_source_qualification.csv", index=False)
         status.to_csv(args.output_dir / "india_benchmark_status.csv", index=False)
+        print(status.to_csv(index=False))
+        return
+    if args.pilot == "china":
+        register, status = qualify_china_issue_124_sources(china_issue_124_source_register())
+        register.to_csv(args.output_dir / "china_source_qualification.csv", index=False)
+        status.to_csv(args.output_dir / "china_benchmark_status.csv", index=False)
         print(status.to_csv(index=False))
         return
 

--- a/src/urban_growth/china_census_124.py
+++ b/src/urban_growth/china_census_124.py
@@ -1,0 +1,204 @@
+"""Qualification gate for a China direct-count benchmark under issue #124."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
+
+REQUIRED = {
+    "candidate_id",
+    "official_source",
+    "waves",
+    "direct_enumeration",
+    "locality_concept_comparable",
+    "population_concept_consistent",
+    "origin_denominator_available",
+    "future_membership_conditioned",
+    "official_population_weighted_concordance",
+    "usable_forecast_origins",
+    "release_status",
+}
+
+
+def china_issue_124_source_register() -> pd.DataFrame:
+    """Register official China source paths without equating cities and administrative units."""
+    return pd.DataFrame(
+        [
+            {
+                "candidate_id": "china_census_county_2000_2020",
+                "official_source": "NBS fifth, sixth, and seventh national population censuses",
+                "waves": "2000;2010;2020",
+                "direct_enumeration": True,
+                "locality_concept_comparable": False,
+                "population_concept_consistent": True,
+                "origin_denominator_available": True,
+                "future_membership_conditioned": False,
+                "official_population_weighted_concordance": False,
+                "usable_forecast_origins": 1,
+                "release_status": "released",
+                "qualification_note": (
+                    "County, county-level city, and urban-district populations are administrative "
+                    "territories rather than stable settlement footprints; three waves yield only "
+                    "one recent-to-future origin"
+                ),
+            },
+            {
+                "candidate_id": "china_census_county_1990_2020",
+                "official_source": "NBS fourth through seventh national population censuses",
+                "waves": "1990;2000;2010;2020",
+                "direct_enumeration": True,
+                "locality_concept_comparable": False,
+                "population_concept_consistent": True,
+                "origin_denominator_available": True,
+                "future_membership_conditioned": False,
+                "official_population_weighted_concordance": False,
+                "usable_forecast_origins": 0,
+                "release_status": "released_fragmented",
+                "qualification_note": (
+                    "Nominally enough waves, but no registered national population-weighted "
+                    "crosswalk resolves district annexations, splits, mergers, and code changes"
+                ),
+            },
+            {
+                "candidate_id": "china_city_statistical_yearbooks",
+                "official_source": "NBS and Ministry of Housing urban construction/city yearbooks",
+                "waves": "annual",
+                "direct_enumeration": False,
+                "locality_concept_comparable": False,
+                "population_concept_consistent": False,
+                "origin_denominator_available": False,
+                "future_membership_conditioned": False,
+                "official_population_weighted_concordance": False,
+                "usable_forecast_origins": 0,
+                "release_status": "released",
+                "qualification_note": (
+                    "Annual city fields mix administrative territory, urban district, built-up-area, "
+                    "permanent-resident, and hukou concepts and are not direct locality enumerations"
+                ),
+            },
+            {
+                "candidate_id": "china_statistical_zoning_codes",
+                "official_source": "NBS statistical division and urban-rural division codes",
+                "waves": "annual_from_2009",
+                "direct_enumeration": False,
+                "locality_concept_comparable": False,
+                "population_concept_consistent": False,
+                "origin_denominator_available": False,
+                "future_membership_conditioned": False,
+                "official_population_weighted_concordance": False,
+                "usable_forecast_origins": 0,
+                "release_status": "released",
+                "qualification_note": (
+                    "Codes classify main-city, fringe, town-centre, and rural areas for a vintage; "
+                    "they do not provide direct counts or a population-weighted crosswave concordance"
+                ),
+            },
+            {
+                "candidate_id": "china_prefecture_city_totals",
+                "official_source": "China Statistical Yearbook prefecture-level administrative data",
+                "waves": "annual",
+                "direct_enumeration": False,
+                "locality_concept_comparable": False,
+                "population_concept_consistent": False,
+                "origin_denominator_available": True,
+                "future_membership_conditioned": False,
+                "official_population_weighted_concordance": False,
+                "usable_forecast_origins": 0,
+                "release_status": "released",
+                "qualification_note": (
+                    "Prefecture-level cities include large rural hinterlands and cannot be matched "
+                    "to GHSL urban-centre footprints as if they were individual localities"
+                ),
+            },
+        ]
+    )
+
+
+def qualify_china_issue_124_sources(register: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Apply the direct-count, geographic-identity, and multi-origin requirements."""
+    require_columns(register, REQUIRED, source_name="China issue 124 source register")
+    reject_duplicate_keys(register, ["candidate_id"], source_name="China issue 124 source register")
+    out = register.copy()
+    boolean_columns = [
+        "direct_enumeration",
+        "locality_concept_comparable",
+        "population_concept_consistent",
+        "origin_denominator_available",
+        "future_membership_conditioned",
+        "official_population_weighted_concordance",
+    ]
+    for column in boolean_columns:
+        if out[column].isna().any():
+            raise SourceSchemaError(f"China source register has unknown {column}")
+        out[column] = out[column].astype(bool)
+    out["usable_forecast_origins"] = pd.to_numeric(
+        out["usable_forecast_origins"], errors="coerce"
+    )
+    if out["usable_forecast_origins"].isna().any():
+        raise SourceSchemaError("China source register has invalid usable forecast-origin counts")
+
+    out["issue_124_qualified"] = (
+        out["direct_enumeration"]
+        & out["locality_concept_comparable"]
+        & out["population_concept_consistent"]
+        & out["origin_denominator_available"]
+        & ~out["future_membership_conditioned"]
+        & out["official_population_weighted_concordance"]
+        & out["usable_forecast_origins"].ge(2)
+        & out["release_status"].eq("released")
+    )
+    out["exclusion_reason"] = "qualified"
+    out.loc[~out["direct_enumeration"], "exclusion_reason"] = "not_direct_enumeration"
+    out.loc[
+        out["direct_enumeration"] & ~out["locality_concept_comparable"], "exclusion_reason"
+    ] = "administrative_unit_not_comparable_locality"
+    out.loc[
+        out["direct_enumeration"]
+        & out["locality_concept_comparable"]
+        & ~out["population_concept_consistent"],
+        "exclusion_reason",
+    ] = "population_concept_inconsistent"
+    out.loc[out["future_membership_conditioned"], "exclusion_reason"] = (
+        "future_conditioned_universe"
+    )
+    out.loc[
+        out["direct_enumeration"]
+        & out["locality_concept_comparable"]
+        & out["population_concept_consistent"]
+        & ~out["official_population_weighted_concordance"],
+        "exclusion_reason",
+    ] = "official_population_weighted_concordance_unresolved"
+    out.loc[
+        out["direct_enumeration"]
+        & out["locality_concept_comparable"]
+        & out["population_concept_consistent"]
+        & out["official_population_weighted_concordance"]
+        & out["usable_forecast_origins"].lt(2),
+        "exclusion_reason",
+    ] = "insufficient_forecast_origins"
+    out.loc[out["release_status"].eq("not_released"), "exclusion_reason"] = (
+        "official_outputs_not_released"
+    )
+
+    qualified = out["issue_124_qualified"]
+    status = pd.DataFrame(
+        [
+            {
+                "issue": 124,
+                "pilot": "China national censuses",
+                "candidate_sources": len(out),
+                "qualified_sources": int(qualified.sum()),
+                "benchmark_estimable": bool(qualified.any()),
+                "h1_independent_confirmation": False,
+                "county_2000_2020_sensitivity_permitted": True,
+                "county_sensitivity_closes_issue_124": False,
+                "decision": (
+                    "ready_for_matched_benchmark"
+                    if qualified.any()
+                    else "unresolved_no_stable_locality_multiwave_population_concordance"
+                ),
+            }
+        ]
+    )
+    return out, status

--- a/tests/test_china_census_124.py
+++ b/tests/test_china_census_124.py
@@ -1,0 +1,41 @@
+from urban_growth.china_census_124 import (
+    china_issue_124_source_register,
+    qualify_china_issue_124_sources,
+)
+
+
+def test_three_censuses_do_not_supply_two_forecast_origins_or_stable_localities() -> None:
+    qualified, status = qualify_china_issue_124_sources(china_issue_124_source_register())
+    census = qualified.set_index("candidate_id").loc["china_census_county_2000_2020"]
+    assert census["exclusion_reason"] == "administrative_unit_not_comparable_locality"
+    assert census["usable_forecast_origins"] == 1
+    assert not status.iloc[0]["benchmark_estimable"]
+
+
+def test_prefecture_totals_are_not_treated_as_city_locality_counts() -> None:
+    qualified, _ = qualify_china_issue_124_sources(china_issue_124_source_register())
+    prefecture = qualified.set_index("candidate_id").loc["china_prefecture_city_totals"]
+    assert prefecture["exclusion_reason"] == "not_direct_enumeration"
+    assert not prefecture["issue_124_qualified"]
+
+
+def test_candidate_requires_population_weighted_crosswave_concordance() -> None:
+    candidate = china_issue_124_source_register().iloc[[1]].copy()
+    candidate["locality_concept_comparable"] = True
+    candidate["usable_forecast_origins"] = 2
+    candidate["release_status"] = "released"
+    qualified, _ = qualify_china_issue_124_sources(candidate)
+    assert qualified.iloc[0]["exclusion_reason"] == (
+        "official_population_weighted_concordance_unresolved"
+    )
+
+
+def test_candidate_passes_only_when_all_identification_requirements_pass() -> None:
+    candidate = china_issue_124_source_register().iloc[[1]].copy()
+    candidate["locality_concept_comparable"] = True
+    candidate["official_population_weighted_concordance"] = True
+    candidate["usable_forecast_origins"] = 2
+    candidate["release_status"] = "released"
+    qualified, status = qualify_china_issue_124_sources(candidate)
+    assert qualified.iloc[0]["issue_124_qualified"]
+    assert status.iloc[0]["benchmark_estimable"]


### PR DESCRIPTION
Extends #124 with a China-specific direct-count qualification gate.

- distinguishes census enumeration from stable settlement-locality geography
- rejects prefecture and urban-district totals as interchangeable city footprints
- records the 2000/2010/2020 census path as only one recent-to-future origin
- rejects annual city/yearbook series that mix administrative, built-up-area, permanent-resident, and hukou concepts
- treats NBS statistical zoning codes as vintage classifications, not population-weighted crosswave concordances
- emits China source-qualification and benchmark-status artifacts

Current decision: `unresolved_no_stable_locality_multiwave_population_concordance`; `benchmark_estimable=false`; `h1_independent_confirmation=false`.

Local verification: 347 tests passed; ruff passed.

Refs #124.