### PR TITLE
Add Japan acquisition gate for issue 124

### DIFF
--- a/.github/workflows/construction-smoothing-124.yml
+++ b/.github/workflows/construction-smoothing-124.yml
@@ -9,9 +9,11 @@ on:
       - "src/urban_growth/construction_smoothing.py"
       - "src/urban_growth/china_census_124.py"
       - "src/urban_growth/india_census_124.py"
+      - "src/urban_growth/japan_census_124.py"
       - "tests/test_construction_smoothing.py"
       - "tests/test_china_census_124.py"
       - "tests/test_india_census_124.py"
+      - "tests/test_japan_census_124.py"
 
 permissions:
   contents: read
@@ -32,13 +34,22 @@ jobs:
           uv run --locked --extra dev pytest
           tests/test_construction_smoothing.py tests/test_india_census_124.py
           tests/test_china_census_124.py
+          tests/test_japan_census_124.py
       - run: uv run --locked python scripts/run_construction_smoothing_124.py
       - run: uv run --locked python scripts/run_construction_smoothing_124.py --pilot india
       - run: uv run --locked python scripts/run_construction_smoothing_124.py --pilot china
+      - run: uv run --locked python scripts/run_construction_smoothing_124.py --pilot japan
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: construction-smoothing-124-status
           path: outputs/construction_smoothing_124/benchmark_status.csv
+          if-no-files-found: error
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: construction-smoothing-124-japan-status
+          path: |
+            outputs/construction_smoothing_124/japan_source_qualification.csv
+            outputs/construction_smoothing_124/japan_benchmark_status.csv
           if-no-files-found: error
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/docs/japan-direct-count-validation-124.md
+++ b/docs/japan-direct-count-validation-124.md
@@ -1,0 +1,56 @@
+# Japan direct-count qualification for issue #124
+
+Japan is the first reviewed country with a credible path to the direct-count benchmark.
+It is acquisition-ready, not yet benchmark-complete.
+
+## Recommended unit: Densely Inhabited Districts
+
+The Statistics Bureau defines Densely Inhabited Districts (DIDs) from Population Census
+small-area data and has designated them in every census since 1960. DIDs are census-defined
+urban areas rather than whole municipalities. Official census population and vintage geography
+for 2000, 2005, 2010, 2015, and 2020 provide three possible recent-to-future origins.
+
+That does not authorize a naive DID-code join. DID boundaries can expand, contract, split, or
+merge. The implementation therefore withholds empirical qualification until the official inputs
+are registered, each origin denominator is constructed before later concordance, and a geometry
+overlap audit classifies stable one-to-one relationships, splits, mergers, births, and disappearances.
+Every unresolved origin DID must remain in the coverage denominator.
+
+## Rejected shortcuts
+
+Municipality census tables are useful administrative-area sensitivities but municipalities can
+contain multiple settlements and rural territory. Japan's official tables also publish prior-census
+population readjusted to later municipal boundaries. Those adjacent comparisons are valuable for
+transition checks, but chaining them into a historical panel on a later municipality universe would
+condition earlier membership on future mergers and boundaries.
+
+Small-area grid data could support a fixed-footprint sensitivity, but grid cells are not official
+localities. Aggregating them directly to a future GHSL footprint would reproduce the future-membership
+problem rather than test it.
+
+## Required acquisition sequence
+
+1. Acquire and hash official DID population tables and vintage polygons for 2000–2020.
+2. Define the eligible DID population cohort independently at each forecast origin.
+3. Overlay only the lag, origin, and outcome vintages needed at that origin; do not use 2020
+   membership to construct earlier risk sets.
+4. Require one-to-one overlap thresholds for the primary sample and retain all other origin DIDs
+   as unresolved denominator rows.
+5. Match GHSL fixed and dynamic population to the accepted DID-period rows without using future
+   outcomes for membership.
+6. Run the registered #124 coefficient, MAE/RMSE, sign-reversal, and curvature comparisons.
+
+Run the current qualification gate with:
+
+```bash
+uv run --locked python scripts/run_construction_smoothing_124.py --pilot japan
+```
+
+It writes `japan_source_qualification.csv` and `japan_benchmark_status.csv`. The current decision
+is `acquisition_ready_not_yet_empirically_qualified`; H1 remains unconfirmed by direct counts.
+
+Official source entry points:
+
+- Population Census: https://www.stat.go.jp/english/data/kokusei/
+- DID definition: https://www.stat.go.jp/english/data/chiri/did/1-1.html
+- e-Stat official data portal: https://www.e-stat.go.jp/en/

--- a/scripts/run_construction_smoothing_124.py
+++ b/scripts/run_construction_smoothing_124.py
@@ -17,13 +17,17 @@ from urban_growth.india_census_124 import (
     qualify_india_issue_124_sources,
 )
 from urban_growth.io import SourceSchemaError
+from urban_growth.japan_census_124 import (
+    japan_issue_124_source_register,
+    qualify_japan_issue_124_sources,
+)
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--direct-input", type=Path)
     parser.add_argument("--ghsl-input", type=Path)
-    parser.add_argument("--pilot", choices=["us", "india", "china"], default="us")
+    parser.add_argument("--pilot", choices=["us", "india", "china", "japan"], default="us")
     parser.add_argument("--output-dir", type=Path, default=Path("outputs/construction_smoothing_124"))
     args = parser.parse_args()
     args.output_dir.mkdir(parents=True, exist_ok=True)
@@ -38,6 +42,12 @@ def main() -> None:
         register, status = qualify_china_issue_124_sources(china_issue_124_source_register())
         register.to_csv(args.output_dir / "china_source_qualification.csv", index=False)
         status.to_csv(args.output_dir / "china_benchmark_status.csv", index=False)
+        print(status.to_csv(index=False))
+        return
+    if args.pilot == "japan":
+        register, status = qualify_japan_issue_124_sources(japan_issue_124_source_register())
+        register.to_csv(args.output_dir / "japan_source_qualification.csv", index=False)
+        status.to_csv(args.output_dir / "japan_benchmark_status.csv", index=False)
         print(status.to_csv(index=False))
         return
 

--- a/src/urban_growth/japan_census_124.py
+++ b/src/urban_growth/japan_census_124.py
@@ -1,0 +1,196 @@
+"""Qualification and acquisition gate for Japan under issue #124."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from urban_growth.io import SourceSchemaError, reject_duplicate_keys, require_columns
+
+REQUIRED = {
+    "candidate_id",
+    "official_source",
+    "waves",
+    "direct_census_population",
+    "locality_concept_comparable",
+    "population_concept_consistent",
+    "official_vintage_geometry",
+    "usable_forecast_origins",
+    "future_membership_conditioned",
+    "data_acquired",
+    "origin_denominator_constructed",
+    "geometry_overlap_audited",
+}
+
+
+def japan_issue_124_source_register() -> pd.DataFrame:
+    """Register Japan candidates, separating a viable DID path from municipality shortcuts."""
+    return pd.DataFrame(
+        [
+            {
+                "candidate_id": "japan_did_2000_2020",
+                "official_source": "Statistics Bureau Population Census Densely Inhabited Districts",
+                "waves": "2000;2005;2010;2015;2020",
+                "direct_census_population": True,
+                "locality_concept_comparable": True,
+                "population_concept_consistent": True,
+                "official_vintage_geometry": True,
+                "usable_forecast_origins": 3,
+                "future_membership_conditioned": False,
+                "data_acquired": False,
+                "origin_denominator_constructed": False,
+                "geometry_overlap_audited": False,
+                "qualification_note": (
+                    "Viable national path: census-defined urban districts with five-year direct "
+                    "population and official vintage geography; requires origin-first overlay audit"
+                ),
+            },
+            {
+                "candidate_id": "japan_municipal_census_2000_2025",
+                "official_source": "Statistics Bureau Population Census municipality tables",
+                "waves": "2000;2005;2010;2015;2020;2025_preliminary",
+                "direct_census_population": True,
+                "locality_concept_comparable": False,
+                "population_concept_consistent": True,
+                "official_vintage_geometry": True,
+                "usable_forecast_origins": 4,
+                "future_membership_conditioned": False,
+                "data_acquired": False,
+                "origin_denominator_constructed": False,
+                "geometry_overlap_audited": False,
+                "qualification_note": (
+                    "Strong administrative-unit sensitivity, but municipalities can combine multiple "
+                    "settlements and rural territory and are not interchangeable with urban localities"
+                ),
+            },
+            {
+                "candidate_id": "japan_current_boundary_readjusted_municipal_history",
+                "official_source": "Population Census prior-wave population readjusted to later boundaries",
+                "waves": "adjacent_five_year_pairs",
+                "direct_census_population": True,
+                "locality_concept_comparable": False,
+                "population_concept_consistent": True,
+                "official_vintage_geometry": True,
+                "usable_forecast_origins": 0,
+                "future_membership_conditioned": True,
+                "data_acquired": False,
+                "origin_denominator_constructed": False,
+                "geometry_overlap_audited": False,
+                "qualification_note": (
+                    "Useful for transition checks, but chaining histories on a later municipality "
+                    "universe conditions earlier membership on future mergers and boundaries"
+                ),
+            },
+            {
+                "candidate_id": "japan_population_census_mesh",
+                "official_source": "Statistics Bureau Population Census small-area and grid-square data",
+                "waves": "2000;2005;2010;2015;2020",
+                "direct_census_population": True,
+                "locality_concept_comparable": False,
+                "population_concept_consistent": True,
+                "official_vintage_geometry": True,
+                "usable_forecast_origins": 3,
+                "future_membership_conditioned": False,
+                "data_acquired": False,
+                "origin_denominator_constructed": False,
+                "geometry_overlap_audited": False,
+                "qualification_note": (
+                    "Potential fixed-footprint sensitivity, but grid cells are not official localities "
+                    "and aggregation to a later GHSL footprint would reintroduce future membership"
+                ),
+            },
+        ]
+    )
+
+
+def qualify_japan_issue_124_sources(register: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Identify acquisition-ready sources and withhold empirical qualification until audited."""
+    require_columns(register, REQUIRED, source_name="Japan issue 124 source register")
+    reject_duplicate_keys(register, ["candidate_id"], source_name="Japan issue 124 source register")
+    out = register.copy()
+    boolean_columns = [
+        "direct_census_population",
+        "locality_concept_comparable",
+        "population_concept_consistent",
+        "official_vintage_geometry",
+        "future_membership_conditioned",
+        "data_acquired",
+        "origin_denominator_constructed",
+        "geometry_overlap_audited",
+    ]
+    for column in boolean_columns:
+        if out[column].isna().any():
+            raise SourceSchemaError(f"Japan source register has unknown {column}")
+        out[column] = out[column].astype(bool)
+    out["usable_forecast_origins"] = pd.to_numeric(
+        out["usable_forecast_origins"], errors="coerce"
+    )
+    if out["usable_forecast_origins"].isna().any():
+        raise SourceSchemaError("Japan source register has invalid usable forecast-origin counts")
+
+    out["acquisition_ready"] = (
+        out["direct_census_population"]
+        & out["locality_concept_comparable"]
+        & out["population_concept_consistent"]
+        & out["official_vintage_geometry"]
+        & out["usable_forecast_origins"].ge(2)
+        & ~out["future_membership_conditioned"]
+    )
+    out["issue_124_qualified"] = (
+        out["acquisition_ready"]
+        & out["data_acquired"]
+        & out["origin_denominator_constructed"]
+        & out["geometry_overlap_audited"]
+    )
+    out["status"] = "not_comparable_locality_source"
+    out.loc[out["future_membership_conditioned"], "status"] = "future_conditioned_universe"
+    out.loc[
+        out["direct_census_population"]
+        & out["locality_concept_comparable"]
+        & out["usable_forecast_origins"].lt(2),
+        "status",
+    ] = "insufficient_forecast_origins"
+    out.loc[out["acquisition_ready"] & ~out["data_acquired"], "status"] = (
+        "acquisition_ready_inputs_not_registered"
+    )
+    out.loc[
+        out["acquisition_ready"]
+        & out["data_acquired"]
+        & ~out["origin_denominator_constructed"],
+        "status",
+    ] = "origin_denominator_not_constructed"
+    out.loc[
+        out["acquisition_ready"]
+        & out["data_acquired"]
+        & out["origin_denominator_constructed"]
+        & ~out["geometry_overlap_audited"],
+        "status",
+    ] = "geometry_overlap_not_audited"
+    out.loc[out["issue_124_qualified"], "status"] = "qualified"
+
+    acquisition_ready = out["acquisition_ready"]
+    qualified = out["issue_124_qualified"]
+    status = pd.DataFrame(
+        [
+            {
+                "issue": 124,
+                "pilot": "Japan Population Census DIDs",
+                "candidate_sources": len(out),
+                "acquisition_ready_sources": int(acquisition_ready.sum()),
+                "qualified_sources": int(qualified.sum()),
+                "benchmark_estimable": bool(qualified.any()),
+                "h1_independent_confirmation": False,
+                "recommended_candidate": "japan_did_2000_2020",
+                "next_gate": (
+                    "run_matched_direct_ghsl_benchmark"
+                    if qualified.any()
+                    else "acquire_did_counts_and_geometry_then_audit_origin_overlap"
+                ),
+                "decision": (
+                    "ready_for_matched_benchmark"
+                    if qualified.any()
+                    else "acquisition_ready_not_yet_empirically_qualified"
+                ),
+            }
+        ]
+    )
+    return out, status

--- a/tests/test_japan_census_124.py
+++ b/tests/test_japan_census_124.py
@@ -1,0 +1,44 @@
+from urban_growth.japan_census_124 import (
+    japan_issue_124_source_register,
+    qualify_japan_issue_124_sources,
+)
+
+
+def test_did_path_is_acquisition_ready_but_not_yet_empirically_qualified() -> None:
+    qualified, status = qualify_japan_issue_124_sources(japan_issue_124_source_register())
+    did = qualified.set_index("candidate_id").loc["japan_did_2000_2020"]
+    assert did["acquisition_ready"]
+    assert did["status"] == "acquisition_ready_inputs_not_registered"
+    assert not did["issue_124_qualified"]
+    assert status.iloc[0]["acquisition_ready_sources"] == 1
+    assert not status.iloc[0]["benchmark_estimable"]
+
+
+def test_municipality_panel_remains_administrative_sensitivity() -> None:
+    qualified, _ = qualify_japan_issue_124_sources(japan_issue_124_source_register())
+    municipality = qualified.set_index("candidate_id").loc[
+        "japan_municipal_census_2000_2025"
+    ]
+    assert municipality["status"] == "not_comparable_locality_source"
+    assert not municipality["acquisition_ready"]
+
+
+def test_later_boundary_readjustment_cannot_define_earlier_origin_cohort() -> None:
+    qualified, _ = qualify_japan_issue_124_sources(japan_issue_124_source_register())
+    adjusted = qualified.set_index("candidate_id").loc[
+        "japan_current_boundary_readjusted_municipal_history"
+    ]
+    assert adjusted["status"] == "future_conditioned_universe"
+    assert not adjusted["issue_124_qualified"]
+
+
+def test_did_path_qualifies_only_after_denominator_and_overlap_audit() -> None:
+    candidate = japan_issue_124_source_register().iloc[[0]].copy()
+    candidate["data_acquired"] = True
+    candidate["origin_denominator_constructed"] = True
+    partly, _ = qualify_japan_issue_124_sources(candidate)
+    assert partly.iloc[0]["status"] == "geometry_overlap_not_audited"
+    candidate["geometry_overlap_audited"] = True
+    complete, status = qualify_japan_issue_124_sources(candidate)
+    assert complete.iloc[0]["issue_124_qualified"]
+    assert status.iloc[0]["benchmark_estimable"]


### PR DESCRIPTION
Extends #124 with a Japan-specific source qualification and acquisition gate.

- identifies Population Census Densely Inhabited Districts (DIDs) as the first acquisition-ready direct-count locality path
- registers five official census waves (2000-2020) and three potential recent-to-future origins
- rejects municipality totals as interchangeable urban localities
- rejects chaining prior populations readjusted to later municipal boundaries
- requires origin-first DID denominators and a vintage-geometry overlap audit before empirical qualification
- emits Japan source-qualification and benchmark-status artifacts

Current decision: `acquisition_ready_not_yet_empirically_qualified`; one acquisition-ready source, zero empirically qualified sources; `benchmark_estimable=false`; `h1_independent_confirmation=false`.

Local verification: 351 tests passed; ruff passed.

Refs #124.