### PR TITLE
Implement vintage-qualified census evidence contract

### DIFF
--- a/docs/census-evidence-163-status.md
+++ b/docs/census-evidence-163-status.md
@@ -1,0 +1,14 @@
+# Census evidence #163 — schema implemented, acquisition open
+
+The executable census-event and estimate-incorporation contracts are implemented in
+`src/urban_growth/census_evidence.py`. They enforce controlled vocabularies, chronology,
+source-specific event identities, assertion uniqueness, explicit unknown states, and
+estimate-series/vintage-qualified incorporation claims. Conflicting source assertions remain
+separate rows. Census recency never implies quality, PES status, undercount, adjustment, or
+incorporation.
+
+Issue #163 is not empirically complete. UNSD publishes a maintained global census-date table,
+but the required PES, undercount, coverage-adjustment, results-status, and WPP/IDB incorporation
+evidence is distributed across country reports and publisher notes. Those artifacts still need
+release-specific capture, checksums, licenses, crosswalks, and transformation lineage. A global
+census-date scrape alone would satisfy only one field and must not be presented as completion.

--- a/docs/research-status.md
+++ b/docs/research-status.md
@@ -665,6 +665,14 @@ and economy crosswalk status. A five-day pre-release comparison finds two revise
 182,280 common cells. No overall SPI score or population-accuracy claim is produced. See
 `docs/spi-evidence-166-result.md`.
 
+## Vintage-qualified census evidence contract
+
+Issue #163 now has executable census-event and estimate-incorporation schemas with controlled
+vocabularies, chronology checks, explicit unknowns, separate conflicting assertions, and
+estimate-series/vintage-qualified incorporation. Empirical acquisition remains open because
+PES, undercount, adjustment, and incorporation evidence is fragmented across publisher and
+country documents. See `docs/census-evidence-163-status.md`.
+
 ## Reproduction
 
 With the registered raw files under `data/raw/`, run:

--- a/src/urban_growth/census_evidence.py
+++ b/src/urban_growth/census_evidence.py
@@ -1,0 +1,155 @@
+"""Vintage-qualified census-event and estimate-incorporation evidence contracts."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import date
+
+ENUMERATION_BASES = {"de_facto", "de_jure", "register_based", "combined", "unknown"}
+GEOGRAPHIC_COVERAGE = {"national", "partial", "excluded_areas", "unknown"}
+RESULTS_STATUSES = {"preliminary", "final", "partially_published", "unpublished", "unknown"}
+PES_STATUSES = {"none_reported", "planned", "conducted", "published", "unknown"}
+YES_NO_UNKNOWN = {"yes", "no", "unknown"}
+INCORPORATION = {"yes", "partially", "no", "unknown"}
+EVIDENCE_LEVELS = {"explicit", "inferred_documented", "unknown"}
+
+
+class CensusEvidenceError(ValueError):
+    """Raised when census evidence violates its documentary contract."""
+
+
+def _text(value: str, field: str) -> str:
+    if not isinstance(value, str) or not value.strip() or value != value.strip():
+        raise CensusEvidenceError(f"{field} must be normalized non-empty text")
+    return value
+
+
+def _date(value: str | None, field: str, *, required: bool = False) -> date | None:
+    if value is None:
+        if required:
+            raise CensusEvidenceError(f"{field} is required")
+        return None
+    try:
+        return date.fromisoformat(value)
+    except (TypeError, ValueError) as error:
+        raise CensusEvidenceError(f"{field} must be an ISO date") from error
+
+
+def census_event_id_for(country_id: str, reference_date: str, source_id: str) -> str:
+    payload = "|".join(
+        (_text(country_id, "country_id"), reference_date, _text(source_id, "source_id"))
+    )
+    _date(reference_date, "census_reference_date", required=True)
+    return "census:" + hashlib.sha256(payload.encode()).hexdigest()
+
+
+@dataclass(frozen=True)
+class CensusEvent:
+    census_event_id: str
+    country_id: str
+    census_round: str
+    census_reference_date: str
+    enumeration_start_date: str | None
+    enumeration_basis: str
+    geographic_coverage: str
+    geographic_coverage_source_text: str
+    results_status: str
+    post_enumeration_survey_status: str
+    pes_results_published: str
+    estimated_net_undercount: float | None
+    official_coverage_adjustment_applied: str
+    source_id: str
+    snapshot_id: str
+
+
+@dataclass(frozen=True)
+class EstimateIncorporation:
+    country_id: str
+    estimate_series: str
+    estimate_vintage: str
+    census_event_id: str
+    census_incorporated: str
+    incorporation_method: str
+    source_evidence_level: str
+    source_id: str
+    snapshot_id: str
+
+
+def validate_census_events(events: Iterable[CensusEvent]) -> None:
+    rows = list(events)
+    identities: set[tuple[str, str]] = set()
+    for row in rows:
+        for field in ("country_id", "census_round", "source_id", "snapshot_id"):
+            _text(getattr(row, field), field)
+        reference = _date(row.census_reference_date, "census_reference_date", required=True)
+        start = _date(row.enumeration_start_date, "enumeration_start_date")
+        if start and reference and start > reference:
+            raise CensusEvidenceError("enumeration_start_date cannot follow census_reference_date")
+        expected_id = census_event_id_for(row.country_id, row.census_reference_date, row.source_id)
+        if row.census_event_id != expected_id:
+            raise CensusEvidenceError("census_event_id does not match country, date, and source")
+        vocabularies = {
+            "enumeration_basis": ENUMERATION_BASES,
+            "geographic_coverage": GEOGRAPHIC_COVERAGE,
+            "results_status": RESULTS_STATUSES,
+            "post_enumeration_survey_status": PES_STATUSES,
+            "pes_results_published": YES_NO_UNKNOWN,
+            "official_coverage_adjustment_applied": YES_NO_UNKNOWN,
+        }
+        for field, allowed in vocabularies.items():
+            if getattr(row, field) not in allowed:
+                raise CensusEvidenceError(f"{field} has an invalid value")
+        _text(row.geographic_coverage_source_text, "geographic_coverage_source_text")
+        if (
+            row.estimated_net_undercount is not None
+            and not -100 <= row.estimated_net_undercount <= 100
+        ):
+            raise CensusEvidenceError(
+                "estimated_net_undercount must be a source percentage in [-100, 100]"
+            )
+        if row.post_enumeration_survey_status == "published" and row.pes_results_published != "yes":
+            raise CensusEvidenceError("published PES status requires pes_results_published=yes")
+        identity = (row.census_event_id, row.snapshot_id)
+        if identity in identities:
+            raise CensusEvidenceError("duplicate census assertion")
+        identities.add(identity)
+
+
+def validate_estimate_incorporations(
+    records: Iterable[EstimateIncorporation], *, events: Iterable[CensusEvent]
+) -> None:
+    event_ids = {row.census_event_id for row in events}
+    identities: set[tuple[str, str, str, str, str]] = set()
+    for row in records:
+        for field in (
+            "country_id",
+            "estimate_series",
+            "estimate_vintage",
+            "census_event_id",
+            "source_id",
+            "snapshot_id",
+        ):
+            _text(getattr(row, field), field)
+        if row.census_event_id not in event_ids:
+            raise CensusEvidenceError("estimate incorporation references an unknown census event")
+        if row.census_incorporated not in INCORPORATION:
+            raise CensusEvidenceError("census_incorporated has an invalid value")
+        if row.source_evidence_level not in EVIDENCE_LEVELS:
+            raise CensusEvidenceError("source_evidence_level has an invalid value")
+        if row.source_evidence_level == "unknown":
+            if row.census_incorporated != "unknown" or row.incorporation_method != "unknown":
+                raise CensusEvidenceError("unknown evidence cannot assert incorporation or method")
+        else:
+            _text(row.incorporation_method, "incorporation_method")
+        identity = (
+            row.country_id,
+            row.estimate_series,
+            row.estimate_vintage,
+            row.census_event_id,
+            row.snapshot_id,
+        )
+        if identity in identities:
+            raise CensusEvidenceError("duplicate estimate-incorporation assertion")
+        identities.add(identity)

--- a/tests/test_census_evidence.py
+++ b/tests/test_census_evidence.py
@@ -1,0 +1,106 @@
+from dataclasses import replace
+
+import pytest
+
+from urban_growth.census_evidence import (
+    CensusEvent,
+    CensusEvidenceError,
+    EstimateIncorporation,
+    census_event_id_for,
+    validate_census_events,
+    validate_estimate_incorporations,
+)
+
+
+def event(**changes):
+    values = {
+        "country_id": "USA",
+        "census_round": "2020",
+        "census_reference_date": "2020-04-01",
+        "enumeration_start_date": "2020-03-01",
+        "enumeration_basis": "de_jure",
+        "geographic_coverage": "national",
+        "geographic_coverage_source_text": "50 states and DC",
+        "results_status": "final",
+        "post_enumeration_survey_status": "published",
+        "pes_results_published": "yes",
+        "estimated_net_undercount": -0.24,
+        "official_coverage_adjustment_applied": "no",
+        "source_id": "unsd_census_dates",
+        "snapshot_id": "snapshot:one",
+    }
+    values.update(changes)
+    values.setdefault(
+        "census_event_id",
+        census_event_id_for(
+            values["country_id"], values["census_reference_date"], values["source_id"]
+        ),
+    )
+    return CensusEvent(**values)
+
+
+def incorporation(census_event_id, **changes):
+    values = {
+        "country_id": "USA",
+        "estimate_series": "WPP",
+        "estimate_vintage": "2024 Revision",
+        "census_event_id": census_event_id,
+        "census_incorporated": "yes",
+        "incorporation_method": "Publisher country note identifies 2020 census",
+        "source_evidence_level": "explicit",
+        "source_id": "un_wpp_2024",
+        "snapshot_id": "snapshot:wpp",
+    }
+    values.update(changes)
+    return EstimateIncorporation(**values)
+
+
+def test_valid_records_preserve_event_and_vintage_qualified_incorporation():
+    e = event()
+    validate_census_events([e])
+    validate_estimate_incorporations([incorporation(e.census_event_id)], events=[e])
+
+
+def test_conflicting_sources_are_separate_assertions_not_overwritten():
+    a = event()
+    b = event(source_id="unfpa_census", snapshot_id="snapshot:two", results_status="preliminary")
+    validate_census_events([a, b])
+    assert a.census_event_id != b.census_event_id
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"enumeration_start_date": "2020-05-01"}, "cannot follow"),
+        ({"enumeration_basis": "assumed"}, "invalid value"),
+        ({"estimated_net_undercount": 101}, "source percentage"),
+        (
+            {"post_enumeration_survey_status": "published", "pes_results_published": "unknown"},
+            "requires",
+        ),
+    ],
+)
+def test_event_chronology_vocabulary_and_consistency_fail_closed(changes, message):
+    with pytest.raises(CensusEvidenceError, match=message):
+        validate_census_events([event(**changes)])
+
+
+def test_unknown_incorporation_cannot_hide_an_analyst_inference():
+    e = event()
+    row = incorporation(
+        e.census_event_id, source_evidence_level="unknown", census_incorporated="yes"
+    )
+    with pytest.raises(CensusEvidenceError, match="unknown evidence"):
+        validate_estimate_incorporations([row], events=[e])
+    validate_estimate_incorporations(
+        [replace(row, census_incorporated="unknown", incorporation_method="unknown")], events=[e]
+    )
+
+
+def test_incorporation_requires_registered_event_and_unique_assertion():
+    e = event()
+    row = incorporation(e.census_event_id)
+    with pytest.raises(CensusEvidenceError, match="unknown census event"):
+        validate_estimate_incorporations([row], events=[])
+    with pytest.raises(CensusEvidenceError, match="duplicate"):
+        validate_estimate_incorporations([row, row], events=[e])


### PR DESCRIPTION
Implements the executable schema and validation foundation for #163 without claiming empirical completion.

Adds source-specific census-event identities; controlled enumeration, coverage, results, PES, and adjustment vocabularies; chronology and consistency checks; separate conflicting assertions; and estimate-series/vintage-qualified incorporation records with explicit evidence levels.

The status document records the remaining blocker: global PES, undercount, coverage-adjustment, results-status, and WPP/IDB incorporation evidence is fragmented across country and publisher documents. UNSD census dates alone cannot close #163.

Validation: lint passes; 382 tests pass; diff check passes.