### PR TITLE
Add deterministic UNSD assertion export

### DIFF
--- a/docs/census-evidence-163-status.md
+++ b/docs/census-evidence-163-status.md
@@ -39,6 +39,17 @@ Of the 1,530 cells, one remains syntactically unparsed because the source says
 promoted to a `CensusEvent`: the UNSD date table alone does not establish reference-date versus
 enumeration-date semantics, results status, geographic coverage, or census quality.
 
+`scripts/build_unsd_census_assertions.py` generates a deterministic staging CSV only from the two
+checksum-verified captures. The run must declare the exact reviewed unmatched-label and
+unparsed-value sets; any source drift fails closed. The staging rows carry the census-date source
+snapshot, while the transformation registry separately records both the census-date and M49
+input snapshots. The transformation ID is not embedded in the hashed staging output because the
+ID itself includes the output checksum; embedding it would create a circular identity.
+
+The generated CSV remains under ignored `data/processed/restricted/` storage and is not committed
+or distributed. A transformation run can be registered only after the generator commit is merged
+and the output is regenerated from that exact commit.
+
 Issue #163 is not empirically complete. Required PES, undercount, coverage-adjustment,
 results-status, and WPP/IDB incorporation evidence is distributed across country reports and
 publisher notes. The UNFPA, WPP, and IDB artifacts still need release-specific capture,

--- a/scripts/build_unsd_census_assertions.py
+++ b/scripts/build_unsd_census_assertions.py
@@ -1,0 +1,92 @@
+"""Build a deterministic, non-committed UNSD census-date staging table."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+from urban_growth.unsd_census_dates import (
+    UNSD_TO_M49_ALIASES,
+    build_census_assertions,
+    build_country_crosswalk,
+    census_assertions_csv_bytes,
+    parse_m49_countries,
+    parse_raw_census_cells,
+    require_expected_exceptions,
+)
+
+CENSUS_SOURCE_ID = "unsd_census_dates_2026_02_03"
+CENSUS_RELEASE = "Last updated 03 February 2026"
+CENSUS_SHA256 = "900b7f3691efe2c1309e422b16816e5ed45ebb127a7e71db3443f987fccf6165"
+CENSUS_SNAPSHOT_ID = f"{CENSUS_SOURCE_ID}:{CENSUS_SHA256}"
+M49_SHA256 = "b9048114f6e7f2abda83bf03d4263c9d7cd1bd7230e3d0461025ee7839a7a1fb"
+
+
+def _verified_text(path: Path, expected_sha256: str) -> str:
+    payload = path.read_bytes()
+    actual = hashlib.sha256(payload).hexdigest()
+    if actual != expected_sha256:
+        raise ValueError(f"{path} checksum mismatch: expected {expected_sha256}, got {actual}")
+    return payload.decode("utf-8")
+
+
+def build_output(
+    *,
+    census_html_path: Path,
+    m49_html_path: Path,
+    allowed_unmatched: set[str],
+    allowed_unparsed: set[str],
+) -> bytes:
+    census_html = _verified_text(census_html_path, CENSUS_SHA256)
+    m49_html = _verified_text(m49_html_path, M49_SHA256)
+    cells = parse_raw_census_cells(census_html)
+    m49 = parse_m49_countries(m49_html)
+    names = sorted({row.source_country_name for row in cells})
+    crosswalk = build_country_crosswalk(names, m49, aliases=UNSD_TO_M49_ALIASES)
+    assertions = build_census_assertions(cells, crosswalk)
+    require_expected_exceptions(
+        assertions,
+        allowed_unmatched=allowed_unmatched,
+        allowed_unparsed=allowed_unparsed,
+    )
+    return census_assertions_csv_bytes(
+        assertions,
+        source_id=CENSUS_SOURCE_ID,
+        source_release=CENSUS_RELEASE,
+        snapshot_id=CENSUS_SNAPSHOT_ID,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--census-html", type=Path, required=True)
+    parser.add_argument("--m49-html", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--allow-unmatched", action="append", default=[])
+    parser.add_argument("--allow-unparsed", action="append", default=[])
+    args = parser.parse_args()
+
+    payload = build_output(
+        census_html_path=args.census_html,
+        m49_html_path=args.m49_html,
+        allowed_unmatched=set(args.allow_unmatched),
+        allowed_unparsed=set(args.allow_unparsed),
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_bytes(payload)
+    print(
+        json.dumps(
+            {
+                "output_path": args.output.as_posix(),
+                "bytes": len(payload),
+                "sha256": hashlib.sha256(payload).hexdigest(),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/urban_growth/unsd_census_dates.py
+++ b/src/urban_growth/unsd_census_dates.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import csv
+import io
+import json
 import re
 import unicodedata
 from dataclasses import dataclass
@@ -23,6 +26,24 @@ ASSERTION_STATUSES = {
     "unparsed",
 }
 CROSSWALK_STATUSES = {"matched", "unmatched", "ambiguous"}
+ASSERTION_OUTPUT_FIELDS = [
+    "region",
+    "source_country_name",
+    "country_id",
+    "crosswalk_status",
+    "census_round",
+    "occurrence",
+    "raw_text",
+    "assertion_status",
+    "date_start",
+    "date_end",
+    "date_precision",
+    "footnotes_json",
+    "source_links_json",
+    "source_id",
+    "source_release",
+    "snapshot_id",
+]
 
 # Source-specific historical/abbreviated labels mapped to exact names in the pinned M49 page.
 # UK constituent-country rows and dissolved areas are deliberately absent: mapping them to a
@@ -493,3 +514,66 @@ def validate_census_assertions(assertions: list[CensusDateAssertion]) -> None:
         if identity in identities:
             raise UNSDParseError("duplicate source census cell")
         identities.add(identity)
+
+
+def require_expected_exceptions(
+    assertions: list[CensusDateAssertion],
+    *,
+    allowed_unmatched: set[str],
+    allowed_unparsed: set[str],
+) -> None:
+    """Require an exact, reviewed exception set rather than accepting new source drift."""
+    actual_unmatched = {
+        row.source_country_name for row in assertions if row.crosswalk_status != "matched"
+    }
+    actual_unparsed = {row.raw_text for row in assertions if row.assertion_status == "unparsed"}
+    if actual_unmatched != allowed_unmatched:
+        raise UNSDParseError(
+            f"unmatched country labels changed: expected={sorted(allowed_unmatched)!r}, "
+            f"actual={sorted(actual_unmatched)!r}"
+        )
+    if actual_unparsed != allowed_unparsed:
+        raise UNSDParseError(
+            f"unparsed date cells changed: expected={sorted(allowed_unparsed)!r}, "
+            f"actual={sorted(actual_unparsed)!r}"
+        )
+
+
+def census_assertions_csv_bytes(
+    assertions: list[CensusDateAssertion],
+    *,
+    source_id: str,
+    source_release: str,
+    snapshot_id: str,
+) -> bytes:
+    """Serialize staging assertions as deterministic UTF-8 CSV bytes."""
+    validate_census_assertions(assertions)
+    handle = io.StringIO(newline="")
+    writer = csv.DictWriter(handle, fieldnames=ASSERTION_OUTPUT_FIELDS, lineterminator="\n")
+    writer.writeheader()
+    for row in assertions:
+        writer.writerow(
+            {
+                "region": row.region,
+                "source_country_name": row.source_country_name,
+                "country_id": row.country_id or "",
+                "crosswalk_status": row.crosswalk_status,
+                "census_round": row.census_round,
+                "occurrence": row.occurrence,
+                "raw_text": row.raw_text,
+                "assertion_status": row.assertion_status,
+                "date_start": row.date_start or "",
+                "date_end": row.date_end or "",
+                "date_precision": row.date_precision or "",
+                "footnotes_json": json.dumps(
+                    row.footnotes, ensure_ascii=False, separators=(",", ":")
+                ),
+                "source_links_json": json.dumps(
+                    row.source_links, ensure_ascii=False, separators=(",", ":")
+                ),
+                "source_id": source_id,
+                "source_release": source_release,
+                "snapshot_id": snapshot_id,
+            }
+        )
+    return handle.getvalue().encode("utf-8")

--- a/tests/test_unsd_census_dates.py
+++ b/tests/test_unsd_census_dates.py
@@ -1,10 +1,18 @@
+import csv
+import io
+
+import pytest
+
 from urban_growth.unsd_census_dates import (
     UNSD_TO_M49_ALIASES,
+    UNSDParseError,
     build_census_assertions,
     build_country_crosswalk,
+    census_assertions_csv_bytes,
     classify_date_text,
     parse_m49_countries,
     parse_raw_census_cells,
+    require_expected_exceptions,
 )
 
 CENSUS_HTML = """
@@ -82,3 +90,32 @@ def test_symbol_states_remain_distinct():
     }
     for raw, status in expected.items():
         assert classify_date_text(raw)[0] == status
+
+
+def test_exception_gate_requires_exact_reviewed_sets():
+    m49 = parse_m49_countries(M49_HTML)
+    crosswalk = build_country_crosswalk(["United States of America"], m49)
+    assertions = build_census_assertions(parse_raw_census_cells(CENSUS_HTML), crosswalk)
+    require_expected_exceptions(assertions, allowed_unmatched=set(), allowed_unparsed=set())
+    with pytest.raises(UNSDParseError, match="unmatched country labels changed"):
+        require_expected_exceptions(
+            assertions,
+            allowed_unmatched={"invented exception"},
+            allowed_unparsed=set(),
+        )
+
+
+def test_csv_serialization_is_deterministic_and_keeps_source_snapshot():
+    m49 = parse_m49_countries(M49_HTML)
+    crosswalk = build_country_crosswalk(["United States of America"], m49)
+    assertions = build_census_assertions(parse_raw_census_cells(CENSUS_HTML), crosswalk)
+    kwargs = {
+        "source_id": "unsd_dates",
+        "source_release": "release",
+        "snapshot_id": "snapshot:abc",
+    }
+    first = census_assertions_csv_bytes(assertions, **kwargs)
+    assert first == census_assertions_csv_bytes(assertions, **kwargs)
+    rows = list(csv.DictReader(io.StringIO(first.decode("utf-8"))))
+    assert rows[0]["snapshot_id"] == "snapshot:abc"
+    assert rows[0]["footnotes_json"] == '["(C)","(17)"]'


### PR DESCRIPTION
Advances #163 without closing it.

Adds a checksum-gated generator for the non-committed UNSD census-date staging table.

Controls:
- reads only the two registered exact HTML captures
- verifies both SHA-256 values before parsing
- requires the exact reviewed unmatched-label and unparsed-value sets
- fails on any source or exception drift
- produces deterministic UTF-8 CSV with fixed columns and LF line endings
- carries source identity, release, and census-date snapshot on every staging row
- keeps output under ignored restricted processed storage

The transformation ID is deliberately not embedded in the hashed output because the ID includes the output checksum. The transformation registry will be added only after this generator is merged and rerun from the merge commit.

Validation:
- 387 tests passed
- Ruff passed
- diff check passed

The generated table remains non-committed pending UNSD page-specific rights review.