### PR TITLE
Add MAP accessibility sensitivity infrastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add synthetic MAP-accessibility sensitivity infrastructure: smooth exponential rival-mass exposure and preregistered threshold-proximity diagnostics for the 1h/2h/4h hard-band boundaries. This is measurement-error/robustness infrastructure, not an empirical accessibility finding.
+
 - Add fail-closed population-reliability snapshot and transformation provenance contracts,
   including deterministic lineage IDs, existing catalog/license foreign keys, exact UTC
   capture times, revision coexistence, and evidence-to-input validation. No empirical

--- a/docs/h5-border-neutral-accessibility.md
+++ b/docs/h5-border-neutral-accessibility.md
@@ -1,0 +1,39 @@
+# H5 border-neutral accessibility requirement
+
+H5 asks whether national borders condition spatial spillovers beyond distance and physical accessibility.
+
+## Source constraint
+
+Weiss et al. (2018) construct the nominal-2015 friction surface from roads, rail, rivers, water, land cover, terrain and national borders. Border penalties are imposed inside the friction surface with priority over other layers. The published implementation uses a static one-hour crossing penalty outside Schengen and the UK-Ireland common zone because globally consistent crossing-time data were unavailable.
+
+The current Malaria Atlas Project resource page exposes direct downloads for both the travel-time-to-cities raster and the associated friction surface. MAP's current open-access policy states that its maps are available under CC BY 3.0 Unported with citation.
+
+## Identification consequence
+
+The published MAP surface cannot be the primary H5 exposure. Using a border-penalized travel-time surface and then testing whether cross-border rival mass is weaker would partly recover an upstream modeling assumption.
+
+The primary H5 exposure must use **border-neutral physical travel time**. Rival population is split into same-country and cross-border mass only after physical travel time is computed:
+
+`M_ib = M_ib_same_country + M_ib_cross_border`
+
+The substantive H5 contrast is the difference between the predictive contribution of same-country and cross-border physically accessible rival mass conditional on the baseline geography/accessibility model. Coefficient sign alone does not identify competition or agglomeration.
+
+## Why the released friction surface cannot simply be corrected
+
+Because the border rule is imposed within friction construction, the released raster does not preserve the counterfactual border-free cost at those cells. Subtracting one hour from cross-border paths is not an equivalent reconstruction: removing the penalty can change the least-cost route itself.
+
+Rebuilding the original 2015 surface without borders also has a lineage constraint because the paper merged OSM roads with a Google roads-derived layer; the historical Google component is not a reproducible open input in this repository.
+
+## Empirical activation gate
+
+H5 remains blocked until one of these is preregistered and implemented:
+
+1. a separately sourced border-neutral physical friction surface with acceptable vintage, licensing and reproducibility;
+2. an open reconstruction from pinned transport/terrain inputs, validated against MAP or another benchmark, with the estimand explicitly defined to that reconstruction; or
+3. a different border-discontinuity design that does not condition on a border-penalized accessibility raster.
+
+The MAP border-penalized surface may remain as a sensitivity specification only.
+
+Related: #31, #157, #203.
+
+This document is a design constraint, not an empirical result.

--- a/src/urban_growth/accessibility.py
+++ b/src/urban_growth/accessibility.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pandas as pd
 
 from urban_growth.io import SourceSchemaError, require_columns
 
 TRAVEL_TIME_BANDS = ((0, 1), (1, 2), (2, 4), (4, 8))
+DEFAULT_THRESHOLD_HOURS = (1.0, 2.0, 4.0)
 
 
 def _validate_accessibility_pairs(
@@ -56,6 +58,107 @@ def mutually_exclusive_rival_mass(
     result["accessibility_nominal_vintage"] = nominal_vintage
     result["band_definition"] = "mutually_exclusive_left_closed"
     return result.reset_index()
+
+
+def continuous_rival_mass(
+    pairs: pd.DataFrame,
+    *,
+    nominal_vintage: int,
+    decay_scale_hours: float = 1.0,
+    max_time_hours: float = 8.0,
+    focal_column: str = "focal_city_id",
+    travel_time_column: str = "travel_time_hours",
+    rival_population_column: str = "rival_population",
+) -> pd.DataFrame:
+    """Aggregate rival population with smooth exponential travel-time decay.
+
+    This is a robustness exposure for hard travel-time bands. It is descriptive and
+    predictive only: the weighted mass does not identify competition, agglomeration,
+    or a causal infrastructure effect.
+    """
+    _validate_accessibility_pairs(
+        pairs,
+        nominal_vintage=nominal_vintage,
+        focal_column=focal_column,
+        travel_time_column=travel_time_column,
+        rival_population_column=rival_population_column,
+    )
+    if decay_scale_hours <= 0:
+        raise SourceSchemaError("decay_scale_hours must be positive")
+    if max_time_hours <= 0:
+        raise SourceSchemaError("max_time_hours must be positive")
+
+    eligible = pairs.loc[pairs[travel_time_column].lt(max_time_hours)].copy()
+    eligible["_accessibility_weight"] = np.exp(
+        -eligible[travel_time_column].astype(float) / float(decay_scale_hours)
+    )
+    eligible["_weighted_rival_population"] = (
+        eligible[rival_population_column].astype(float) * eligible["_accessibility_weight"]
+    )
+
+    index = pd.Index(pairs[focal_column].drop_duplicates(), name=focal_column)
+    weighted = eligible.groupby(focal_column)["_weighted_rival_population"].sum()
+    result = pd.DataFrame(index=index)
+    result["rival_mass_exponential"] = weighted.reindex(index, fill_value=0.0)
+    result["decay_scale_hours"] = float(decay_scale_hours)
+    result["max_time_hours"] = float(max_time_hours)
+    result["accessibility_nominal_vintage"] = nominal_vintage
+    result["exposure_definition"] = "exponential_decay_border_neutral_or_registered_input"
+    return result.reset_index()
+
+
+def travel_time_threshold_diagnostics(
+    pairs: pd.DataFrame,
+    *,
+    nominal_vintage: int,
+    tolerance_minutes: float,
+    thresholds_hours: tuple[float, ...] = DEFAULT_THRESHOLD_HOURS,
+    focal_column: str = "focal_city_id",
+    travel_time_column: str = "travel_time_hours",
+    rival_population_column: str = "rival_population",
+) -> pd.DataFrame:
+    """Measure how much pair count and rival mass lie near hard band thresholds.
+
+    The tolerance must be preregistered before empirical growth outcomes are inspected.
+    Rows near a threshold are not automatically excluded; the output quantifies how much
+    exposure could change band under travel-time measurement error of that magnitude.
+    """
+    _validate_accessibility_pairs(
+        pairs,
+        nominal_vintage=nominal_vintage,
+        focal_column=focal_column,
+        travel_time_column=travel_time_column,
+        rival_population_column=rival_population_column,
+    )
+    if tolerance_minutes <= 0:
+        raise SourceSchemaError("tolerance_minutes must be positive")
+    if not thresholds_hours:
+        raise SourceSchemaError("At least one travel-time threshold is required")
+    if any(threshold <= 0 for threshold in thresholds_hours):
+        raise SourceSchemaError("Travel-time thresholds must be positive")
+    if len(set(thresholds_hours)) != len(thresholds_hours):
+        raise SourceSchemaError("Travel-time thresholds must be unique")
+
+    tolerance_hours = float(tolerance_minutes) / 60.0
+    total_pairs = len(pairs)
+    total_mass = float(pairs[rival_population_column].sum())
+    rows: list[dict[str, float | int]] = []
+    for threshold in thresholds_hours:
+        near = pairs[travel_time_column].sub(float(threshold)).abs().le(tolerance_hours)
+        pair_count = int(near.sum())
+        rival_mass = float(pairs.loc[near, rival_population_column].sum())
+        rows.append(
+            {
+                "threshold_hours": float(threshold),
+                "tolerance_minutes": float(tolerance_minutes),
+                "pair_count_near_threshold": pair_count,
+                "pair_share_near_threshold": pair_count / total_pairs if total_pairs else 0.0,
+                "rival_mass_near_threshold": rival_mass,
+                "rival_mass_share_near_threshold": rival_mass / total_mass if total_mass else 0.0,
+                "accessibility_nominal_vintage": nominal_vintage,
+            }
+        )
+    return pd.DataFrame(rows)
 
 
 def border_conditioned_rival_mass(

--- a/src/urban_growth/accessibility.py
+++ b/src/urban_growth/accessibility.py
@@ -144,7 +144,9 @@ def travel_time_threshold_diagnostics(
     total_mass = float(pairs[rival_population_column].sum())
     rows: list[dict[str, float | int]] = []
     for threshold in thresholds_hours:
-        near = pairs[travel_time_column].sub(float(threshold)).abs().le(tolerance_hours)
+        distance = pairs[travel_time_column].astype(float).sub(float(threshold)).abs()
+        boundary_slack = np.finfo(float).eps * max(1.0, abs(float(threshold)), tolerance_hours) * 8
+        near = distance.le(tolerance_hours + boundary_slack)
         pair_count = int(near.sum())
         rival_mass = float(pairs.loc[near, rival_population_column].sum())
         rows.append(

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -1,7 +1,13 @@
+import numpy as np
 import pandas as pd
 import pytest
 
-from urban_growth.accessibility import border_conditioned_rival_mass, mutually_exclusive_rival_mass
+from urban_growth.accessibility import (
+    border_conditioned_rival_mass,
+    continuous_rival_mass,
+    mutually_exclusive_rival_mass,
+    travel_time_threshold_diagnostics,
+)
 from urban_growth.io import SourceSchemaError
 
 
@@ -32,6 +38,101 @@ def test_accessibility_rejects_historical_vintage() -> None:
     )
     with pytest.raises(SourceSchemaError, match="modern validation"):
         mutually_exclusive_rival_mass(pairs, nominal_vintage=1990)
+
+
+def test_continuous_rival_mass_uses_exponential_decay_and_cutoff() -> None:
+    pairs = pd.DataFrame(
+        {
+            "focal_city_id": ["a", "a", "b"],
+            "rival_city_id": ["b", "c", "a"],
+            "travel_time_hours": [0.0, 1.0, 9.0],
+            "rival_population": [100.0, 100.0, 500.0],
+        }
+    )
+
+    result = continuous_rival_mass(
+        pairs,
+        nominal_vintage=2015,
+        decay_scale_hours=1.0,
+        max_time_hours=8.0,
+    ).set_index("focal_city_id")
+
+    assert result.loc["a", "rival_mass_exponential"] == pytest.approx(100 + 100 / np.e)
+    assert result.loc["b", "rival_mass_exponential"] == 0
+    assert result.loc["a", "exposure_definition"] == (
+        "exponential_decay_border_neutral_or_registered_input"
+    )
+
+
+@pytest.mark.parametrize(
+    ("parameter", "value", "message"),
+    [
+        ("decay_scale_hours", 0.0, "decay_scale_hours"),
+        ("max_time_hours", 0.0, "max_time_hours"),
+    ],
+)
+def test_continuous_rival_mass_rejects_nonpositive_parameters(
+    parameter: str, value: float, message: str
+) -> None:
+    pairs = pd.DataFrame(
+        {
+            "focal_city_id": ["a"],
+            "rival_city_id": ["b"],
+            "travel_time_hours": [1.0],
+            "rival_population": [10],
+        }
+    )
+    kwargs = {parameter: value}
+    with pytest.raises(SourceSchemaError, match=message):
+        continuous_rival_mass(pairs, nominal_vintage=2015, **kwargs)
+
+
+def test_threshold_diagnostics_quantify_pair_and_mass_exposure() -> None:
+    pairs = pd.DataFrame(
+        {
+            "focal_city_id": ["a"] * 5,
+            "rival_city_id": ["b", "c", "d", "e", "f"],
+            "travel_time_hours": [0.75, 0.9, 1.1, 2.2, 4.0],
+            "rival_population": [10, 20, 30, 40, 100],
+        }
+    )
+
+    result = travel_time_threshold_diagnostics(
+        pairs,
+        nominal_vintage=2015,
+        tolerance_minutes=6,
+    ).set_index("threshold_hours")
+
+    assert result.loc[1.0, "pair_count_near_threshold"] == 2
+    assert result.loc[1.0, "pair_share_near_threshold"] == pytest.approx(2 / 5)
+    assert result.loc[1.0, "rival_mass_near_threshold"] == 50
+    assert result.loc[1.0, "rival_mass_share_near_threshold"] == pytest.approx(50 / 200)
+    assert result.loc[2.0, "pair_count_near_threshold"] == 0
+    assert result.loc[4.0, "pair_count_near_threshold"] == 1
+    assert result.loc[4.0, "rival_mass_near_threshold"] == 100
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"tolerance_minutes": 0}, "tolerance_minutes"),
+        ({"tolerance_minutes": 10, "thresholds_hours": ()}, "At least one"),
+        ({"tolerance_minutes": 10, "thresholds_hours": (1.0, 1.0)}, "unique"),
+        ({"tolerance_minutes": 10, "thresholds_hours": (0.0,)}, "positive"),
+    ],
+)
+def test_threshold_diagnostics_fail_closed(kwargs: dict[str, object], message: str) -> None:
+    pairs = pd.DataFrame(
+        {
+            "focal_city_id": ["a"],
+            "rival_city_id": ["b"],
+            "travel_time_hours": [1.0],
+            "rival_population": [10],
+        }
+    )
+
+    with pytest.raises(SourceSchemaError, match=message):
+        travel_time_threshold_diagnostics(pairs, nominal_vintage=2015, **kwargs)
 
 
 def test_border_conditioned_mass_splits_each_band() -> None:


### PR DESCRIPTION
Implements the synthetic infrastructure for #203 without activating empirical MAP results.

Changes:
- add `continuous_rival_mass()` with exponential travel-time decay as a smooth robustness exposure;
- add `travel_time_threshold_diagnostics()` to quantify pair and rival-population mass near preregistered 1h/2h/4h hard-band thresholds;
- add fail-closed validation for nonpositive decay/cutoff/tolerance and invalid threshold definitions;
- add synthetic tests for decay behavior, cutoff behavior, threshold shares, and validation gates;
- update CHANGELOG to state explicitly that this is measurement-error/robustness infrastructure, not an empirical finding.

Methodological intent: support #203 diagnostics once #31 allows empirical MAP/friction data. This PR does not resolve #31 and does not add any result to `results/`.

Closes the synthetic-infrastructure portion of #203; empirical execution remains blocked by #31.