### PR TITLE
Add H5 border-neutral road routing pilot contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add an outcome-blind H5 historical-OSM routing pilot preregistration and fail-closed routed-pair validation contract. Primary routes must be border-neutral, within preregistered snap/time limits, and explicitly successful before they can feed H5 exposures. This is pilot infrastructure, not an empirical border finding.
+
 - Add synthetic MAP-accessibility sensitivity infrastructure: smooth exponential rival-mass exposure and preregistered threshold-proximity diagnostics for the 1h/2h/4h hard-band boundaries. This is measurement-error/robustness infrastructure, not an empirical accessibility finding.
 
 - Add fail-closed population-reliability snapshot and transformation provenance contracts,

--- a/docs/h5-internal-accessibility-preregistration.md
+++ b/docs/h5-internal-accessibility-preregistration.md
@@ -1,0 +1,120 @@
+# H5 internal accessibility control — draft preregistration
+
+Status: **draft preregistration**. The computational architecture is fixed in principle, but empirical activation remains blocked pending OSM source/vintage acquisition and routing-quality assessment. Three residual specification TODOs (R1–R3) must be closed before preregistration is complete.
+
+Related: #157, #203, #205, #206, PR #207.
+
+## Purpose
+
+Control explicitly for focal-city internal accessibility so H5 domestic/foreign rival-mass coefficients do not absorb within-city form, sprawl, or egress friction. Internal accessibility is treated as a focal-city attribute, separate from pairwise intercity accessibility.
+
+Primary H5 interpretation remains: physically accessible rival population across versus within borders, conditional on focal-city internal accessibility and other preregistered controls.
+
+## Primary estimator
+
+Let `g` index population grid cells inside city `i`, `P_g` denote gridded population, and `A_i` denote the city's algorithmic set of eligible intercity-network gateway nodes. For each grid cell, compute minimum routed time to any eligible gateway:
+
+`T_gAi = min_{a in A_i} T(g -> a)`.
+
+Primary internal-accessibility summaries are population-weighted:
+
+- mean travel time;
+- median travel time;
+- P90 travel time;
+- `Share30`: share of city population with modeled travel time greater than 30 minutes.
+
+Preregistered tail sensitivities are `Share15` and `Share45`. These thresholds may not be changed after growth outcomes are inspected.
+
+## Gateway set A_i
+
+Primary eligible road classes are OpenStreetMap `motorway`, `trunk`, and `primary`, including corresponding `_link` variants.
+
+`A_i` contains all routable nodes on those eligible classes located within the urban footprint plus a fixed **5 km buffer**. There is no analyst-selected minimum or maximum gateway count.
+
+If no eligible gateway node exists within the footprint plus 5 km, the primary metric is unavailable. It must not be replaced by an arbitrarily large travel time.
+
+Adding `secondary` roads is a preregistered sensitivity only.
+
+Directional egress toward a specific rival city is a sensitivity analysis only. It is not the primary `InternalAccess_i` measure because pair-specific egress would contaminate the focal-city control with external-exposure direction.
+
+**TODO R1 — urban footprint pointer:** link this definition to the exact project city-boundary/urban-footprint layer already used by the city concordance and spatial modules. Internal-accessibility cells, gateway selection, and H5 rival-mass city extents must use the same city-extent semantics unless an explicitly preregistered sensitivity says otherwise.
+
+## Rival-side access
+
+Rival-city internal access `T_j^access` is excluded from the primary rival-mass travel-time decay/bands. Primary H5 pairwise accessibility is gateway-to-gateway physical road-network travel time.
+
+Rival-side access may enter only through a separately labeled sensitivity, such as an access-adjusted rival-population weight or rival-city attribute. It may not silently alter the primary domestic/foreign rival-mass estimand.
+
+## Source and temporal contract
+
+Historical OSM routing is the primary measurement source. Weiss/MAP accessibility may be used only as validation/sensitivity context, not as an intra-urban ground-truth measure.
+
+Internal and intercity routing must use the same primary network specification:
+
+- same OSM snapshot vintage;
+- same geographic build/extract lineage;
+- same routing-engine version;
+- same routing profile;
+- same speed defaults;
+- same ferry policy;
+- same snapping rules.
+
+Any deliberate divergence belongs in a separately labeled sensitivity and must state why the sources differ.
+
+A later road network is never carried backward to an earlier growth period. Unsupported city-rounds remain in the underlying city panel but receive `internal_access_status = vintage_unavailable` and are excluded only from specifications requiring InternalAccess.
+
+**TODO R2 — vintage tolerance:** set the maximum allowed lag between the accessibility reference date and the admissible OSM snapshot. The rule must be numeric and applied identically across cities before empirical routing.
+
+## Routing-support adequacy
+
+Primary maximum population-cell snap distance is **2 km**.
+
+Define population-weighted snap coverage as:
+
+`SnapCoverage_i = population successfully snapped within 2 km / total gridded population in city i`.
+
+Primary InternalAccess requires `SnapCoverage_i >= 0.90`.
+
+Also report the fraction of successfully snapped population connected to a graph component containing at least one eligible gateway node.
+
+**TODO R3 — connectivity gate:** either set a numeric minimum connected-population fraction for primary acceptance or state explicitly that the connectivity statistic is informational only. This choice must be frozen before empirical routing.
+
+A city failing a required routing-support gate receives `internal_access_status = insufficient_routing_support` rather than a high travel-time value.
+
+**Measurement unavailable is not measured low accessibility. A sparse OSM network must never be interpreted as evidence of poor internal connectivity.**
+
+Do not label low road density or poor routing support as "OSM incompleteness" unless an independent external benchmark actually supports a completeness assessment.
+
+## Measurement semantics and caveat
+
+InternalAccess is a modeled road-network accessibility proxy, not observed commuting or urban travel time. It does not observe congestion, transit schedules, mode availability, vehicle ownership, waiting, or other behavioral frictions.
+
+The Weiss/MAP friction surface is approximately kilometre-scale and designed for global accessibility-to-cities rather than intra-urban circulation; it may inform sensitivity/validation but must not be presented as observed internal travel time.
+
+## Relationship to Module C
+
+Built-up extent, density, and InternalAccess are related but not interchangeable. Joint specifications must diagnose collinearity and emphasize incremental out-of-sample predictive value rather than over-interpreting individual coefficients when predictors are strongly correlated.
+
+## Missingness states
+
+At minimum retain distinct states for:
+
+- `measured`;
+- `vintage_unavailable`;
+- `no_eligible_gateway`;
+- `insufficient_routing_support`;
+- `route_failure` or equivalent graph/routing failure.
+
+These states may not be collapsed into high accessibility cost.
+
+## Empirical activation gate
+
+This draft may be implemented with synthetic tests now. Empirical H5 use remains blocked until:
+
+1. R1–R3 are closed;
+2. exact OSM source, vintage, checksum, engine, and profile are registered;
+3. source/license governance is resolved;
+4. routing-support adequacy is evaluated outcome-blind;
+5. no growth outcomes have influenced network/profile/gateway choices.
+
+Only after those conditions are met may InternalAccess enter H5 empirical specifications.

--- a/docs/h5-osm-pilot-preregistration.md
+++ b/docs/h5-osm-pilot-preregistration.md
@@ -1,0 +1,62 @@
+# H5 historical OSM border-neutral routing pilot — preregistration
+
+Status: **method-selection preregistration; no city-growth outcomes may be inspected for this pilot before the routing/validation decision is frozen.**
+
+Parent issues: #205, #206. Related: #31, #157, #203.
+
+## Purpose
+
+Test whether a reproducible historical OpenStreetMap road-network measure can provide the border-neutral physical-accessibility input required by H5. This is not a reproduction of the MAP multimodal friction surface and is not a causal border design.
+
+## Pilot geographies
+
+The pilot is fixed before growth outcomes are inspected:
+
+1. **Germany–Czechia**: high-connectivity European land-border corridor.
+2. **Mexico–Guatemala**: non-European land-border corridor with substantially different network density and mapping conditions.
+
+For each corridor, include domestic comparison pairs drawn from the same country-side border regions at comparable straight-line distance. Pair selection may use geography, city size, and network feasibility only; it may not use observed or forecast city-growth outcomes.
+
+A continent-scale or merged extract must be used where necessary so source clipping does not mechanically sever cross-border roads.
+
+## City and pair contract
+
+- City identity comes from the project's existing city concordance, not OSM place nodes.
+- Representative point: project city centroid/representative point already used by spatial modules; if multiple definitions exist, freeze one before routing.
+- Directed focal-rival pairs; self-pairs prohibited.
+- Maximum routing horizon: **8 hours**, matching the existing H5 accessibility bands.
+- Maximum allowed snap distance: **2,000 m** for the primary pilot. Sensitivity at 1,000 m and 5,000 m may be reported, but the primary rule cannot change after outcome inspection.
+- Route failures and graph-disconnected pairs remain explicit validation failures; they are not assigned large synthetic travel times.
+
+## Border-neutrality rule
+
+The routing graph must not add any cost, delay, restriction, or penalty solely because an edge crosses an international boundary. Real road attributes present in OSM may affect routing, but country identity itself may not alter generalized cost in the primary H5 route.
+
+`border_penalty_applied` must be `False` for every primary routed pair accepted into exposure construction.
+
+## Routing profile
+
+Use an open reproducible motor-vehicle routing engine and a pinned profile. Engine version, profile hash, allowed highway classes, speed defaults, ferries, toll/restricted roads, and third-country routing must be committed before any growth regression is run.
+
+Until those fields are pinned, the pilot may generate synthetic/contract tests only and may not create empirical H5 results.
+
+## Source vintage
+
+Target a **2019-01-01 historical OSM snapshot** when an appropriate Geofabrik historical extract exists. If the exact geography/date is unavailable, the replacement vintage must be documented and approved before routing; it must not be selected based on growth results. The resulting variable is named by its actual OSM snapshot vintage, not "MAP 2015".
+
+## Validation
+
+Before any H5 growth model:
+
+- compare an outcome-blind preregistered sample of away-from-border pairs with an external travel-time benchmark;
+- report MAE, median absolute error, mean signed error/bias, and rank correlation;
+- report route success and snap-distance distributions separately for domestic and cross-border pairs;
+- verify no cost discontinuity is introduced merely by international-border crossing;
+- run hard-band and continuous/smoothed exposure constructions on the same accepted route table;
+- report sensitivity to reasonable routing-profile speed defaults.
+
+No single accuracy threshold is claimed in advance because a defensible external benchmark/sample has not yet been acquired. The go/no-go decision must therefore be documented before growth outcomes are inspected and must compare cross-border failure/snap behavior with domestic controls rather than accepting differential missingness silently.
+
+## Output semantics
+
+The pilot output is a modeled **road-network accessibility** measure. It excludes rail, navigable water, off-road walking, congestion, schedules, and other MAP friction components. It is a predictive exposure covariate only; coefficient signs do not identify competition, agglomeration, or causal border effects.

--- a/src/urban_growth/road_accessibility.py
+++ b/src/urban_growth/road_accessibility.py
@@ -1,0 +1,97 @@
+"""Validation helpers for border-neutral road-network accessibility pilots."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from urban_growth.io import SourceSchemaError, require_columns
+
+REQUIRED_ROUTE_COLUMNS = {
+    "focal_city_id",
+    "rival_city_id",
+    "travel_time_hours",
+    "route_distance_km",
+    "focal_snap_distance_m",
+    "rival_snap_distance_m",
+    "route_status",
+    "crosses_international_border",
+    "border_penalty_applied",
+}
+
+
+def validate_border_neutral_routes(
+    routes: pd.DataFrame,
+    *,
+    max_snap_distance_m: float,
+    max_travel_time_hours: float = 8.0,
+) -> pd.DataFrame:
+    """Validate routed city pairs before H5 exposure construction.
+
+    The contract is deliberately routing-engine agnostic. It accepts an audited table of
+    pairwise road-network routes and fails closed if any route embeds a border penalty,
+    exceeds preregistered snap/travel-time limits, duplicates a city pair, or is not
+    explicitly successful.
+    """
+    require_columns(routes, REQUIRED_ROUTE_COLUMNS, source_name="road accessibility routes")
+    if max_snap_distance_m <= 0:
+        raise SourceSchemaError("max_snap_distance_m must be positive")
+    if max_travel_time_hours <= 0:
+        raise SourceSchemaError("max_travel_time_hours must be positive")
+    if routes[["focal_city_id", "rival_city_id"]].isna().any().any():
+        raise SourceSchemaError("Route city IDs cannot be missing")
+    if (routes["focal_city_id"] == routes["rival_city_id"]).any():
+        raise SourceSchemaError("Road accessibility routes must exclude self-pairs")
+    if routes.duplicated(["focal_city_id", "rival_city_id"]).any():
+        raise SourceSchemaError("Road accessibility routes must contain unique directed city pairs")
+
+    numeric = [
+        "travel_time_hours",
+        "route_distance_km",
+        "focal_snap_distance_m",
+        "rival_snap_distance_m",
+    ]
+    if routes[numeric].isna().any().any():
+        raise SourceSchemaError("Successful road routes cannot contain missing numeric values")
+    if (routes[numeric] < 0).any().any():
+        raise SourceSchemaError("Road route time, distance, and snap distances cannot be negative")
+    if routes["route_status"].astype("string").ne("ok").any():
+        raise SourceSchemaError("Every routed pair must have route_status='ok'")
+    if routes["border_penalty_applied"].fillna(False).astype(bool).any():
+        raise SourceSchemaError("Primary H5 routes cannot include an international-border penalty")
+    if routes[["focal_snap_distance_m", "rival_snap_distance_m"]].gt(max_snap_distance_m).any().any():
+        raise SourceSchemaError("Route snap distance exceeds preregistered maximum")
+    if routes["travel_time_hours"].gt(max_travel_time_hours).any():
+        raise SourceSchemaError("Route travel time exceeds preregistered routing horizon")
+
+    result = routes.copy()
+    result["routing_definition"] = "border_neutral_road_network"
+    result["max_snap_distance_m"] = float(max_snap_distance_m)
+    result["max_travel_time_hours"] = float(max_travel_time_hours)
+    return result
+
+
+def route_quality_summary(routes: pd.DataFrame) -> pd.DataFrame:
+    """Summarize route quality separately for domestic and cross-border pairs."""
+    require_columns(
+        routes,
+        {
+            "route_status",
+            "crosses_international_border",
+            "focal_snap_distance_m",
+            "rival_snap_distance_m",
+        },
+        source_name="road accessibility routes",
+    )
+    rows: list[dict[str, float | int | bool]] = []
+    for cross_border, group in routes.groupby("crosses_international_border", dropna=False):
+        success = group["route_status"].astype("string").eq("ok")
+        snap_max = group[["focal_snap_distance_m", "rival_snap_distance_m"]].max(axis=1)
+        rows.append(
+            {
+                "crosses_international_border": bool(cross_border),
+                "pair_count": int(len(group)),
+                "route_success_rate": float(success.mean()) if len(group) else 0.0,
+                "median_max_snap_distance_m": float(snap_max.median()) if len(group) else 0.0,
+            }
+        )
+    return pd.DataFrame(rows)

--- a/src/urban_growth/road_accessibility.py
+++ b/src/urban_growth/road_accessibility.py
@@ -89,7 +89,7 @@ def route_quality_summary(routes: pd.DataFrame) -> pd.DataFrame:
         rows.append(
             {
                 "crosses_international_border": bool(cross_border),
-                "pair_count": int(len(group)),
+                "pair_count": len(group),
                 "route_success_rate": float(success.mean()) if len(group) else 0.0,
                 "median_max_snap_distance_m": float(snap_max.median()) if len(group) else 0.0,
             }

--- a/tests/test_road_accessibility.py
+++ b/tests/test_road_accessibility.py
@@ -1,0 +1,66 @@
+import pandas as pd
+import pytest
+
+from urban_growth.io import SourceSchemaError
+from urban_growth.road_accessibility import route_quality_summary, validate_border_neutral_routes
+
+
+def _routes() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "focal_city_id": ["a", "a", "d"],
+            "rival_city_id": ["b", "c", "e"],
+            "travel_time_hours": [1.0, 2.5, 0.75],
+            "route_distance_km": [70.0, 180.0, 45.0],
+            "focal_snap_distance_m": [100.0, 100.0, 75.0],
+            "rival_snap_distance_m": [125.0, 250.0, 90.0],
+            "route_status": ["ok", "ok", "ok"],
+            "crosses_international_border": [False, True, False],
+            "border_penalty_applied": [False, False, False],
+        }
+    )
+
+
+def test_validate_border_neutral_routes_accepts_clean_pairs() -> None:
+    result = validate_border_neutral_routes(_routes(), max_snap_distance_m=500)
+    assert (result["routing_definition"] == "border_neutral_road_network").all()
+    assert (result["max_snap_distance_m"] == 500.0).all()
+    assert (result["max_travel_time_hours"] == 8.0).all()
+
+
+def test_validate_border_neutral_routes_rejects_border_penalty() -> None:
+    routes = _routes()
+    routes.loc[1, "border_penalty_applied"] = True
+    with pytest.raises(SourceSchemaError, match="border penalty"):
+        validate_border_neutral_routes(routes, max_snap_distance_m=500)
+
+
+def test_validate_border_neutral_routes_rejects_route_failure() -> None:
+    routes = _routes()
+    routes.loc[1, "route_status"] = "no_route"
+    with pytest.raises(SourceSchemaError, match="route_status='ok'"):
+        validate_border_neutral_routes(routes, max_snap_distance_m=500)
+
+
+def test_validate_border_neutral_routes_rejects_excessive_snap() -> None:
+    routes = _routes()
+    routes.loc[1, "rival_snap_distance_m"] = 501.0
+    with pytest.raises(SourceSchemaError, match="snap distance"):
+        validate_border_neutral_routes(routes, max_snap_distance_m=500)
+
+
+def test_validate_border_neutral_routes_rejects_duplicate_directed_pairs() -> None:
+    routes = pd.concat([_routes(), _routes().iloc[[0]]], ignore_index=True)
+    with pytest.raises(SourceSchemaError, match="unique directed city pairs"):
+        validate_border_neutral_routes(routes, max_snap_distance_m=500)
+
+
+def test_route_quality_summary_separates_cross_border_pairs() -> None:
+    routes = _routes()
+    routes.loc[1, "route_status"] = "no_route"
+    summary = route_quality_summary(routes).set_index("crosses_international_border")
+    assert summary.loc[False, "pair_count"] == 2
+    assert summary.loc[False, "route_success_rate"] == 1.0
+    assert summary.loc[True, "pair_count"] == 1
+    assert summary.loc[True, "route_success_rate"] == 0.0
+    assert summary.loc[True, "median_max_snap_distance_m"] == 250.0


### PR DESCRIPTION
Implements the synthetic/method-selection portion of #206 without adding empirical OSM routes or growth results.

Changes:
- add `validate_border_neutral_routes()` fail-closed contract for routed city-pair tables;
- reject self-pairs, duplicates, route failures, missing/negative route metrics, excessive snap distance, excessive routing horizon, and any explicit border penalty;
- add `route_quality_summary()` to compare domestic and cross-border route success/snap behavior;
- add synthetic tests;
- preregister the pilot geographies (Germany–Czechia and Mexico–Guatemala), 8-hour routing horizon, 2 km primary snap threshold, outcome-blind pair selection, and border-neutrality rule;
- update CHANGELOG to state that this is pilot infrastructure, not an empirical border finding.

No OSM extract, engine/profile, route table, or empirical result is committed. Exact source/version/license/profile acquisition remains required under #206/#205 before empirical activation.