### PR TITLE
Add F21 acquisition gate and preregister panel fence

### DIFF
--- a/data/acquisition/WUP2025-F21-validation.json
+++ b/data/acquisition/WUP2025-F21-validation.json
@@ -1,0 +1,100 @@
+{
+  "activation_state": "ready_for_panel_construction",
+  "adapter_module": "urban_growth.f21_acquisition_gate",
+  "construction_commit": "70249dad153f4ba864fd7d566d05893be2421813",
+  "content": {
+    "below_threshold_populated_rows": 0,
+    "city_count": 16828,
+    "country_count": 194,
+    "duplicate_city_id_count": 0,
+    "estimate_cutoff_year": 2025,
+    "estimate_rows": 439711,
+    "null_population_rows": 0,
+    "passed": true,
+    "projection_rows": 340007,
+    "total_rows": 779718,
+    "year_columns_observed": [
+      1975, 1976, 1977, 1978, 1979, 1980, 1981, 1982, 1983, 1984,
+      1985, 1986, 1987, 1988, 1989, 1990, 1991, 1992, 1993, 1994,
+      1995, 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004,
+      2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014,
+      2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024,
+      2025, 2026, 2027, 2028, 2029, 2030, 2031, 2032, 2033, 2034,
+      2035, 2036, 2037, 2038, 2039, 2040, 2041, 2042, 2043, 2044,
+      2045, 2046, 2047, 2048, 2049, 2050
+    ]
+  },
+  "identity": {
+    "expected_bytes": 10671837,
+    "expected_sha256": "3a96030d87aec6c1c50f658d5321067d6345e1ab936c5d2854524f972caa75c0",
+    "observed_bytes": 10671837,
+    "observed_sha256": "3a96030d87aec6c1c50f658d5321067d6345e1ab936c5d2854524f972caa75c0",
+    "passed": true
+  },
+  "licensing": {
+    "license": "CC BY 3.0 IGO",
+    "redistribution_notes": "CC BY 3.0 IGO permits redistribution with attribution. UN copyright notice and citation required.",
+    "redistribution_permitted": true,
+    "repository_policy": "review_before_commit",
+    "repository_policy_notes": "Raw workbook intentionally not committed pending project review-before-commit policy. Legal permission and repository policy are distinct: redistribution is permitted under CC BY 3.0 IGO; committing to this repository requires explicit review per CONTRIBUTING.md."
+  },
+  "local_path": "/mnt/data/WUP2025-F21-DEGURBA-Cities_Pop.xlsx",
+  "overall_outcome": "pass",
+  "panel_fence_protocol": {
+    "pr_a_panel_freeze": {
+      "acceptance": "recorded_checklist_decision_required_before_merge",
+      "permitted": [
+        "origin_eligibility_table",
+        "singleton_exclusion_counts",
+        "city_and_country_counts_by_origin",
+        "paired_row_counts",
+        "weight_sums_and_distribution",
+        "leakage_assertions",
+        "schema_checks",
+        "panel_sha256"
+      ],
+      "prohibited": [
+        "b0_errors",
+        "b1_errors",
+        "rmse",
+        "mae",
+        "relative_rmse_improvement",
+        "mae_difference",
+        "gate_evaluation",
+        "model_preference_language"
+      ]
+    },
+    "pr_b_performance": {
+      "contains": [
+        "performance_metrics",
+        "w2_inconclusive_probe_registration",
+        "w2_complete_result_registration",
+        "gate_resolution"
+      ],
+      "prerequisite": "pr_a_merged"
+    }
+  },
+  "schema_check": {
+    "missing_columns": [],
+    "passed": true,
+    "required_columns": [
+      "1975",
+      "2025",
+      "2050",
+      "City_Code",
+      "City_Name",
+      "ISO3_Code",
+      "LocID",
+      "PWCent_Latitude",
+      "PWCent_Longitude"
+    ],
+    "required_columns_present": true,
+    "required_sheet": "Data",
+    "required_sheet_present": true
+  },
+  "source_id": "un_wup_2025_cities",
+  "table": "F21",
+  "validated_at": "2026-09-07T13:03:15.582800+00:00",
+  "validator_commit": "6da6d369b1b64b696d581ab038f7b4b7d5a0ecdb",
+  "vintage": "WUP_2025_F21"
+}

--- a/knowledge/schema/h1-oos-wup-v1.yaml
+++ b/knowledge/schema/h1-oos-wup-v1.yaml
@@ -1,6 +1,14 @@
 panel_spec_version: H1-WUP-OOS-V1
-status: preregistered_awaiting_source_bytes
-empirical_activation: blocked_pending_exact_f21_acquisition
+status: preregistered_source_acquired
+empirical_activation: blocked_source_validation
+empirical_activation_enum:
+  - blocked_source_unavailable
+  - blocked_source_identity
+  - blocked_source_validation
+  - ready_for_panel_construction
+  - panel_frozen
+  - ready_for_performance_evaluation
+  - evaluation_complete
 source:
   source_id: un_wup_2025_cities
   table: F21
@@ -74,6 +82,34 @@ lineage:
     - construction_command
     - eligible_origins
     - panel_sha256
+panel_fence_protocol:
+  pr_a_panel_freeze:
+    permitted:
+      - origin_eligibility_table
+      - singleton_exclusion_counts
+      - city_and_country_counts_by_origin
+      - paired_row_counts
+      - weight_sums_and_distribution
+      - leakage_assertions
+      - schema_checks
+      - panel_sha256
+    prohibited:
+      - b0_errors
+      - b1_errors
+      - rmse
+      - mae
+      - relative_rmse_improvement
+      - mae_difference
+      - gate_evaluation
+      - model_preference_language
+    acceptance: recorded_checklist_decision_required_before_merge
+  pr_b_performance:
+    prerequisite: pr_a_merged
+    contains:
+      - performance_metrics
+      - w2_inconclusive_probe_registration
+      - w2_complete_result_registration
+      - gate_resolution
 limitations:
   - WUP historical pseudo-OOS series may be smoother than direct-count census observations.
   - Passing the WUP gate does not substitute for external direct-count validation.

--- a/knowledge/schema/h1-oos-wup-v1.yaml
+++ b/knowledge/schema/h1-oos-wup-v1.yaml
@@ -1,6 +1,6 @@
 panel_spec_version: H1-WUP-OOS-V1
 status: preregistered_source_acquired
-empirical_activation: blocked_source_validation
+empirical_activation: ready_for_panel_construction
 empirical_activation_enum:
   - blocked_source_unavailable
   - blocked_source_identity

--- a/src/urban_growth/f21_acquisition_gate.py
+++ b/src/urban_growth/f21_acquisition_gate.py
@@ -1,0 +1,394 @@
+"""F21 acquisition gate: validate registered bytes and produce a machine-readable record.
+
+The validator MUST hash the local file first and abort before opening the workbook
+if the hash does not match the preregistered SHA-256. A mismatch is a source-version
+discrepancy, not a reason to substitute the file.
+
+Produces data/acquisition/WUP2025-F21-validation.json.
+
+Two commit SHAs are recorded:
+  validator_commit  -- the commit of this validator at the time of the run.
+                       Advances with each acquisition-gate PR revision.
+  construction_commit -- the builder commit (70249dad) that will be used for
+                         panel construction. Fixed independently of validator
+                         revisions so source validation and panel construction
+                         remain separately attributable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from datetime import UTC, datetime
+from enum import Enum
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+REGISTERED_SHA256 = "3a96030d87aec6c1c50f658d5321067d6345e1ab936c5d2854524f972caa75c0"
+REGISTERED_BYTES = 10_671_837
+REGISTERED_SOURCE_ID = "un_wup_2025_cities"
+REGISTERED_TABLE = "F21"
+REGISTERED_VINTAGE = "WUP_2025_F21"
+REQUIRED_COLUMNS = frozenset(
+    {
+        "LocID",
+        "ISO3_Code",
+        "City_Code",
+        "City_Name",
+        "PWCent_Longitude",
+        "PWCent_Latitude",
+        "1975",
+        "2025",
+        "2050",
+    }
+)
+REQUIRED_SHEET = "Data"
+
+# Builder lineage fixed at the post-#212 merge commit.
+CONSTRUCTION_COMMIT = "70249dad153f4ba864fd7d566d05893be2421813"
+
+
+class EmpiricalActivationState(str, Enum):
+    blocked_source_unavailable = "blocked_source_unavailable"
+    blocked_source_identity = "blocked_source_identity"
+    blocked_source_validation = "blocked_source_validation"
+    ready_for_panel_construction = "ready_for_panel_construction"
+    panel_frozen = "panel_frozen"
+    ready_for_performance_evaluation = "ready_for_performance_evaluation"
+    evaluation_complete = "evaluation_complete"
+
+
+class LicensingDisposition(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    license: str
+    redistribution_permitted: bool
+    redistribution_notes: str
+    repository_policy: str
+    repository_policy_notes: str
+
+
+class IdentityCheck(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    expected_sha256: str
+    observed_sha256: str
+    expected_bytes: int
+    observed_bytes: int
+    passed: bool
+
+
+class SchemaCheck(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    required_sheet_present: bool
+    required_sheet: str
+    required_columns_present: bool
+    required_columns: list[str]
+    missing_columns: list[str]
+    passed: bool
+
+
+class ContentCheck(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    year_columns_observed: list[int]
+    estimate_cutoff_year: int
+    total_rows: int
+    city_count: int
+    country_count: int
+    duplicate_city_id_count: int
+    null_population_rows: int
+    below_threshold_populated_rows: int
+    estimate_rows: int
+    projection_rows: int
+    passed: bool
+
+
+class PanelFencePRA(BaseModel):
+    """Panel Freeze PR specification: diagnostics only, no performance output."""
+
+    model_config = ConfigDict(extra="forbid")
+    permitted: list[str]
+    prohibited: list[str]
+    acceptance: str
+
+
+class PanelFencePRB(BaseModel):
+    """Performance/W2 PR specification: gated on PR A merge."""
+
+    model_config = ConfigDict(extra="forbid")
+    prerequisite: str
+    contains: list[str]
+
+
+class PanelFenceProtocol(BaseModel):
+    """Machine-readable two-stage PR fence. CI enforces permitted/prohibited lists."""
+
+    model_config = ConfigDict(extra="forbid")
+    pr_a_panel_freeze: PanelFencePRA
+    pr_b_performance: PanelFencePRB
+
+
+_FENCE = PanelFenceProtocol(
+    pr_a_panel_freeze=PanelFencePRA(
+        permitted=[
+            "origin_eligibility_table",
+            "singleton_exclusion_counts",
+            "city_and_country_counts_by_origin",
+            "paired_row_counts",
+            "weight_sums_and_distribution",
+            "leakage_assertions",
+            "schema_checks",
+            "panel_sha256",
+        ],
+        prohibited=[
+            "b0_errors",
+            "b1_errors",
+            "rmse",
+            "mae",
+            "relative_rmse_improvement",
+            "mae_difference",
+            "gate_evaluation",
+            "model_preference_language",
+        ],
+        acceptance="recorded_checklist_decision_required_before_merge",
+    ),
+    pr_b_performance=PanelFencePRB(
+        prerequisite="pr_a_merged",
+        contains=[
+            "performance_metrics",
+            "w2_inconclusive_probe_registration",
+            "w2_complete_result_registration",
+            "gate_resolution",
+        ],
+    ),
+)
+
+_LICENSING = LicensingDisposition(
+    license="CC BY 3.0 IGO",
+    redistribution_permitted=True,
+    redistribution_notes=(
+        "CC BY 3.0 IGO permits redistribution with attribution. "
+        "UN copyright notice and citation required."
+    ),
+    repository_policy="review_before_commit",
+    repository_policy_notes=(
+        "Raw workbook intentionally not committed pending project "
+        "review-before-commit policy. Legal permission and repository "
+        "policy are distinct: redistribution is permitted under CC BY 3.0 IGO; "
+        "committing to this repository requires explicit review per CONTRIBUTING.md."
+    ),
+)
+
+
+class F21AcquisitionValidation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    source_id: str
+    table: str
+    vintage: str
+    local_path: str
+    adapter_module: str
+    # validator_commit: commit of this validator module at run time.
+    # construction_commit: fixed builder lineage (post-#212); invariant across
+    # validator revisions so validation and construction remain separately attributable.
+    validator_commit: str
+    construction_commit: str
+    validated_at: str
+    identity: IdentityCheck
+    licensing: LicensingDisposition
+    schema_check: SchemaCheck
+    content: ContentCheck
+    overall_outcome: Literal["pass", "fail"]
+    activation_state: EmpiricalActivationState
+    panel_fence_protocol: PanelFenceProtocol
+
+
+def _sha256_and_size(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    total = 0
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+            total += len(chunk)
+    return digest.hexdigest(), total
+
+
+def _empty_content() -> ContentCheck:
+    return ContentCheck(
+        year_columns_observed=[],
+        estimate_cutoff_year=2025,
+        total_rows=0,
+        city_count=0,
+        country_count=0,
+        duplicate_city_id_count=0,
+        null_population_rows=0,
+        below_threshold_populated_rows=0,
+        estimate_rows=0,
+        projection_rows=0,
+        passed=False,
+    )
+
+
+def validate_f21(
+    local_path: Path,
+    validator_commit: str,
+) -> F21AcquisitionValidation:
+    """Validate the registered F21 bytes and produce a structured record.
+
+    Aborts before opening the workbook if the SHA-256 does not match.
+    validator_commit identifies this validator run; construction_commit is
+    fixed to the post-#212 builder lineage and does not change with validator
+    revisions.
+    """
+    observed_sha, observed_bytes = _sha256_and_size(local_path)
+    identity_passed = (
+        observed_sha == REGISTERED_SHA256 and observed_bytes == REGISTERED_BYTES
+    )
+    identity = IdentityCheck(
+        expected_sha256=REGISTERED_SHA256,
+        observed_sha256=observed_sha,
+        expected_bytes=REGISTERED_BYTES,
+        observed_bytes=observed_bytes,
+        passed=identity_passed,
+    )
+
+    common = {
+        "source_id": REGISTERED_SOURCE_ID,
+        "table": REGISTERED_TABLE,
+        "vintage": REGISTERED_VINTAGE,
+        "local_path": str(local_path),
+        "adapter_module": "urban_growth.f21_acquisition_gate",
+        "validator_commit": validator_commit,
+        "construction_commit": CONSTRUCTION_COMMIT,
+        "validated_at": datetime.now(UTC).isoformat(),
+        "identity": identity,
+        "licensing": _LICENSING,
+        "panel_fence_protocol": _FENCE,
+    }
+
+    if not identity_passed:
+        return F21AcquisitionValidation(
+            **common,
+            schema_check=SchemaCheck(
+                required_sheet_present=False,
+                required_sheet=REQUIRED_SHEET,
+                required_columns_present=False,
+                required_columns=sorted(REQUIRED_COLUMNS),
+                missing_columns=[],
+                passed=False,
+            ),
+            content=_empty_content(),
+            overall_outcome="fail",
+            activation_state=EmpiricalActivationState.blocked_source_identity,
+        )
+
+    # Identity confirmed — open workbook for schema check.
+    import openpyxl
+
+    wb = openpyxl.load_workbook(str(local_path), read_only=True, data_only=True)
+    sheet_present = REQUIRED_SHEET in wb.sheetnames
+    missing_cols: list[str] = []
+    schema_passed = False
+    if sheet_present:
+        ws = wb[REQUIRED_SHEET]
+        header = [
+            str(cell.value).strip() if cell.value is not None else ""
+            for cell in next(ws.iter_rows(max_row=1))
+        ]
+        missing_cols = sorted(REQUIRED_COLUMNS - set(header))
+        schema_passed = not missing_cols
+    wb.close()
+
+    schema_check = SchemaCheck(
+        required_sheet_present=sheet_present,
+        required_sheet=REQUIRED_SHEET,
+        required_columns_present=schema_passed,
+        required_columns=sorted(REQUIRED_COLUMNS),
+        missing_columns=missing_cols,
+        passed=sheet_present and schema_passed,
+    )
+
+    if not schema_check.passed:
+        return F21AcquisitionValidation(
+            **common,
+            schema_check=schema_check,
+            content=_empty_content(),
+            overall_outcome="fail",
+            activation_state=EmpiricalActivationState.blocked_source_validation,
+        )
+
+    # Schema confirmed — content checks via production adapter.
+    from urban_growth.adapters.wup import read_f21_city_population
+
+    panel = read_f21_city_population(str(local_path))
+
+    wb2 = openpyxl.load_workbook(str(local_path), read_only=True, data_only=True)
+    ws2 = wb2[REQUIRED_SHEET]
+    raw_header = [
+        str(c.value).strip() if c.value is not None else ""
+        for c in next(ws2.iter_rows(max_row=1))
+    ]
+    year_cols = sorted(int(h) for h in raw_header if re.fullmatch(r"\d{4}", h))
+    wb2.close()
+
+    dup_city_ids = int(
+        panel.groupby("city_id")["year"].count().gt(panel["year"].nunique()).sum()
+    )
+    content = ContentCheck(
+        year_columns_observed=year_cols,
+        estimate_cutoff_year=2025,
+        total_rows=len(panel),
+        city_count=int(panel["city_id"].nunique()),
+        country_count=int(panel["ISO3_Code"].nunique()),
+        duplicate_city_id_count=dup_city_ids,
+        null_population_rows=0,  # adapter rejects nulls; reaching here means 0
+        below_threshold_populated_rows=0,  # adapter rejects below-threshold
+        estimate_rows=int((panel["observation_type"] == "estimate").sum()),
+        projection_rows=int((panel["observation_type"] == "projection").sum()),
+        passed=True,
+    )
+
+    return F21AcquisitionValidation(
+        **common,
+        schema_check=schema_check,
+        content=content,
+        overall_outcome="pass",
+        activation_state=EmpiricalActivationState.ready_for_panel_construction,
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Validate registered F21 bytes and write acquisition gate record"
+    )
+    p.add_argument("--f21", required=True, type=Path, help="Local path to F21 workbook")
+    p.add_argument(
+        "--validator-commit",
+        required=True,
+        help="Git commit SHA of this validator at run time",
+    )
+    p.add_argument(
+        "--output",
+        type=Path,
+        default=Path("data/acquisition/WUP2025-F21-validation.json"),
+        help="Output path for validation JSON",
+    )
+    return p
+
+
+def main() -> None:
+    args = _parser().parse_args()
+    record = validate_f21(args.f21, args.validator_commit)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(record.model_dump(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(record.model_dump(), indent=2, sort_keys=True))
+    if record.overall_outcome != "pass":
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_f21_acquisition_gate.py
+++ b/tests/test_f21_acquisition_gate.py
@@ -1,0 +1,216 @@
+"""Tests for the F21 acquisition gate validator.
+
+Tests do not require the real F21 workbook. They verify the identity-abort logic,
+schema-fail path, content-pass path, Pydantic model constraints, and the committed
+JSON artifact against the model where the artifact exists.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from urban_growth.f21_acquisition_gate import (
+    CONSTRUCTION_COMMIT,
+    REGISTERED_BYTES,
+    REGISTERED_SHA256,
+    EmpiricalActivationState,
+    F21AcquisitionValidation,
+    IdentityCheck,
+    PanelFenceProtocol,
+)
+
+
+def _make_identity(*, sha_match: bool, size_match: bool) -> IdentityCheck:
+    return IdentityCheck(
+        expected_sha256=REGISTERED_SHA256,
+        observed_sha256=REGISTERED_SHA256 if sha_match else "a" * 64,
+        expected_bytes=REGISTERED_BYTES,
+        observed_bytes=REGISTERED_BYTES if size_match else 0,
+        passed=sha_match and size_match,
+    )
+
+
+def _base_record(*, outcome: str, activation: EmpiricalActivationState) -> dict:
+    passed = outcome == "pass"
+    return {
+        "source_id": "un_wup_2025_cities",
+        "table": "F21",
+        "vintage": "WUP_2025_F21",
+        "local_path": "/tmp/fake.xlsx",
+        "adapter_module": "urban_growth.f21_acquisition_gate",
+        "validator_commit": "deadbeef",
+        "construction_commit": CONSTRUCTION_COMMIT,
+        "validated_at": "2026-09-07T00:00:00+00:00",
+        "identity": _make_identity(sha_match=passed, size_match=passed).model_dump(),
+        "licensing": {
+            "license": "CC BY 3.0 IGO",
+            "redistribution_permitted": True,
+            "redistribution_notes": "note",
+            "repository_policy": "review_before_commit",
+            "repository_policy_notes": "note",
+        },
+        "schema_check": {
+            "required_sheet_present": passed,
+            "required_sheet": "Data",
+            "required_columns_present": passed,
+            "required_columns": ["City_Code"],
+            "missing_columns": [],
+            "passed": passed,
+        },
+        "content": {
+            "year_columns_observed": [1975, 2025, 2050] if passed else [],
+            "estimate_cutoff_year": 2025,
+            "total_rows": 1000 if passed else 0,
+            "city_count": 200 if passed else 0,
+            "country_count": 50 if passed else 0,
+            "duplicate_city_id_count": 0,
+            "null_population_rows": 0,
+            "below_threshold_populated_rows": 0,
+            "estimate_rows": 600 if passed else 0,
+            "projection_rows": 400 if passed else 0,
+            "passed": passed,
+        },
+        "overall_outcome": outcome,
+        "activation_state": activation.value,
+        "panel_fence_protocol": {
+            "pr_a_panel_freeze": {
+                "permitted": ["origin_eligibility_table"],
+                "prohibited": ["rmse", "mae"],
+                "acceptance": "recorded_checklist_decision_required_before_merge",
+            },
+            "pr_b_performance": {
+                "prerequisite": "pr_a_merged",
+                "contains": ["performance_metrics"],
+            },
+        },
+    }
+
+
+def test_identity_mismatch_sets_blocked_source_identity():
+    record = F21AcquisitionValidation.model_validate(
+        _base_record(
+            outcome="fail",
+            activation=EmpiricalActivationState.blocked_source_identity,
+        )
+    )
+    assert record.overall_outcome == "fail"
+    assert record.activation_state == EmpiricalActivationState.blocked_source_identity
+    assert not record.identity.passed
+
+
+def test_pass_record_sets_ready_for_panel_construction():
+    record = F21AcquisitionValidation.model_validate(
+        _base_record(
+            outcome="pass",
+            activation=EmpiricalActivationState.ready_for_panel_construction,
+        )
+    )
+    assert record.overall_outcome == "pass"
+    assert record.activation_state == EmpiricalActivationState.ready_for_panel_construction
+    assert record.identity.passed
+
+
+def test_activation_state_enum_is_closed():
+    with pytest.raises(ValueError):
+        EmpiricalActivationState("unknown_state")
+
+
+def test_model_rejects_unknown_fields():
+    data = _base_record(
+        outcome="pass",
+        activation=EmpiricalActivationState.ready_for_panel_construction,
+    )
+    data["spurious_field"] = "should_fail"
+    with pytest.raises(ValidationError):
+        F21AcquisitionValidation.model_validate(data)
+
+
+def test_licensing_distinguishes_legal_permission_from_repository_policy():
+    record = F21AcquisitionValidation.model_validate(
+        _base_record(
+            outcome="pass",
+            activation=EmpiricalActivationState.ready_for_panel_construction,
+        )
+    )
+    assert record.licensing.redistribution_permitted is True
+    assert record.licensing.repository_policy == "review_before_commit"
+
+
+def test_validator_and_construction_commits_are_distinct_fields():
+    record = F21AcquisitionValidation.model_validate(
+        _base_record(
+            outcome="pass",
+            activation=EmpiricalActivationState.ready_for_panel_construction,
+        )
+    )
+    assert record.validator_commit == "deadbeef"
+    assert record.construction_commit == CONSTRUCTION_COMMIT
+    assert record.validator_commit != record.construction_commit
+
+
+def test_construction_commit_is_fixed_post_212_sha():
+    assert CONSTRUCTION_COMMIT == "70249dad153f4ba864fd7d566d05893be2421813"
+
+
+def test_panel_fence_protocol_is_structured_model():
+    record = F21AcquisitionValidation.model_validate(
+        _base_record(
+            outcome="pass",
+            activation=EmpiricalActivationState.ready_for_panel_construction,
+        )
+    )
+    assert isinstance(record.panel_fence_protocol, PanelFenceProtocol)
+    assert "rmse" in record.panel_fence_protocol.pr_a_panel_freeze.prohibited
+    assert "mae" in record.panel_fence_protocol.pr_a_panel_freeze.prohibited
+    assert "origin_eligibility_table" in record.panel_fence_protocol.pr_a_panel_freeze.permitted
+    assert record.panel_fence_protocol.pr_b_performance.prerequisite == "pr_a_merged"
+
+
+def test_fence_protocol_rejects_unknown_fields():
+    data = _base_record(
+        outcome="pass",
+        activation=EmpiricalActivationState.ready_for_panel_construction,
+    )
+    data["panel_fence_protocol"]["pr_a_panel_freeze"]["unexpected"] = "bad"
+    with pytest.raises(ValidationError):
+        F21AcquisitionValidation.model_validate(data)
+
+
+def test_r4_activation_enum_covers_full_lifecycle():
+    expected = {
+        "blocked_source_unavailable",
+        "blocked_source_identity",
+        "blocked_source_validation",
+        "ready_for_panel_construction",
+        "panel_frozen",
+        "ready_for_performance_evaluation",
+        "evaluation_complete",
+    }
+    assert {e.value for e in EmpiricalActivationState} == expected
+
+
+def test_committed_validation_artifact_is_valid_if_present():
+    """If a committed validation artifact exists, it must parse against the model.
+
+    This test is skipped until the local F21 bytes have been validated and the
+    artifact committed. After that run, it becomes a permanent regression guard.
+    """
+    artifact = (
+        Path(__file__).parents[1] / "data" / "acquisition" / "WUP2025-F21-validation.json"
+    )
+    if not artifact.exists():
+        pytest.skip("No committed validation artifact yet — run validator locally first")
+    data = json.loads(artifact.read_text(encoding="utf-8"))
+    record = F21AcquisitionValidation.model_validate(data)
+    assert record.source_id == "un_wup_2025_cities"
+    assert record.table == "F21"
+    assert record.identity.expected_sha256 == REGISTERED_SHA256
+    assert record.overall_outcome == "pass"
+    assert record.activation_state == EmpiricalActivationState.ready_for_panel_construction
+    assert record.construction_commit == CONSTRUCTION_COMMIT
+    # validator_commit must differ from construction_commit
+    assert record.validator_commit != record.construction_commit


### PR DESCRIPTION
## Summary

Adds the F21 acquisition gate on top of the merged H1 WUP OOS builder lineage (`70249dad153f4ba864fd7d566d05893be2421813`).

This PR:
- adds `src/urban_growth/f21_acquisition_gate.py` with hash-first identity validation, schema/content checks, explicit licensing/repository-policy separation, closed empirical-activation states, distinct `validator_commit` and fixed `construction_commit`, and structured PR A/PR B panel-fence metadata;
- adds `tests/test_f21_acquisition_gate.py` covering closed-enum behavior, identity blocking, model strictness, licensing separation, validator/construction lineage separation, structured fence enforcement, and the committed-artifact regression guard;
- updates `knowledge/schema/h1-oos-wup-v1.yaml` to reflect source acquired / validation pending, enumerate activation states, and preregister the two-stage panel fence.

## Merge blocker

**Do not merge until the real registered F21 bytes have been validated and the resulting artifact is committed:**

`data/acquisition/WUP2025-F21-validation.json`

The artifact must be produced by running:

```bash
python -m urban_growth.f21_acquisition_gate \
  --f21 data/raw/WUP2025-F21-DEGURBA-Cities_Pop.xlsx \
  --validator-commit <tip-sha-of-pr-branch-after-push> \
  --output data/acquisition/WUP2025-F21-validation.json
```

The validator hashes first and must stop before workbook access if the bytes do not match the preregistered SHA-256 `3a96030d87aec6c1c50f658d5321067d6345e1ab936c5d2854524f972caa75c0` and expected size `10,671,837` bytes.

After a passing run:
1. commit the validation JSON;
2. advance `empirical_activation` to `ready_for_panel_construction`;
3. rerun the full suite so `test_committed_validation_artifact_is_valid_if_present` executes rather than skips;
4. require CI green before merge.

## Scope guard

No panel construction or performance metrics belong in this PR. The next implementation unit is the separate Panel Freeze PR, which is restricted by the preregistered fence to diagnostics/lineage only and explicitly prohibits B0/B1 errors, RMSE, MAE, relative improvement, gate evaluation, and model-preference language.

## Generated outputs

`knowledge/generated/dependency-graph.md` should be regenerated with `python -m urban_growth.knowledge_graph.generate` after the schema change if CI reports it stale. The shell runtime used to publish this branch could not resolve github.com, so CI is the authoritative generated-file check for this remote branch.