### PR TITLE
Draft: recompute point-in-time flags from primitive evidence

### DIFF
--- a/docs/point-in-time-persistence-gate.md
+++ b/docs/point-in-time-persistence-gate.md
@@ -5,11 +5,27 @@ A persistence benchmark can be out-of-sample in reference-year terms while still
 Deployable persistence evaluation requires all of the following:
 
 - the source-specific City Data Fitness eligibility flag (normally `growth_eligible`);
+- raw `forecast_origin_date`, predictor availability, concordance availability, and supporting source references;
+- the raw registered forecast-origin rule in `forecast_origin_registration`;
 - `point_in_time_available = true` for test rows at the origin being scored;
 - verified predictor and concordance availability provenance;
 - `forecast_origin_registration_verified = true` for every row entering the point-in-time persistence path;
 - explicit predictor, concordance, and outcome availability dates for candidate training rows; and
 - nonblank provenance supporting those availability dates.
+
+## Recompute derived point-in-time flags before headline use
+
+Derived booleans are not primary evidence. A caller could otherwise copy or manually set `point_in_time_available`, `availability_provenance_verified`, or `forecast_origin_registration_verified` to `true` without having passed the availability constructor that produced them.
+
+`recompute_point_in_time_evidence` therefore reruns `apply_forecast_availability_gate` from the raw dates, source references, and registered origin rule. It then reconciles the recomputed values against all three supplied derived flags. Missing raw evidence, an invalid origin calendar rule, or any disagreement between a supplied flag and the recomputed value fails closed.
+
+Headline persistence uses `evaluate_verified_point_in_time_persistence_baselines` and `verified_point_in_time_persistence_errors`, not the lower-level persistence evaluator directly. Qualified outputs record:
+
+- `point_in_time_evidence_recomputed = true`;
+- `derived_point_in_time_flags_reconciled = true`; and
+- `headline_point_in_time_integrity_enforced = true`.
+
+The lower-level `evaluate_point_in_time_persistence_baselines` and `point_in_time_persistence_errors` remain useful intermediate diagnostics, but their derived booleans are not independently sufficient evidence for a headline deployability claim.
 
 ## Test rows versus training rows
 
@@ -25,8 +41,6 @@ Historical training rows use a different rule. They are **not** required to have
 This matters because a row can legitimately be unavailable in real time at, for example, its 2000 origin but become fully observable before a 2010 forecast. Permanently excluding it because `point_in_time_available` was false in 2000 would understate the information set available in 2010 and could distort comparisons across models or origins.
 
 The training gate therefore evaluates availability **as of the current origin**, not the historical row's own origin. The implementation reports `training_uses_current_origin_as_of = true`, along with `training_predictor_availability_enforced`, `training_concordance_availability_enforced`, and `training_outcome_availability_enforced`.
-
-The downstream evaluator still independently requires verified origin registration and availability provenance; it does not trust a caller-supplied `point_in_time_available` boolean as sufficient evidence.
 
 Reference years, enumeration dates, endpoint years, current download dates, or analyst-entered assumptions are not sufficient provenance for availability dates. Evidence should point to the relevant statistical release, archived publication, geography release, metadata record, or equivalent source establishing when the information became observable.
 

--- a/src/urban_growth/forecast_headline.py
+++ b/src/urban_growth/forecast_headline.py
@@ -113,6 +113,7 @@ def _attach_coverage_to_metrics(
     result["origin_risk_set_coverage_enforced"] = True
     result["headline_coverage_contract_enforced"] = True
     result["headline_coverage_minimum_enforced"] = True
+    result["headline_point_in_time_integrity_enforced"] = True
     result["benchmark_stage"] = "point_in_time_persistence_with_origin_coverage"
     return result.sort_values(["origin", "model"]).reset_index(drop=True)
 
@@ -125,15 +126,15 @@ def evaluate_headline_point_in_time_persistence(
     coverage_policy_id: str,
     **kwargs: object,
 ) -> pd.DataFrame:
-    """Evaluate point-in-time persistence only under a versioned coverage policy."""
-    from urban_growth.forecast_fitness import evaluate_point_in_time_persistence_baselines
+    """Evaluate headline persistence only after recomputing point-in-time evidence."""
+    from urban_growth.forecast_integrity import evaluate_verified_point_in_time_persistence_baselines
 
     coverage = _headline_coverage(
         coverage_summary,
         origins,
         coverage_policy_id=coverage_policy_id,
     )
-    metrics = evaluate_point_in_time_persistence_baselines(panel, origins, **kwargs)
+    metrics = evaluate_verified_point_in_time_persistence_baselines(panel, origins, **kwargs)
     return _attach_coverage_to_metrics(metrics, coverage)
 
 
@@ -145,15 +146,15 @@ def headline_point_in_time_persistence_errors(
     coverage_policy_id: str,
     **kwargs: object,
 ) -> pd.DataFrame:
-    """Return row-level errors only under a versioned coverage policy."""
-    from urban_growth.forecast_fitness import point_in_time_persistence_errors
+    """Return headline row errors only after recomputing point-in-time evidence."""
+    from urban_growth.forecast_integrity import verified_point_in_time_persistence_errors
 
     coverage = _headline_coverage(
         coverage_summary,
         origins,
         coverage_policy_id=coverage_policy_id,
     )
-    errors = point_in_time_persistence_errors(panel, origins, **kwargs)
+    errors = verified_point_in_time_persistence_errors(panel, origins, **kwargs)
     result = errors.merge(coverage, on="origin", how="left", validate="many_to_one")
     required_attached = COVERAGE_COLUMNS - {"origin"}
     if result[list(required_attached)].isna().any().any():
@@ -168,5 +169,6 @@ def headline_point_in_time_persistence_errors(
     result["origin_risk_set_coverage_enforced"] = True
     result["headline_coverage_contract_enforced"] = True
     result["headline_coverage_minimum_enforced"] = True
+    result["headline_point_in_time_integrity_enforced"] = True
     result["benchmark_stage"] = "point_in_time_persistence_with_origin_coverage"
     return result.reset_index(drop=True)

--- a/src/urban_growth/forecast_integrity.py
+++ b/src/urban_growth/forecast_integrity.py
@@ -1,0 +1,107 @@
+"""Recompute point-in-time forecast eligibility from raw evidence before scoring."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from urban_growth.forecast_availability import apply_forecast_availability_gate
+from urban_growth.io import SourceSchemaError, require_columns
+
+
+DERIVED_POINT_IN_TIME_COLUMNS = {
+    "point_in_time_available": "point_in_time_available",
+    "availability_provenance_verified": "availability_provenance_verified",
+    "forecast_origin_registration_verified": "forecast_origin_registration_verified",
+}
+
+
+def recompute_point_in_time_evidence(
+    panel: pd.DataFrame,
+    *,
+    origin_column: str = "forecast_origin_date",
+    predictor_available_column: str = "predictor_available_date",
+    concordance_available_column: str = "concordance_available_date",
+    predictor_provenance_column: str = "predictor_availability_source",
+    concordance_provenance_column: str = "concordance_availability_source",
+    origin_registration_column: str = "forecast_origin_registration",
+    availability_column: str = "point_in_time_available",
+    provenance_verified_column: str = "availability_provenance_verified",
+    origin_registration_verified_column: str = "forecast_origin_registration_verified",
+) -> pd.DataFrame:
+    """Recompute deployability flags and reject caller-supplied flag disagreement."""
+    require_columns(
+        panel,
+        {
+            origin_column,
+            predictor_available_column,
+            concordance_available_column,
+            predictor_provenance_column,
+            concordance_provenance_column,
+            origin_registration_column,
+        },
+        source_name="verified point-in-time forecast panel",
+    )
+
+    supplied = panel.copy()
+    recomputed = apply_forecast_availability_gate(
+        supplied,
+        origin_column=origin_column,
+        predictor_available_column=predictor_available_column,
+        concordance_available_column=concordance_available_column,
+        predictor_provenance_column=predictor_provenance_column,
+        concordance_provenance_column=concordance_provenance_column,
+        origin_registration_column=origin_registration_column,
+    )
+
+    comparisons = {
+        availability_column: "point_in_time_available",
+        provenance_verified_column: "availability_provenance_verified",
+        origin_registration_verified_column: "forecast_origin_registration_verified",
+    }
+    for supplied_column, derived_column in comparisons.items():
+        if supplied_column not in supplied.columns:
+            raise SourceSchemaError(
+                f"{supplied_column} must be present so recomputed point-in-time evidence can be reconciled"
+            )
+        if not pd.api.types.is_bool_dtype(supplied[supplied_column].dtype):
+            raise SourceSchemaError(f"{supplied_column} must be boolean")
+        expected = recomputed[derived_column]
+        actual = supplied[supplied_column]
+        if not actual.equals(expected):
+            raise SourceSchemaError(
+                f"{supplied_column} disagrees with the value recomputed from raw availability evidence"
+            )
+
+    recomputed["point_in_time_evidence_recomputed"] = True
+    recomputed["derived_point_in_time_flags_reconciled"] = True
+    return recomputed
+
+
+def evaluate_verified_point_in_time_persistence_baselines(
+    panel: pd.DataFrame,
+    origins: list[int],
+    **kwargs: object,
+) -> pd.DataFrame:
+    """Evaluate persistence only after recomputing own-origin deployability evidence."""
+    from urban_growth.forecast_fitness import evaluate_point_in_time_persistence_baselines
+
+    verified = recompute_point_in_time_evidence(panel)
+    result = evaluate_point_in_time_persistence_baselines(verified, origins, **kwargs)
+    result["point_in_time_evidence_recomputed"] = True
+    result["derived_point_in_time_flags_reconciled"] = True
+    return result
+
+
+def verified_point_in_time_persistence_errors(
+    panel: pd.DataFrame,
+    origins: list[int],
+    **kwargs: object,
+) -> pd.DataFrame:
+    """Return row-level errors only after recomputing own-origin deployability evidence."""
+    from urban_growth.forecast_fitness import point_in_time_persistence_errors
+
+    verified = recompute_point_in_time_evidence(panel)
+    result = point_in_time_persistence_errors(verified, origins, **kwargs)
+    result["point_in_time_evidence_recomputed"] = True
+    result["derived_point_in_time_flags_reconciled"] = True
+    return result

--- a/tests/test_forecast_headline.py
+++ b/tests/test_forecast_headline.py
@@ -53,6 +53,7 @@ def _panel() -> pd.DataFrame:
                     "availability_provenance_verified": True,
                     "forecast_origin_registration_verified": True,
                     "forecast_origin_date": f"{start}-12-31",
+                    "forecast_origin_registration": "annual December 31 as-of",
                     "predictor_available_date": f"{start}-01-01",
                     "concordance_available_date": f"{start}-01-01",
                     "predictor_availability_source": f"predictor-release-{start}",
@@ -101,6 +102,9 @@ def test_headline_metrics_attach_registered_policy_and_coverage() -> None:
     assert result["minimum_observed_outcome_share"].eq(0.60).all()
     assert result["forecast_origin_registration_gate_enforced"].all()
     assert result["training_uses_current_origin_as_of"].all()
+    assert result["point_in_time_evidence_recomputed"].all()
+    assert result["derived_point_in_time_flags_reconciled"].all()
+    assert result["headline_point_in_time_integrity_enforced"].all()
 
 
 def test_headline_errors_attach_same_registered_policy() -> None:
@@ -111,12 +115,24 @@ def test_headline_errors_attach_same_registered_policy() -> None:
     assert result["coverage_policy_id"].eq(TEST_POLICY_ID).all()
     assert result["forecast_origin_registration_gate_enforced"].all()
     assert result["training_uses_current_origin_as_of"].all()
+    assert result["point_in_time_evidence_recomputed"].all()
+    assert result["headline_point_in_time_integrity_enforced"].all()
 
 
-def test_headline_rejects_unverified_origin_registration() -> None:
+def test_headline_rejects_forged_origin_registration_flag() -> None:
     panel = _panel()
     panel.loc[0, "forecast_origin_registration_verified"] = False
-    with pytest.raises(SourceSchemaError, match="verified forecast-origin registration"):
+    with pytest.raises(SourceSchemaError, match="disagrees with the value recomputed"):
+        evaluate_headline_point_in_time_persistence(
+            panel, [2005, 2010], _coverage(), coverage_policy_id=TEST_POLICY_ID
+        )
+
+
+def test_headline_rejects_forged_availability_flag() -> None:
+    panel = _panel()
+    panel.loc[0, "predictor_available_date"] = "2001-01-01"
+    panel.loc[0, "point_in_time_available"] = True
+    with pytest.raises(SourceSchemaError, match="point_in_time_available disagrees"):
         evaluate_headline_point_in_time_persistence(
             panel, [2005, 2010], _coverage(), coverage_policy_id=TEST_POLICY_ID
         )

--- a/tests/test_forecast_integrity.py
+++ b/tests/test_forecast_integrity.py
@@ -1,0 +1,67 @@
+import pandas as pd
+import pytest
+
+from urban_growth.forecast_integrity import recompute_point_in_time_evidence
+from urban_growth.io import SourceSchemaError
+
+
+def _panel() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "city_id": ["A", "B"],
+            "period_start": [2000, 2000],
+            "period_end": [2005, 2005],
+            "forecast_origin_date": ["2000-12-31", "2000-12-31"],
+            "forecast_origin_registration": [
+                "annual December 31 as-of",
+                "annual December 31 as-of",
+            ],
+            "predictor_available_date": ["2000-01-01", "2000-01-01"],
+            "concordance_available_date": ["2000-01-01", "2000-01-01"],
+            "predictor_availability_source": ["official predictor release", "official predictor release"],
+            "concordance_availability_source": ["official geography release", "official geography release"],
+            "point_in_time_available": [True, True],
+            "availability_provenance_verified": [True, True],
+            "forecast_origin_registration_verified": [True, True],
+        }
+    )
+
+
+def test_recompute_accepts_matching_derived_flags() -> None:
+    result = recompute_point_in_time_evidence(_panel())
+    assert result["point_in_time_evidence_recomputed"].all()
+    assert result["derived_point_in_time_flags_reconciled"].all()
+
+
+def test_recompute_rejects_forged_available_flag() -> None:
+    panel = _panel()
+    panel.loc[0, "predictor_available_date"] = "2001-01-01"
+    with pytest.raises(SourceSchemaError, match="point_in_time_available disagrees"):
+        recompute_point_in_time_evidence(panel)
+
+
+def test_recompute_rejects_forged_provenance_flag() -> None:
+    panel = _panel()
+    panel.loc[0, "predictor_availability_source"] = " "
+    with pytest.raises(SourceSchemaError, match="source evidence"):
+        recompute_point_in_time_evidence(panel)
+
+
+def test_recompute_requires_raw_origin_registration() -> None:
+    panel = _panel().drop(columns="forecast_origin_registration")
+    with pytest.raises(SourceSchemaError, match="forecast_origin_registration"):
+        recompute_point_in_time_evidence(panel)
+
+
+def test_recompute_rejects_inconsistent_origin_calendar_rule() -> None:
+    panel = _panel()
+    extra = panel.iloc[[0]].copy()
+    extra["city_id"] = "C"
+    extra["period_start"] = 2005
+    extra["period_end"] = 2010
+    extra["forecast_origin_date"] = "2005-06-30"
+    extra["predictor_available_date"] = "2005-01-01"
+    extra["concordance_available_date"] = "2005-01-01"
+    frame = pd.concat([panel, extra], ignore_index=True)
+    with pytest.raises(SourceSchemaError, match="one registered month-day rule"):
+        recompute_point_in_time_evidence(frame)


### PR DESCRIPTION
Partial implementation toward #137.

Current branch scope:
- adds `recompute_point_in_time_evidence(...)`;
- checks supplied point-in-time flags against primitive availability evidence;
- adds regression tests and updates the point-in-time gate documentation.

Known blockers before review:
- the branch is substantially behind `main` and must be rebased;
- its existing GitHub Actions run fails at lint;
- it addresses the point-in-time portion of #137 but does not yet demonstrate full recomputation of City Data Fitness eligibility, registered custom-gate provenance, or the complete acceptance criteria;
- historical results must not be silently regenerated or replaced.

This draft exists to make the orphaned branch visible and reviewable. It is not merge-ready.